### PR TITLE
chore(ci): désactiver le full scan DAST automatique sur les PRs

### DIFF
--- a/.github/workflows/dast-preview-full.yml
+++ b/.github/workflows/dast-preview-full.yml
@@ -1,17 +1,18 @@
 name: DAST — Full Scan (Preview)
 
 on:
-  # Se déclenche quand Vercel crée ou met à jour un déploiement
-  deployment_status:
+  # Déclenchement manuel depuis GitHub Actions UI — fournir l'URL du déploiement Preview
+  workflow_dispatch:
+    inputs:
+      target_url:
+        description: "URL du déploiement Vercel Preview à scanner"
+        required: true
+        type: string
 
 jobs:
   zap-full:
     name: ZAP Full Scan — Preview
     runs-on: ubuntu-latest
-    # Ne s'exécute que sur les déploiements Vercel Preview (pas Production) qui ont réussi
-    if: |
-      github.event.deployment_status.state == 'success' &&
-      contains(github.event.deployment.environment, 'Preview')
     permissions:
       issues: write
       pull-requests: write  # Pour commenter la PR avec le résumé du scan
@@ -23,8 +24,8 @@ jobs:
       - name: ZAP Full Scan
         uses: zaproxy/action-full-scan@v0.11.0
         with:
-          # URL du déploiement Vercel Preview (fournie automatiquement par GitHub)
-          target: "${{ github.event.deployment_status.target_url }}"
+          # URL du déploiement Vercel Preview (saisie manuellement au lancement)
+          target: "${{ github.event.inputs.target_url }}"
           # Règles personnalisées (faux positifs Next.js filtrés)
           rules_file_name: ".zap/rules.tsv"
           # Ne pas faire échouer le CI — alertes en avertissement uniquement


### PR DESCRIPTION
## Summary

- Le full scan ZAP s'exécutait automatiquement sur **chaque PR** via `deployment_status`, ajoutant ~10 minutes au cycle CI (perçu comme 1m30 → 2m30+)
- Le workflow échouait systématiquement (findings ZAP + nommage artifacts)
- Conversion en **déclenchement manuel uniquement** (`workflow_dispatch`) avec saisie de l'URL Preview

## Utilisation

Pour scanner un déploiement Preview manuellement :
1. GitHub Actions → "DAST — Full Scan (Preview)" → Run workflow
2. Saisir l'URL Vercel Preview à scanner

## Test plan

- [ ] Ouvrir une PR → vérifier que le full scan **ne se déclenche plus automatiquement**
- [ ] CI retourne à ~30s (typecheck + test-unit)
- [ ] Le baseline hebdomadaire prod reste inchangé

🤖 Generated with [Claude Code](https://claude.com/claude-code)