### PR TITLE
docs(backlog): ajouter B-04 — page changelog non traduite en anglais

### DIFF
--- a/spec/BACKLOG.md
+++ b/spec/BACKLOG.md
@@ -328,6 +328,7 @@
 | B-01 | OAuth Google bloquée depuis les navigateurs in-app (Instagram, WhatsApp, Facebook…) | ⚠️ Workaround utilisateur | Google refuse les WebViews (`Error 403: disallowed_useragent`). Fix possible : détecter le user-agent et afficher un message explicatif sur `/auth/error` à la place de l'erreur Google. |
 | B-02 | Page `/changelog` — RangeError stack overflow en prod | ✅ Corrigé `3fd5a2b` | `readFileSync(CHANGELOG.md)` pouvait crasher si le fichier absent du bundle serverless Vercel → boucle error boundary React. Fix : `outputFileTracingIncludes` + try/catch. |
 | B-03 | OAuth Google `redirect_uri_mismatch` pour certains users | ✅ Corrigé (config Vercel) | `AUTH_URL` absent → Auth.js utilisait `VERCEL_URL` ou le header `x-forwarded-host` de façon non déterministe. Fix : ajouter `AUTH_URL=https://the-playground.fr` dans les variables Vercel. |
+| B-04 | Page `/changelog` uniquement en français | 🔴 Ouvert | Contenu de `CHANGELOG.md` rédigé en FR uniquement. Fix possible : deux fichiers `CHANGELOG.fr.md` / `CHANGELOG.en.md`, ou sections FR/EN dans un seul fichier, ou afficher le même contenu FR pour les deux locales (acceptable pour un changelog technique). |
 
 ---
 


### PR DESCRIPTION
## Summary

- Ajout de l'entrée **B-04** dans la section "Bugs connus" du backlog
- Bug : la page `/changelog` affiche uniquement du contenu en français, même pour les utilisateurs en anglais
- Statut : 🔴 Ouvert (à traiter ultérieurement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)