### PR TITLE
feat(dashboard): état vide onglet Communautés

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -117,6 +117,8 @@
     "noUpcomingMoments": "No upcoming Events.",
     "noMoments": "No Events yet.",
     "noMomentsHint": "Join an Event or create your community.",
+    "emptyCircles": "You're not a member of any Community.",
+    "emptyCirclesHint": "Create a Community or join an Event to become a member of one.",
     "noCirclesMember": "You are not a member of any Community yet.",
     "role": {
       "host": "Host",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -117,6 +117,8 @@
     "noUpcomingMoments": "Aucun événement à venir.",
     "noMoments": "Aucun événement pour l'instant.",
     "noMomentsHint": "Inscrivez-vous à un événement ou créez votre communauté.",
+    "emptyCircles": "Vous n'êtes membre d'aucune Communauté.",
+    "emptyCirclesHint": "Créez une Communauté ou rejoignez un événement pour en rejoindre une.",
     "noCirclesMember": "Vous n'êtes membre d'aucune Communauté.",
     "role": {
       "host": "Organisateur",

--- a/src/app/[locale]/(routes)/dashboard/(app)/(main)/page.tsx
+++ b/src/app/[locale]/(routes)/dashboard/(app)/(main)/page.tsx
@@ -169,11 +169,18 @@ export default async function DashboardPage({
         </section>
       ) : (
         <section>
-          <div className="grid grid-cols-1 gap-5 sm:grid-cols-2">
-            {circles.map((circle) => (
-              <DashboardCircleCard key={circle.id} circle={circle} />
-            ))}
-          </div>
+          {circles.length === 0 ? (
+            <div className="flex flex-col items-center justify-center rounded-lg border border-dashed py-12">
+              <p className="text-muted-foreground text-sm">{t("emptyCircles")}</p>
+              <p className="text-muted-foreground mt-1 text-xs">{t("emptyCirclesHint")}</p>
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 gap-5 sm:grid-cols-2">
+              {circles.map((circle) => (
+                <DashboardCircleCard key={circle.id} circle={circle} />
+              ))}
+            </div>
+          )}
         </section>
       )}
     </div>


### PR DESCRIPTION
## Summary

- Ajoute un état vide sur l'onglet "Mes Communautés" du dashboard quand l'utilisateur n'appartient à aucune communauté (mais a des événements)
- Même pattern que l'état vide existant sur l'onglet "Mes événements"
- Clés i18n FR + EN ajoutées

## Test plan

- [ ] Vérifier l'onglet "Mes Communautés" pour un utilisateur sans communauté
- [ ] Vérifier que la grille s'affiche normalement pour un utilisateur avec des communautés

🤖 Generated with [Claude Code](https://claude.com/claude-code)