### PR TITLE
chore(security): DAST OWASP ZAP — baseline prod + full scan preview

### DIFF
--- a/.github/workflows/dast-preview-full.yml
+++ b/.github/workflows/dast-preview-full.yml
@@ -1,0 +1,51 @@
+name: DAST — Full Scan (Preview)
+
+on:
+  # Se déclenche quand Vercel crée ou met à jour un déploiement
+  deployment_status:
+
+jobs:
+  zap-full:
+    name: ZAP Full Scan — Preview
+    runs-on: ubuntu-latest
+    # Ne s'exécute que sur les déploiements Vercel Preview (pas Production) qui ont réussi
+    if: |
+      github.event.deployment_status.state == 'success' &&
+      contains(github.event.deployment.environment, 'Preview')
+    permissions:
+      issues: write
+      pull-requests: write  # Pour commenter la PR avec le résumé du scan
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: ZAP Full Scan
+        uses: zaproxy/action-full-scan@v0.11.0
+        with:
+          # URL du déploiement Vercel Preview (fournie automatiquement par GitHub)
+          target: "${{ github.event.deployment_status.target_url }}"
+          # Règles personnalisées (faux positifs Next.js filtrés)
+          rules_file_name: ".zap/rules.tsv"
+          # Ne pas faire échouer le CI — alertes en avertissement uniquement
+          fail_action: false
+          # Ouvrir une issue GitHub si de nouvelles alertes critiques sont détectées
+          allow_issue_writing: true
+          # Durée max du spider (en minutes)
+          cmd_options: "-m 5"
+
+      - name: Upload rapport HTML
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: zap-full-report-${{ github.run_number }}
+          path: report_html.html
+          retention-days: 14
+
+      - name: Upload rapport JSON
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: zap-full-report-json-${{ github.run_number }}
+          path: report_json.json
+          retention-days: 14

--- a/.github/workflows/dast-prod-baseline.yml
+++ b/.github/workflows/dast-prod-baseline.yml
@@ -1,0 +1,47 @@
+name: DAST — Baseline Scan (Production)
+
+on:
+  # Déclenchement manuel depuis GitHub Actions UI
+  workflow_dispatch:
+  # Scan hebdomadaire automatique — dimanche à 4h UTC
+  schedule:
+    - cron: "0 4 * * 0"
+
+jobs:
+  zap-baseline:
+    name: ZAP Baseline Scan — Production
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write  # ZAP peut ouvrir des issues GitHub sur les alertes
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: ZAP Baseline Scan
+        uses: zaproxy/action-baseline@v0.14.0
+        with:
+          # URL de production Vercel
+          target: "https://the-playground-eight.vercel.app/"
+          # Règles personnalisées (faux positifs Next.js filtrés)
+          rules_file_name: ".zap/rules.tsv"
+          # Ne pas faire échouer le CI — alertes en avertissement uniquement
+          fail_action: false
+          # Ouvrir une issue GitHub si de nouvelles alertes sont détectées
+          allow_issue_writing: true
+
+      - name: Upload rapport HTML
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: zap-baseline-report-${{ github.run_number }}
+          path: report_html.html
+          retention-days: 30
+
+      - name: Upload rapport JSON
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: zap-baseline-report-json-${{ github.run_number }}
+          path: report_json.json
+          retention-days: 30

--- a/.zap/rules.tsv
+++ b/.zap/rules.tsv
@@ -1,0 +1,5 @@
+10015	IGNORE	(Incomplete or No Cache-control Header Set)	Next.js gère le cache via CDN (Vercel), pas via les headers HTTP classiques
+10027	IGNORE	(Information Disclosure - Suspicious Comments)	Artefacts de build Next.js minifiés, non exploitables
+10096	IGNORE	(Timestamp Disclosure - Unix)	Timestamps de build dans les assets statiques, non exploitables
+10049	IGNORE	(Storable and Cacheable Content)	Pages Next.js avec ISR/SSG, comportement voulu
+10050	IGNORE	(Retrieved from Cache)	Cache CDN Vercel, comportement attendu


### PR DESCRIPTION
## Summary

Mise en place du DAST (Dynamic Application Security Testing) via OWASP ZAP en GitHub Actions.

## Deux workflows

### `dast-prod-baseline.yml` — Scan passif Production
- **Déclenchement** : hebdomadaire (dimanche 4h UTC) + `workflow_dispatch` manuel
- **Cible** : `https://the-playground-eight.vercel.app/`
- **Mode** : Baseline (passif — safe sur prod, pas d'attaques réelles)
- **Output** : rapport HTML + JSON en artifact (30 jours), issues GitHub ouvertes sur nouvelles alertes

### `dast-preview-full.yml` — Full scan Preview
- **Déclenchement** : `deployment_status` → chaque déploiement Vercel Preview réussi
- **Cible** : URL dynamique `${{ github.event.deployment_status.target_url }}`
- **Mode** : Full scan (actif — attaques réelles sur l'environnement de staging)
- **Output** : rapport HTML + JSON en artifact (14 jours)

### `.zap/rules.tsv` — Filtres faux positifs Next.js
- Cache-control (CDN Vercel)
- Timestamps de build statiques
- Commentaires dans assets minifiés

## Ce que ça détecte

- Headers de sécurité manquants ou mal configurés
- XSS réfléchi et stocké
- Injection (SQL, LDAP, etc.)
- CSRF
- Informations sensibles exposées
- Problèmes d'authentification / session
- CORS mal configuré

## Test plan

- [ ] Merger → vérifier que le workflow `dast-prod-baseline` apparaît dans Actions
- [ ] Lancer manuellement via `workflow_dispatch` → rapport disponible en artifact
- [ ] Créer une PR → vérifier que `dast-preview-full` se déclenche sur le déploiement Vercel Preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)