### PR TITLE
fix(admin): remonter "Retour au site" juste sous le menu

### DIFF
--- a/src/components/admin/admin-sidebar.tsx
+++ b/src/components/admin/admin-sidebar.tsx
@@ -40,7 +40,7 @@ export function AdminSidebar() {
       </div>
 
       {/* Navigation */}
-      <nav className="flex flex-1 flex-col gap-1 p-3">
+      <nav className="flex flex-col gap-1 p-3">
         {navItems.map(({ key, href, icon: Icon }) => (
           <Link
             key={key}
@@ -56,18 +56,18 @@ export function AdminSidebar() {
             {t(key)}
           </Link>
         ))}
-      </nav>
 
-      {/* Back to site */}
-      <div className="border-t border-border/40 p-3">
-        <Link
-          href="/dashboard"
-          className="flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-        >
-          <ArrowLeft className="size-4" />
-          {t("backToSite")}
-        </Link>
-      </div>
+        {/* Back to site */}
+        <div className="mt-2 border-t border-border/40 pt-2">
+          <Link
+            href="/dashboard"
+            className="flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          >
+            <ArrowLeft className="size-4" />
+            {t("backToSite")}
+          </Link>
+        </div>
+      </nav>
     </aside>
   );
 }


### PR DESCRIPTION
## Summary

- Déplace le lien "Retour au site" depuis le footer collé en bas de sidebar vers juste en dessous des items de navigation
- Séparé des nav items par un petit trait (`border-t`) pour rester lisible

## Test plan

- [ ] Page `/admin` → "Retour au site" apparaît juste sous les 4 liens de navigation
- [ ] Clic → redirige vers `/dashboard`

🤖 Generated with [Claude Code](https://claude.com/claude-code)