### PR TITLE
feat(explorer): pagination "Voir plus" sur la page Découvrir

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -65,7 +65,8 @@
       "github": "Continue with GitHub",
       "emailPlaceholder": "your@email.com",
       "magicLink": "Send a magic link",
-      "or": "or"
+      "or": "or",
+      "linkedin": "Continue with LinkedIn"
     },
     "verifyRequest": {
       "title": "Check your email",
@@ -377,7 +378,8 @@
         "registered": "Joined",
         "waitlisted": "Waitlisted"
       }
-    }
+    },
+    "loadMore": "Show more"
   },
   "Admin": {
     "title": "Administration",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -65,7 +65,8 @@
       "github": "Continuer avec GitHub",
       "emailPlaceholder": "votre@email.com",
       "magicLink": "Envoyer un lien magique",
-      "or": "ou"
+      "or": "ou",
+      "linkedin": "Continuer avec LinkedIn"
     },
     "verifyRequest": {
       "title": "Vérifiez votre email",
@@ -377,7 +378,8 @@
         "registered": "Inscrit",
         "waitlisted": "Liste d'attente"
       }
-    }
+    },
+    "loadMore": "Voir plus"
   },
   "Admin": {
     "title": "Administration",

--- a/src/app/actions/explorer.ts
+++ b/src/app/actions/explorer.ts
@@ -1,0 +1,97 @@
+"use server";
+
+import {
+  prismaCircleRepository,
+  prismaMomentRepository,
+  prismaRegistrationRepository,
+} from "@/infrastructure/repositories";
+import { auth } from "@/infrastructure/auth/auth.config";
+import { getPublicCircles } from "@/domain/usecases/get-public-circles";
+import { getPublicUpcomingMoments } from "@/domain/usecases/get-public-upcoming-moments";
+import type { CircleCategory, CircleMemberRole } from "@/domain/models/circle";
+import type { PublicCircle } from "@/domain/ports/repositories/circle-repository";
+import type { PublicMoment } from "@/domain/ports/repositories/moment-repository";
+import type { RegistrationStatus } from "@/domain/models/registration";
+
+const PAGE_SIZE = 12;
+const FETCH_SIZE = PAGE_SIZE + 1;
+
+export async function loadMoreCirclesAction({
+  offset,
+  category,
+}: {
+  offset: number;
+  category?: CircleCategory;
+}): Promise<{
+  circles: PublicCircle[];
+  hasMore: boolean;
+  membershipRoleMap: Record<string, CircleMemberRole>;
+}> {
+  const session = await auth();
+
+  const [fetched, userCircles] = await Promise.all([
+    getPublicCircles(
+      { category, limit: FETCH_SIZE, offset },
+      { circleRepository: prismaCircleRepository }
+    ),
+    session?.user?.id
+      ? prismaCircleRepository.findAllByUserId(session.user.id)
+      : Promise.resolve([]),
+  ]);
+
+  const hasMore = fetched.length > PAGE_SIZE;
+  const circles = hasMore ? fetched.slice(0, PAGE_SIZE) : fetched;
+
+  const membershipRoleMap: Record<string, CircleMemberRole> = {};
+  for (const c of userCircles) {
+    membershipRoleMap[c.id] = c.memberRole;
+  }
+
+  return { circles, hasMore, membershipRoleMap };
+}
+
+export async function loadMoreMomentsAction({
+  offset,
+  category,
+}: {
+  offset: number;
+  category?: CircleCategory;
+}): Promise<{
+  moments: PublicMoment[];
+  hasMore: boolean;
+  registrationStatusMap: Record<string, RegistrationStatus | null>;
+  membershipBySlug: Record<string, CircleMemberRole>;
+}> {
+  const session = await auth();
+
+  const [fetched, userCircles] = await Promise.all([
+    getPublicUpcomingMoments(
+      { category, limit: FETCH_SIZE, offset },
+      { momentRepository: prismaMomentRepository }
+    ),
+    session?.user?.id
+      ? prismaCircleRepository.findAllByUserId(session.user.id)
+      : Promise.resolve([]),
+  ]);
+
+  const hasMore = fetched.length > PAGE_SIZE;
+  const moments = hasMore ? fetched.slice(0, PAGE_SIZE) : fetched;
+
+  const registrationStatusMap: Record<string, RegistrationStatus | null> = {};
+  if (session?.user?.id && moments.length > 0) {
+    const regMap = await prismaRegistrationRepository.findByMomentIdsAndUser(
+      moments.map((m) => m.id),
+      session.user.id
+    );
+    for (const [momentId, reg] of regMap) {
+      registrationStatusMap[momentId] = reg?.status ?? null;
+    }
+  }
+
+  const membershipBySlug: Record<string, CircleMemberRole> = {};
+  for (const c of userCircles) {
+    membershipBySlug[c.slug] = c.memberRole;
+  }
+
+  return { moments, hasMore, registrationStatusMap, membershipBySlug };
+}

--- a/src/components/explorer/explorer-grid.tsx
+++ b/src/components/explorer/explorer-grid.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useTranslations } from "next-intl";
+import { Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { PublicCircleCard } from "@/components/explorer/public-circle-card";
+import { PublicMomentCard } from "@/components/explorer/public-moment-card";
+import { loadMoreCirclesAction, loadMoreMomentsAction } from "@/app/actions/explorer";
+import type { PublicCircle } from "@/domain/ports/repositories/circle-repository";
+import type { PublicMoment } from "@/domain/ports/repositories/moment-repository";
+import type { CircleCategory, CircleMemberRole } from "@/domain/models/circle";
+import type { RegistrationStatus } from "@/domain/models/registration";
+
+type CirclesProps = {
+  tab: "circles";
+  initialItems: PublicCircle[];
+  initialHasMore: boolean;
+  membershipRoleMap: Record<string, CircleMemberRole>;
+  category?: CircleCategory;
+};
+
+type MomentsProps = {
+  tab: "moments";
+  initialItems: PublicMoment[];
+  initialHasMore: boolean;
+  registrationStatusMap: Record<string, RegistrationStatus | null>;
+  membershipBySlug: Record<string, CircleMemberRole>;
+  category?: CircleCategory;
+};
+
+type Props = CirclesProps | MomentsProps;
+
+export function ExplorerGrid(props: Props) {
+  const t = useTranslations("Explorer");
+  const [isPending, startTransition] = useTransition();
+
+  const [circleItems, setCircleItems] = useState<PublicCircle[]>(
+    props.tab === "circles" ? props.initialItems : []
+  );
+  const [momentItems, setMomentItems] = useState<PublicMoment[]>(
+    props.tab === "moments" ? props.initialItems : []
+  );
+  const [hasMore, setHasMore] = useState(props.initialHasMore);
+
+  const [circleMembershipMap, setCircleMembershipMap] = useState<Record<string, CircleMemberRole>>(
+    props.tab === "circles" ? props.membershipRoleMap : {}
+  );
+  const [registrationStatusMap, setRegistrationStatusMap] = useState<Record<string, RegistrationStatus | null>>(
+    props.tab === "moments" ? props.registrationStatusMap : {}
+  );
+  const [membershipBySlug, setMembershipBySlug] = useState<Record<string, CircleMemberRole>>(
+    props.tab === "moments" ? props.membershipBySlug : {}
+  );
+
+  function handleLoadMore() {
+    startTransition(async () => {
+      if (props.tab === "circles") {
+        const result = await loadMoreCirclesAction({
+          offset: circleItems.length,
+          category: props.category,
+        });
+        setCircleItems((prev) => [...prev, ...result.circles]);
+        setHasMore(result.hasMore);
+        setCircleMembershipMap((prev) => ({ ...prev, ...result.membershipRoleMap }));
+      } else {
+        const result = await loadMoreMomentsAction({
+          offset: momentItems.length,
+          category: props.category,
+        });
+        setMomentItems((prev) => [...prev, ...result.moments]);
+        setHasMore(result.hasMore);
+        setRegistrationStatusMap((prev) => ({ ...prev, ...result.registrationStatusMap }));
+        setMembershipBySlug((prev) => ({ ...prev, ...result.membershipBySlug }));
+      }
+    });
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {props.tab === "circles"
+          ? circleItems.map((circle) => (
+              <PublicCircleCard
+                key={circle.id}
+                circle={circle}
+                membershipRole={circleMembershipMap[circle.id] ?? null}
+              />
+            ))
+          : momentItems.map((moment) => (
+              <PublicMomentCard
+                key={moment.id}
+                moment={moment}
+                registrationStatus={registrationStatusMap[moment.id] ?? null}
+                isOrganizer={membershipBySlug[moment.circle.slug] === "HOST"}
+              />
+            ))}
+      </div>
+
+      {hasMore && (
+        <div className="flex justify-center">
+          <Button
+            variant="outline"
+            onClick={handleLoadMore}
+            disabled={isPending}
+            className="min-w-32"
+          >
+            {isPending ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : (
+              t("loadMore")
+            )}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/explorer/public-circle-card.tsx
+++ b/src/components/explorer/public-circle-card.tsx
@@ -1,5 +1,7 @@
+"use client";
+
 import { Link } from "@/i18n/navigation";
-import { getTranslations } from "next-intl/server";
+import { useTranslations } from "next-intl";
 import { getMomentGradient } from "@/lib/gradient";
 import { Users, CalendarIcon } from "lucide-react";
 import type { PublicCircle } from "@/domain/ports/repositories/circle-repository";
@@ -10,14 +12,14 @@ type Props = {
   membershipRole?: CircleMemberRole | null;
 };
 
-export async function PublicCircleCard({ circle, membershipRole }: Props) {
-  const t = await getTranslations("Explorer");
-  const tCategory = await getTranslations("CircleCategory");
+export function PublicCircleCard({ circle, membershipRole }: Props) {
+  const t = useTranslations("Explorer");
+  const tCategory = useTranslations("CircleCategory");
 
   const gradient = getMomentGradient(circle.name);
 
   const nextMomentDate = circle.nextMoment
-    ? circle.nextMoment.startsAt.toLocaleDateString(undefined, {
+    ? new Date(circle.nextMoment.startsAt).toLocaleDateString(undefined, {
         day: "numeric",
         month: "short",
       })

--- a/src/components/explorer/public-moment-card.tsx
+++ b/src/components/explorer/public-moment-card.tsx
@@ -1,5 +1,7 @@
+"use client";
+
 import { Link } from "@/i18n/navigation";
-import { getTranslations } from "next-intl/server";
+import { useTranslations } from "next-intl";
 import { getMomentGradient } from "@/lib/gradient";
 import { MapPin, Globe, Users, Crown, Clock, CalendarIcon } from "lucide-react";
 import type { PublicMoment } from "@/domain/ports/repositories/moment-repository";
@@ -11,18 +13,19 @@ type Props = {
   isOrganizer?: boolean;
 };
 
-export async function PublicMomentCard({ moment, registrationStatus, isOrganizer }: Props) {
-  const t = await getTranslations("Explorer");
-  const tCategory = await getTranslations("CircleCategory");
+export function PublicMomentCard({ moment, registrationStatus, isOrganizer }: Props) {
+  const t = useTranslations("Explorer");
+  const tCategory = useTranslations("CircleCategory");
 
   const gradient = getMomentGradient(moment.title);
 
-  const dateStr = moment.startsAt.toLocaleDateString(undefined, {
+  const startsAt = new Date(moment.startsAt);
+  const dateStr = startsAt.toLocaleDateString(undefined, {
     weekday: "short",
     day: "numeric",
     month: "short",
   });
-  const timeStr = moment.startsAt.toLocaleTimeString(undefined, {
+  const timeStr = startsAt.toLocaleTimeString(undefined, {
     hour: "2-digit",
     minute: "2-digit",
   });


### PR DESCRIPTION
## Summary

- **Over-fetch pattern** : le serveur fetche 13 items, affiche 12 — `hasMore` calculé sans requête `count` supplémentaire
- **Client components** : `PublicCircleCard` et `PublicMomentCard` convertis en `"use client"` avec `useTranslations` pour permettre l'append dynamique
- **`ExplorerGrid`** : nouveau composant client avec `useState` + `useTransition`, grille identique à l'existant, bouton "Voir plus" avec spinner `Loader2`
- **Server actions** : `loadMoreCirclesAction` et `loadMoreMomentsAction` dans `src/app/actions/explorer.ts`
- **Fix bug tab switch** : `key="{tab}-{category}"` sur chaque `ExplorerGrid` pour forcer le remontage et reset du state au changement d'onglet
- **Optimisation SSR** : seul le tab actif est fetchée au chargement initial
- **i18n** : FR "Voir plus" / EN "Show more"

## Test plan

- [ ] `/explorer` → max 12 Communautés au chargement
- [ ] Clic "Voir plus" → 12 de plus s'ajoutent, spinner pendant le chargement
- [ ] Fin de liste → bouton disparaît
- [ ] Tab Événements → même comportement
- [ ] Filtre catégorie → reset à 12, pagination indépendante
- [ ] Switch de tab → les items du bon tab s'affichent (pas de bug état résiduel)
- [ ] User non connecté → pas de badges rôle, pagination fonctionne
- [ ] Mobile → grille responsive, bouton visible
- [ ] i18n EN → "Show more" affiché

🤖 Generated with [Claude Code](https://claude.com/claude-code)