### PR TITLE
fix(mobile): améliorer le layout mobile Explorer et Dashboard

### DIFF
--- a/src/app/[locale]/(routes)/dashboard/(app)/(main)/page.tsx
+++ b/src/app/[locale]/(routes)/dashboard/(app)/(main)/page.tsx
@@ -100,8 +100,8 @@ export default async function DashboardPage({
           </Link>
         </div>
         {activeTab === "circles" && (
-          <div className="flex justify-end sm:contents">
-            <Button asChild size="sm">
+          <div className="sm:contents">
+            <Button asChild size="sm" className="w-full sm:w-auto">
               <Link href="/dashboard/circles/new">{t("createCircle")}</Link>
             </Button>
           </div>

--- a/src/app/[locale]/(routes)/explorer/page.tsx
+++ b/src/app/[locale]/(routes)/explorer/page.tsx
@@ -8,7 +8,6 @@ import { auth } from "@/infrastructure/auth/auth.config";
 import { getPublicCircles } from "@/domain/usecases/get-public-circles";
 import { getPublicUpcomingMoments } from "@/domain/usecases/get-public-upcoming-moments";
 import { ExplorerFilterBar } from "@/components/explorer/explorer-filter-bar";
-import { ExplorerCreateButton } from "@/components/explorer/explorer-create-button";
 import { ExplorerGrid } from "@/components/explorer/explorer-grid";
 import { Link } from "@/i18n/navigation";
 import type { CircleCategory, CircleMemberRole } from "@/domain/models/circle";
@@ -94,12 +93,9 @@ export default async function ExplorerPage({
   return (
     <div className="space-y-8">
       {/* Header */}
-      <div className="flex items-start justify-between gap-4">
-        <div className="space-y-3">
-          <h1 className="text-3xl font-bold tracking-tight">{t("title")}</h1>
-          <p className="text-muted-foreground text-base leading-relaxed">{t("description")}</p>
-        </div>
-        <ExplorerCreateButton />
+      <div className="space-y-3">
+        <h1 className="text-3xl font-bold tracking-tight">{t("title")}</h1>
+        <p className="text-muted-foreground text-base leading-relaxed">{t("description")}</p>
       </div>
 
       {/* Tabs */}


### PR DESCRIPTION
## Changements

### Explorer — suppression du bouton "Créer une Communauté"
La page Découvrir est une page de découverte pour les Participants. Le bouton de création y était hors contexte (action d'Organisateur) et créait un déséquilibre visuel sur mobile (2 colonnes : titre à gauche, gros bouton rose à droite, sous-titre qui wrappait mot par mot).

Le header devient : titre + sous-titre, full-width, propre sur tous les écrans.

### Dashboard — bouton "Créer une Communauté" full-width sur mobile
Sur l'onglet Communautés, le bouton était orphelin à droite sur mobile (`justify-end`). Il est maintenant `w-full` sur mobile et reprend sa taille naturelle sur desktop (`sm:w-auto`). Comportement desktop inchangé.

## Test plan
- [ ] Mobile : page Découvrir → header propre, pas de bouton CTA
- [ ] Mobile : dashboard onglet Communautés → bouton full-width sous les tabs
- [ ] Desktop : dashboard onglet Communautés → bouton aligné à droite des tabs (inchangé)
- [ ] Desktop : page Découvrir → header titre + sous-titre (inchangé)

🤖 Generated with [Claude Code](https://claude.com/claude-code)