### PR TITLE
fix(security): corrections audit SAST — SSRF, auth guard, CSP, HSTS

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -16,6 +16,33 @@ const securityHeaders = [
     key: "Permissions-Policy",
     value: "camera=(), microphone=(), geolocation=(self), interest-cohort=()",
   },
+  // Force HTTPS pendant 2 ans, sous-domaines inclus (HSTS)
+  {
+    key: "Strict-Transport-Security",
+    value: "max-age=63072000; includeSubDomains; preload",
+  },
+  // Content Security Policy — restreint les sources de scripts, styles et images
+  {
+    key: "Content-Security-Policy",
+    value: [
+      "default-src 'self'",
+      // Next.js requiert 'unsafe-inline' pour les styles injectés et 'unsafe-eval' pour le HMR dev
+      // Stripe.js doit être chargé depuis js.stripe.com (exigence PCI-DSS)
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval' js.stripe.com",
+      "style-src 'self' 'unsafe-inline'",
+      // Images : domaine propre + blobs + avatars OAuth + Unsplash + Stripe
+      "img-src 'self' data: blob: *.unsplash.com public.blob.vercel-storage.com avatars.githubusercontent.com lh3.googleusercontent.com q.stripe.com",
+      // Connexions : domaine propre + Sentry (tunnel via /monitoring) + Stripe API
+      "connect-src 'self' *.sentry.io api.stripe.com",
+      "font-src 'self'",
+      // Stripe Elements et Stripe Checkout utilisent des iframes hébergées sur js.stripe.com
+      "frame-src js.stripe.com",
+      // Interdire l'intégration de NOTRE page dans des iframes tierces (anti-clickjacking)
+      "frame-ancestors 'none'",
+      // Formulaires : uniquement vers le domaine propre
+      "form-action 'self'",
+    ].join("; "),
+  },
 ];
 
 const nextConfig: NextConfig = {


### PR DESCRIPTION
## Résumé

Corrections issues de l'audit de sécurité statique (SAST) du 2026-02-25.

## Vulnérabilités corrigées

### 🔴 HIGH — SSRF dans `processCoverImage` (`cover-image.ts`)
- Ajout d'une allowlist de domaines (`images.unsplash.com`, `plus.unsplash.com`)
- Validation HTTPS obligatoire avant tout `fetch()`
- Toute URL non conforme est rejetée avec une erreur explicite

### 🟠 MEDIUM — Auth guard manquant (`cover-image.ts`)
- Ajout de `auth()` en tête de la server action
- Rejet immédiat si pas de session active

### 🟠 MEDIUM — Pas de limite de taille sur les uploads (`cover-image.ts`)
- Rejet des fichiers > 10 Mo avant upload vers Vercel Blob

### 🟠 MEDIUM — Content-Security-Policy (`next.config.ts`)
- CSP complet avec toutes les sources nécessaires
- **Stripe inclus** : `js.stripe.com` (script), `api.stripe.com` (connect), `js.stripe.com` (frame) pour les paiements futurs
- `frame-ancestors 'none'` : anti-clickjacking cohérent avec `X-Frame-Options: DENY`

### 🟡 LOW — HSTS (`next.config.ts`)
- `Strict-Transport-Security: max-age=63072000; includeSubDomains; preload`

## Points non corrigés dans cette PR (recommandations)

- **H02** : API `/api/unsplash/*` sans auth → à traiter séparément (rate limiting)
- **M03** : Rate limiting magic link + commentaires → Upstash Ratelimit (future PR)
- **L01** : `/api/dev/impersonate` → ajouter un `DEV_IMPERSONATE_SECRET`

## Tests

- `pnpm typecheck` ✅
- `pnpm test:unit` : 367 tests passés ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)