### PR TITLE
fix(dashboard): corriger l'hydration error sur les dates

### DIFF
--- a/src/components/moments/dashboard-moment-card.tsx
+++ b/src/components/moments/dashboard-moment-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useTranslations } from "next-intl";
+import { useTranslations, useLocale } from "next-intl";
 import { Link } from "@/i18n/navigation";
 import { Badge } from "@/components/ui/badge";
 import { MapPin, Globe, Check, Clock, Crown } from "lucide-react";
@@ -15,12 +15,12 @@ type DashboardMomentCardProps = {
   isPast?: boolean;
 };
 
-function formatTimelineDate(date: Date): { weekday: string; dateStr: string; isToday: boolean } {
+function formatTimelineDate(date: Date, locale: string): { weekday: string; dateStr: string; isToday: boolean } {
   const now = new Date();
   const isToday = date.toDateString() === now.toDateString();
 
-  const weekday = date.toLocaleDateString(undefined, { weekday: "short" });
-  const dateStr = date.toLocaleDateString(undefined, { day: "numeric", month: "short", year: "numeric" });
+  const weekday = date.toLocaleDateString(locale, { weekday: "short" });
+  const dateStr = date.toLocaleDateString(locale, { day: "numeric", month: "short", year: "numeric" });
 
   return { weekday, dateStr, isToday };
 }
@@ -28,6 +28,7 @@ function formatTimelineDate(date: Date): { weekday: string; dateStr: string; isT
 export function DashboardMomentCard({ registration, isLast, isHost = false, isPast = false }: DashboardMomentCardProps) {
   const t = useTranslations("Dashboard");
   const tCircle = useTranslations("Circle");
+  const locale = useLocale();
   const { moment } = registration;
 
   const isRegistered = registration.status === "REGISTERED" || registration.status === "CHECKED_IN";
@@ -42,9 +43,9 @@ export function DashboardMomentCard({ registration, isLast, isHost = false, isPa
         : "bg-border";
 
   const gradient = getMomentGradient(moment.title);
-  const { weekday, dateStr, isToday } = formatTimelineDate(moment.startsAt);
+  const { weekday, dateStr, isToday } = formatTimelineDate(moment.startsAt, locale);
 
-  const timeStr = moment.startsAt.toLocaleTimeString(undefined, {
+  const timeStr = moment.startsAt.toLocaleTimeString(locale, {
     hour: "2-digit",
     minute: "2-digit",
   });


### PR DESCRIPTION
## Problème

Hydration Error remontée par Sentry sur `https://the-playground.fr/dashboard`.

Le composant `DashboardMomentCard` utilisait `undefined` comme locale dans `toLocaleDateString` et `toLocaleTimeString`. La locale système de Node.js sur le serveur Vercel (UTC / `en-US`) différait de la locale du navigateur des utilisateurs français (`fr`), causant un mismatch entre le HTML SSR et le rendu client :

| | Serveur (en-US) | Client (fr) |
|---|---|---|
| weekday | `"Tue"` | `"mar."` |
| dateStr | `"Feb 24, 2026"` | `"24 févr. 2026"` |
| timeStr | `"04:00 PM"` | `"17:00"` |

## Fix

Remplacement de `undefined` par `useLocale()` (next-intl) — la locale est ainsi cohérente entre le rendu serveur et le rendu client.

## Test plan

- [ ] Vérifier que le dashboard affiche correctement les dates en FR et en EN
- [ ] Vérifier que l'hydration error ne réapparaît plus dans Sentry après déploiement

🤖 Generated with [Claude Code](https://claude.com/claude-code)