### PR TITLE
feat(virality): page profil public /u/[publicId] + champ publicId

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -905,6 +905,21 @@
       "newMomentInCircle": "New event",
       "newMomentInCircleDesc": "When an event is created in a Community you follow",
       "saved": "Preferences saved"
+    },
+    "publicProfile": {
+      "memberSince": "Member since {date}",
+      "communities": "Communities ({count})",
+      "upcomingEvents": "Upcoming events ({count})",
+      "noUpcomingEvents": "No upcoming events",
+      "noCommunities": "No public community",
+      "viewMyProfile": "View my public profile",
+      "itsYourProfile": "This is your profile",
+      "editMyProfile": "Edit my profile",
+      "hostedEvents": "{count, plural, one {# event organized} other {# events organized}}",
+      "notFound": "Profile not found",
+      "signInToView": "Sign in to view this profile",
+      "roleHost": "Organizer",
+      "rolePlayer": "Member"
     }
   },
   "Help": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -905,6 +905,21 @@
       "newMomentInCircle": "Nouvel événement",
       "newMomentInCircleDesc": "Quand un événement est créé dans une Communauté que vous suivez",
       "saved": "Préférences enregistrées"
+    },
+    "publicProfile": {
+      "memberSince": "Membre depuis {date}",
+      "communities": "Communautés ({count})",
+      "upcomingEvents": "Prochains événements ({count})",
+      "noUpcomingEvents": "Aucun événement à venir",
+      "noCommunities": "Aucune communauté publique",
+      "viewMyProfile": "Voir mon profil public",
+      "itsYourProfile": "C'est votre profil",
+      "editMyProfile": "Modifier mon profil",
+      "hostedEvents": "{count, plural, one {# événement organisé} other {# événements organisés}}",
+      "notFound": "Profil introuvable",
+      "signInToView": "Connecte-toi pour voir ce profil",
+      "roleHost": "Organisateur",
+      "rolePlayer": "Participant"
     }
   },
   "Help": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
     "db:backfill-notification-prefs:prod": "bash scripts/backfill-notification-prefs-prod.sh",
     "db:backfill-dashboard-mode": "tsx scripts/backfill-dashboard-mode.ts",
     "db:backfill-dashboard-mode:prod": "bash scripts/backfill-dashboard-mode-prod.sh",
+    "db:backfill-public-id": "tsx scripts/backfill-public-id.ts",
+    "db:backfill-public-id:prod": "bash scripts/backfill-public-id-prod.sh",
     "db:subscribe-demo-to-the-spark:prod": "bash scripts/db-subscribe-demo-to-the-spark-prod.sh",
     "db:seed-covers": "tsx scripts/seed-covers.ts",
     "db:seed-covers:execute": "tsx scripts/seed-covers.ts --execute",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -136,6 +136,7 @@ model User {
   notifyNewFollower         Boolean   @default(true)
   notifyNewMomentInCircle   Boolean   @default(true)
   dashboardMode             DashboardMode?
+  publicId                  String?   @unique @map("public_id")
   createdAt                 DateTime  @default(now())
   updatedAt                 DateTime  @updatedAt
 

--- a/scripts/backfill-public-id-prod.sh
+++ b/scripts/backfill-public-id-prod.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────
+# db:backfill-public-id:prod
+# Génère un publicId unique (prénom-nom-xxxx)
+# pour chaque utilisateur en production qui
+# n'en a pas encore.
+#
+# Usage: pnpm db:backfill-public-id:prod
+# ─────────────────────────────────────────────
+
+set -euo pipefail
+
+# Load env vars
+if [ -f .env.local ]; then
+  export $(grep -E '^(NEON_API_KEY|NEON_PROJECT_ID|NEON_PROD_BRANCH_ID)=' .env.local | xargs)
+fi
+
+if [ -z "${NEON_API_KEY:-}" ] || [ -z "${NEON_PROJECT_ID:-}" ] || [ -z "${NEON_PROD_BRANCH_ID:-}" ]; then
+  echo "❌ Missing NEON_API_KEY, NEON_PROJECT_ID, or NEON_PROD_BRANCH_ID in .env.local"
+  exit 1
+fi
+
+API="https://console.neon.tech/api/v2/projects/${NEON_PROJECT_ID}"
+AUTH="Authorization: Bearer ${NEON_API_KEY}"
+
+echo "🔍 Fetching production connection string..."
+
+RESPONSE=$(curl -s -H "$AUTH" "${API}/connection_uri?branch_id=${NEON_PROD_BRANCH_ID}&pooled=true&database_name=neondb&role_name=neondb_owner")
+PROD_URL=$(echo "$RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin)['uri'])")
+
+if [ -z "$PROD_URL" ]; then
+  echo "❌ Could not retrieve production connection string."
+  exit 1
+fi
+
+echo ""
+echo "⚠️  Vous êtes sur le point de backfiller les publicId en PRODUCTION."
+echo "   Branch : production (${NEON_PROD_BRANCH_ID})"
+echo "   Règle  : génère un publicId (prénom-nom-xxxx) pour les utilisateurs sans publicId"
+echo "   Scope  : uniquement les utilisateurs avec publicId = null"
+echo ""
+read -p "   Continuer ? (y/N) " -n 1 -r
+echo ""
+
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+  echo "   Annulé."
+  exit 0
+fi
+
+echo ""
+echo "🌱 Backfill des publicId en production..."
+DATABASE_URL="${PROD_URL}" npx tsx scripts/backfill-public-id.ts

--- a/scripts/backfill-public-id.ts
+++ b/scripts/backfill-public-id.ts
@@ -1,0 +1,100 @@
+/**
+ * Backfill du publicId pour les utilisateurs existants.
+ *
+ * Génère un publicId unique (prénom-nom-xxxx) pour chaque utilisateur
+ * qui n'en a pas encore.
+ *
+ * Idempotent : ne touche pas les utilisateurs qui ont déjà un publicId.
+ *
+ * Usage dev  : pnpm db:backfill-public-id
+ * Usage prod : pnpm db:backfill-public-id:prod
+ */
+
+import { config } from "dotenv";
+config({ path: ".env.local" });
+
+import { PrismaClient } from "@prisma/client";
+import { PrismaNeon } from "@prisma/adapter-neon";
+
+if (!process.env.DATABASE_URL) {
+  console.error("❌ DATABASE_URL non défini.");
+  process.exit(1);
+}
+
+const prisma = new PrismaClient({
+  adapter: new PrismaNeon({ connectionString: process.env.DATABASE_URL }),
+});
+
+function slugify(str: string): string {
+  return str
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80);
+}
+
+function generatePublicId(firstName: string | null, lastName: string | null): string {
+  const random = Math.floor(1000 + Math.random() * 9000);
+  const base = [firstName, lastName].filter(Boolean).join(" ").trim();
+  if (!base) return `user-${Math.floor(10000 + Math.random() * 90000)}`;
+  return `${slugify(base)}-${random}`;
+}
+
+async function main() {
+  const totalNull = await prisma.user.count({ where: { publicId: null } });
+
+  if (totalNull === 0) {
+    console.log("✅ Tous les utilisateurs ont déjà un publicId. Rien à faire.");
+    return;
+  }
+
+  console.log(`\n🔍 ${totalNull} utilisateur(s) sans publicId — backfill en cours...\n`);
+
+  const users = await prisma.user.findMany({
+    where: { publicId: null },
+    select: { id: true, firstName: true, lastName: true },
+  });
+
+  let updated = 0;
+  let failed = 0;
+
+  for (const user of users) {
+    let success = false;
+
+    for (let attempt = 0; attempt < 10; attempt++) {
+      const candidate = generatePublicId(user.firstName, user.lastName);
+      try {
+        await prisma.user.update({
+          where: { id: user.id },
+          data: { publicId: candidate },
+        });
+        success = true;
+        updated++;
+        break;
+      } catch {
+        // Collision unique constraint → réessayer avec un nouveau nombre aléatoire
+      }
+    }
+
+    if (!success) {
+      console.warn(`  ⚠️  Impossible de générer un publicId pour l'utilisateur ${user.id}`);
+      failed++;
+    }
+  }
+
+  console.log(`\n✅ Backfill terminé — ${updated} utilisateur(s) mis à jour.`);
+  if (failed > 0) {
+    console.warn(`⚠️  ${failed} utilisateur(s) n'ont pas pu être mis à jour.`);
+  }
+  console.log();
+}
+
+main()
+  .catch((e) => {
+    console.error("❌ Erreur :", e);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/scripts/backfill-public-id.ts
+++ b/scripts/backfill-public-id.ts
@@ -15,6 +15,7 @@ config({ path: ".env.local" });
 
 import { PrismaClient } from "@prisma/client";
 import { PrismaNeon } from "@prisma/adapter-neon";
+import { generatePublicId } from "@/lib/public-id";
 
 if (!process.env.DATABASE_URL) {
   console.error("❌ DATABASE_URL non défini.");
@@ -24,24 +25,6 @@ if (!process.env.DATABASE_URL) {
 const prisma = new PrismaClient({
   adapter: new PrismaNeon({ connectionString: process.env.DATABASE_URL }),
 });
-
-function slugify(str: string): string {
-  return str
-    .normalize("NFD")
-    .replace(/[\u0300-\u036f]/g, "")
-    .toLowerCase()
-    .trim()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "")
-    .slice(0, 80);
-}
-
-function generatePublicId(firstName: string | null, lastName: string | null): string {
-  const random = Math.floor(1000 + Math.random() * 9000);
-  const base = [firstName, lastName].filter(Boolean).join(" ").trim();
-  if (!base) return `user-${Math.floor(10000 + Math.random() * 90000)}`;
-  return `${slugify(base)}-${random}`;
-}
 
 async function main() {
   const totalNull = await prisma.user.count({ where: { publicId: null } });

--- a/spec/feature-virality-public-profiles.md
+++ b/spec/feature-virality-public-profiles.md
@@ -1,0 +1,536 @@
+# Spec — Viralité : Membres & Participants visibles + Profils utilisateurs
+
+**Date :** 2026-03-10
+**Statut :** Validé — prêt à implémenter
+**Priorité :** Haute (levier de viralité / conversion)
+
+---
+
+## 1. Vision & Objectif
+
+Augmenter la conversion en rendant visibles les membres d'une communauté à **tout utilisateur connecté**, et en permettant à tout utilisateur connecté de consulter le profil d'un autre utilisateur.
+
+**Principe :** La preuve sociale (social proof) est le premier levier de conversion. Voir que des gens réels participent à une communauté ou à un événement incite à rejoindre. Aujourd'hui, la liste des membres n'est visible que dans le dashboard (membres seulement). C'est un frein à la conversion.
+
+**Contrainte de confidentialité (membres uniquement) :** La liste des membres d'une communauté est réservée aux **utilisateurs connectés**. Un visiteur non connecté voit uniquement le compteur total, pas les noms. La liste des participants à un événement reste visible par tous (comportement actuel conservé).
+
+**Objectif secondaire :** Permettre à tout utilisateur connecté de consulter le profil d'un autre utilisateur en cliquant sur son nom dans une liste. Le profil devient un hub de découverte : communautés + événements de la personne.
+
+---
+
+## 2. Périmètre
+
+### 2.1 Ce que cette feature inclut
+
+| # | Feature | Description |
+| --- | --- | --- |
+| F1 | **Membres visibles pour les connectés — page Communauté** | Afficher la liste des membres (nom + avatar) sur la page `/circles/[slug]`, visible uniquement pour les utilisateurs connectés |
+| F2 | **Noms des participants cliquables — page Événement** | Sur `/m/[slug]`, la liste reste visible par tous (inchangé) — les noms deviennent des liens vers le profil pour les connectés uniquement |
+| F3 | **Page profil utilisateur** | Nouvelle route `/u/[publicId]` accessible aux utilisateurs connectés uniquement |
+| F4 | **Profil enrichi : Communautés** | La page profil affiche les communautés publiques dont l'utilisateur est membre |
+| F5 | **Profil enrichi : Événements** | La page profil affiche les événements publics à venir auxquels l'utilisateur est inscrit |
+| F6 | **Noms cliquables dans CircleMembersList** | Dans le dashboard Circle, les noms des membres redirigent vers `/u/[publicId]` |
+| F7 | **Noms cliquables dans RegistrationsList** | Dans les pages événement (public + dashboard), les noms redirigent vers `/u/[publicId]` pour les connectés |
+| F8 | **Lien "Voir mon profil" — Dashboard Profil** | Lien discret sous les stats sur `/dashboard/profile` → `/u/[publicId]` de l'utilisateur connecté |
+
+### 2.2 Ce que cette feature n'inclut pas (hors scope)
+
+- Messagerie privée entre utilisateurs
+- Abonnement / suivi d'un utilisateur
+- Fil d'actualité des utilisateurs
+- Données privées visibles (email, téléphone, date d'inscription)
+- Paramètres de confidentialité granulaires (scope Phase 2)
+- Communautés privées dans le profil (filtrées — seules les communautés publiques sont visibles)
+
+---
+
+## 3. Règles métier
+
+### 3.1 Visibilité des membres (F1)
+
+- La liste des membres est visible **uniquement par les utilisateurs connectés** (connecté + non-membre = peut voir, non-connecté = ne voit pas)
+- La liste des membres d'une communauté **privée** reste masquée pour les non-membres, même connectés
+- Informations visibles dans la liste : **avatar (initiales/image) + nom complet**
+- Informations masquées : email, date d'adhésion, rôle détaillé (sauf badge Organisateur)
+- Badge "Organisateur" visible sur les Hosts
+- Ordre d'affichage : Organisateurs d'abord, puis membres triés par date d'adhésion ascendante (les membres les plus anciens apparaissent en premier)
+- Pagination : afficher les 12 premiers membres, bouton "Voir tous les membres" pour la liste complète
+- Compteur total de membres visible par tous (connecté ou non) — comportement inchangé
+- **Le compteur de membres est cliquable** pour les utilisateurs connectés → scroll/ancre vers la section membres
+- Pour les visiteurs non connectés : compteur non cliquable + message "Connecte-toi pour voir les membres"
+
+### 3.2 Visibilité des participants (F2)
+
+- **La visibilité de la liste des participants est inchangée** : elle reste visible par tous sur `/m/[slug]`, connecté ou non — comportement actuel conservé
+- **Nouveau :** les noms sont cliquables pour les utilisateurs connectés → redirigent vers `/u/[publicId]`
+- Pour les visiteurs non connectés : noms affichés en texte simple, non cliquables
+- Emails : jamais visibles publiquement (uniquement pour les Organisateurs — comportement inchangé)
+- Bouton export CSV (`variant="host"`) : **strictement conservé**, inchangé
+
+### 3.3 Page profil utilisateur (F3)
+
+- Route : `/u/[publicId]` — ex. `/u/jean-dupont-4821`
+- **Accessible uniquement aux utilisateurs connectés** — redirection vers `/auth/sign-in` si non connecté
+- Si le `publicId` n'existe pas → 404
+- Un utilisateur connecté peut voir son propre profil
+- L'utilisateur qui visite son propre profil voit un bandeau "C'est votre profil · [Modifier mon profil →]"
+
+### 3.4 Communautés sur le profil (F4)
+
+- Seules les communautés **publiques** dont l'utilisateur est membre sont affichées
+- Les communautés privées ne sont JAMAIS affichées sur le profil
+- Informations affichées : nom de la communauté, cover/avatar, rôle (Organisateur / Participant)
+- Tri : les communautés où l'utilisateur est **Organisateur** apparaissent en premier, puis celles où il est **Participant** — au sein de chaque groupe, tri alphabétique par nom de communauté
+- Lien vers la page publique de la communauté (`/circles/[slug]`)
+
+### 3.5 Événements sur le profil (F5)
+
+- Seuls les événements **à venir** auxquels l'utilisateur est inscrit (statut REGISTERED) sont affichés
+- Les événements passés ne sont pas affichés (peu de valeur virale)
+- Les événements appartenant à des communautés **privées** ne sont pas affichés
+- Informations affichées : titre, date, nom de la communauté
+- Lien vers la page publique de l'événement (`/m/[slug]`)
+- Si aucun événement à venir → section masquée ou état vide discret
+
+### 3.6 Données personnelles & RGPD
+
+- Nom complet visible pour les connectés → **l'utilisateur a consenti lors de l'inscription** (le nom est obligatoire à l'onboarding)
+- Email **jamais** visible en dehors du contexte Organisateur
+- Ajout d'une option "Masquer mon profil" dans les paramètres (Phase 2 — hors scope MVP)
+- Avatar visible pour les connectés si uploadé
+
+---
+
+## 4. Décisions d'implémentation
+
+### 4.1 Route de la page profil : `/u/[publicId]`
+
+**Décision : slug généré automatiquement**
+- Format : `prénom-nom` slugifié + nombre aléatoire à 4 chiffres → ex. `/u/jean-dupont-4821`
+- ✅ URL lisible et quasi-mémorisable
+- ✅ Généré automatiquement à la création du compte — aucune action utilisateur
+- ✅ Le nombre aléatoire évite les collisions sans gestion complexe
+- Champ `publicId` (string unique) ajouté au modèle `User` dans le schema Prisma
+- Non éditable par l'utilisateur dans le MVP
+
+### 4.1.1 Stratégie de migration — champ `publicId`
+
+**Étape 1 — Migration Prisma :**
+```prisma
+model User {
+  // ...
+  publicId  String?  @unique  // nullable intentionnellement (backfill à venir)
+}
+```
+Le champ est nullable pour ne pas bloquer les utilisateurs existants pendant la transition.
+
+**Étape 2 — Backfill des utilisateurs existants :**
+Script `pnpm db:backfill-public-id` (dev) / `pnpm db:backfill-public-id:prod` (prod) :
+- Pour chaque `User` sans `publicId` : générer `slugify(firstName + "-" + lastName) + "-" + random(1000, 9999)`
+- Vérifier l'unicité avant d'insérer — si collision, régénérer avec un nouveau nombre aléatoire (retry jusqu'à 10 fois)
+- Fallback si `firstName` ou `lastName` est null/vide : `user-{random(10000, 99999)}`
+- Script idempotent : ne re-génère pas si `publicId` déjà présent
+
+**Étape 3 — Génération automatique pour les nouveaux utilisateurs :**
+À la création d'un compte (callback `signIn` Auth.js ou usecase `CreateUser`) : générer et persister le `publicId` immédiatement.
+
+**Gestion des routes pour les utilisateurs sans \****`publicId`**\*\* :**
+- Edge case post-migration → la page `/u/[publicId]` retourne 404
+- Le lien profil dans les listes n'est rendu que si `publicId` est non null
+
+### 4.2 Gestion de l'accès restreint aux non-connectés
+
+Sur la page **Communauté**, section membres :
+- Connecté → fetch membres + affichage de la liste
+- Non connecté → uniquement le compteur (non cliquable) + placeholder "Connecte-toi pour voir les membres"
+
+Sur la page **Événement**, section participants :
+- Comportement de visibilité inchangé (liste visible par tous)
+- Connecté → noms = liens `/u/[publicId]`
+- Non connecté → noms = texte simple non cliquable
+
+**Implémentation :** guard au niveau du Server Component — la condition `session` est évaluée côté serveur, aucune donnée de membre n'est envoyée au client non connecté (Option A).
+
+### 4.3 Évolution de `CircleMembersList`
+
+Ajouter `variant="member-view"` au composant existant :
+- Masque les emails, masque le bouton retrait
+- Noms cliquables → `/u/[publicId]`
+- Utilisé sur la page Circle publique (connecté non-membre ou membre)
+- Les variants `"player"` et `"host"` existants reçoivent également les liens profil
+
+---
+
+## 5. Comportements UX détaillés
+
+### 5.1 Page publique Communauté — section membres
+
+**Visiteur non connecté :**
+```
+┌─────────────────────────────────────────────────────┐
+│  Membres (42)  ← non cliquable                       │
+│                                                      │
+│  [🔒] Connecte-toi pour voir les membres            │
+│                          [Se connecter →]           │
+└─────────────────────────────────────────────────────┘
+```
+
+**Utilisateur connecté (non-membre ou membre) :**
+```
+┌─────────────────────────────────────────────────────┐
+│  Membres (42)  ← cliquable, scroll vers la section   │
+│                                                      │
+│  [👑 JD] Jean Dupont · Organisateur  ← lien /u/…   │
+│  [MF] Marie Fontaine · Organisateur  ← lien /u/…   │
+│  [AL] Alice Leroy                    ← lien /u/…   │
+│  [TB] Thomas Bernard                 ← lien /u/…   │
+│  [  ] + 38 autres membres                           │
+│                          [Voir tous les membres →]  │
+└─────────────────────────────────────────────────────┘
+```
+
+### 5.2 Page publique Événement — section participants
+
+**Visiteur non connecté :**
+```
+[AB] Alice B.    (texte non cliquable)
+[CB] Charles B.  (texte non cliquable)
+```
+
+**Utilisateur connecté :**
+```
+[AB] Alice B.    → lien /u/jean-dupont-4821
+[CB] Charles B.  → lien /u/charles-b-7392
+```
+
+Aucun autre changement — visibilité, badges, export CSV : inchangés.
+
+### 5.3 Page profil `/u/[publicId]`
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  [bandeau si profil propre]                              │
+│  C'est votre profil · [Modifier mon profil →]            │
+├──────────────────────────────────────────────────────────┤
+│   [Avatar]   Jean Dupont                                 │
+│              /u/jean-dupont-4821                         │
+│              Membre depuis mars 2025                     │
+│              15 événements organisés  ← si ≥ 1 moment    │
+├──────────────────────────────────────────────────────────┤
+│  Communautés (3)                                         │
+│                                                          │
+│  [Cover] Tech Paris           Organisateur    →          │
+│  [Cover] Yoga Montmartre      Participant     →          │
+│  [Cover] Design Thinking FR   Participant     →          │
+├──────────────────────────────────────────────────────────┤
+│  Prochains événements (2)                                │
+│                                                          │
+│  Soirée JS & Pizza            Mar 15 · Tech Paris  →     │
+│  Workshop React 19            Mar 22 · Tech Paris  →     │
+└──────────────────────────────────────────────────────────┘
+```
+
+- Stat "événements organisés" : affichée uniquement si `hostedMomentsCount > 0` (ne pas afficher "0 événement organisé")
+
+- Si aucune communauté publique → section masquée
+- Si aucun événement à venir → section masquée
+
+### 5.4 Dashboard Profil — lien "Voir mon profil" (F8)
+
+Sous les stats `"3 communautés · 12 événements"` :
+```
+↗ Voir mon profil public    ← lien discret, texte primary, underline dotted
+```
+Redirige vers `/u/[publicId]` de l'utilisateur connecté.
+
+---
+
+## 6. Questions ouvertes — résolues
+
+| Question | Décision |
+| --- | --- |
+| Événements passés sur le profil ? | Non — hors scope MVP |
+| "Voir tous les membres" : pagination ou modal ? | Expand en place, load more |
+| Communautés privées visibles dans le profil ? | Non — jamais |
+| User peut masquer son profil ? | Phase 2 |
+| Nombre d'événements organisés sur le profil d'un Organisateur ? | Oui, comme stat |
+| Données de profil éditables depuis `/u/[publicId]` ? | Non — lien "Modifier mon profil" → dashboard |
+
+---
+
+## 7. Contraintes techniques
+
+- **Performance** : fetch des membres conditionné à la session — aucune requête supplémentaire pour les non-connectés.
+- **Sécurité** : les emails ne doivent jamais fuiter via les routes publiques ou semi-publiques.
+- **SSR** : Server Components — la condition `session` est évaluée côté serveur. Aucune donnée de membre envoyée au client non connecté.
+- **i18n** : toutes les nouvelles chaînes UI doivent être ajoutées en FR et EN.
+- **Auth guard sur \****`/u/[publicId]`** : `auth()` dans le Server Component + redirect si non connecté.
+- **Schema Prisma** : ajout du champ `publicId` → migration + backfill requis sur dev et prod.
+
+---
+
+## 8. Analyse complète des modifications par page
+
+### 8.1 Page publique Communauté — `/circles/[slug]/page.tsx`
+
+| Zone | Modification | Détail |
+| --- | --- | --- |
+| **Données chargées** | Conditionner le fetch des membres à la session | Connecté : fetch membres (nom, avatar, rôle). Non connecté : compteur seul (déjà chargé) |
+| **Compteur membres** | Cliquable si connecté | Rendu comme `<a href="#members-section">` pour les connectés. Non cliquable (`<span>`) sinon |
+| **Nouvelle section "Membres"** | Après la section événements, avec `id="members-section"` | Connecté : `CircleMembersList variant="member-view"` + noms → `/u/[publicId]`. Non connecté : placeholder |
+| **Guard communauté privée** | Masquer même pour connecté non-membre | `isPrivate && !isMember` → ne pas afficher la liste |
+
+**Fichiers à modifier :**
+- `src/app/[locale]/(routes)/circles/[slug]/page.tsx`
+- `src/components/circles/circle-members-list.tsx`
+- `src/domain/ports/repositories/circle-repository.ts`
+- `src/infrastructure/repositories/prisma-circle-repository.ts`
+
+**Schema Prisma** : aucune modification.
+
+---
+
+### 8.2 Page publique Événement — `/m/[slug]/page.tsx`
+
+| Zone | Modification | Détail |
+| --- | --- | --- |
+| **Noms dans RegistrationsList** | Cliquables si connecté | Connecté : lien `/u/[publicId]`. Non connecté : texte simple |
+| **Visibilité de la liste** | **Inchangée** | Liste toujours visible par tous — comportement actuel conservé |
+| **Export CSV, emails, badges** | **Inchangés** | Comportement host strictement conservé |
+
+**Fichiers à modifier :**
+- `src/app/[locale]/(routes)/m/[slug]/page.tsx` — passer `isAuthenticated` au composant
+- `src/components/moments/registrations-list.tsx` — noms cliquables si `isConnected`
+
+---
+
+### 8.3 Page Découvrir — `/explorer/page.tsx`
+
+**Optionnel pour le MVP** — prioriser F1, F2, F3.
+
+---
+
+### 8.4 Dashboard Circle — `circles/[slug]/page.tsx`
+
+| Zone | Modification | Détail |
+| --- | --- | --- |
+| **CircleMembersList** | Noms cliquables | Chaque nom → `/u/[publicId]` |
+| **Emails, bouton retrait** | Inchangés | Comportement host conservé |
+
+**Fichiers à modifier :**
+- `src/components/circles/circle-members-list.tsx`
+
+---
+
+### 8.5 Dashboard Moment — `moments/[momentSlug]/page.tsx` (vue host)
+
+| Zone | Modification | Détail |
+| --- | --- | --- |
+| **RegistrationsList** | Noms cliquables | Liens `/u/[publicId]` — emails, export CSV, tous les comportements host **strictement conservés** |
+
+---
+
+### 8.6 Dashboard Profil — `/dashboard/profile/page.tsx`
+
+| Zone | Modification | Détail |
+| --- | --- | --- |
+| **Lien "Voir mon profil"** | Ajouter sous les stats | Lien discret → `/u/[publicId]` de l'utilisateur connecté |
+
+**Fichiers à modifier :**
+- `src/app/[locale]/(routes)/dashboard/(app)/(main)/profile/page.tsx`
+
+---
+
+### 8.7 Nouvelle page — Profil utilisateur `/u/[publicId]/page.tsx`
+
+**Structure :**
+```
+src/app/[locale]/(routes)/u/[publicId]/
+  page.tsx      → Server Component (SSR), auth guard
+  loading.tsx   → Skeleton
+```
+
+**Auth guard :**
+```typescript
+const session = await auth();
+if (!session) redirect(`/${locale}/auth/sign-in`);
+```
+
+**Nouveau usecase :** `GetUserPublicProfile`
+- Input : `publicId: string`
+- Output : `{ user: PublicUser, publicCircles: PublicCircleMembership[], upcomingPublicMoments: PublicMomentRegistration[] }`
+- Filtres : communautés publiques uniquement, événements à venir uniquement, aucune info privée
+
+**Nouveau champ Prisma :**
+```prisma
+model User {
+  // ...champs existants...
+  publicId  String?  @unique  // ex: "jean-dupont-4821" — généré à la création, non éditable
+}
+```
+
+**Types dans le domaine :**
+```typescript
+type PublicUser = {
+  publicId: string;
+  firstName: string;
+  lastName: string;
+  image: string | null;
+  memberSince: Date;
+  hostedMomentsCount: number;  // 0 si jamais organisé — affiché seulement si > 0
+}
+
+type PublicCircleMembership = {
+  circleSlug: string;
+  circleName: string;
+  circleCover: string | null;
+  role: "HOST" | "PLAYER";
+}
+
+type PublicMomentRegistration = {
+  momentSlug: string;
+  momentTitle: string;
+  momentDate: Date;
+  circleName: string;
+}
+```
+
+**Flux du usecase `GetUserPublicProfile` :**
+1. `UserRepository.getUserPublicProfile(publicId)` → résout le `userId` + données de base (`hostedMomentsCount` inclus)
+2. Si `null` → retourner `null` (la page affichera un 404)
+3. `CircleRepository.getPublicCirclesForUser(userId)` → communautés publiques
+4. `MomentRepository.getUpcomingPublicMomentsForUser(userId)` → événements à venir publics
+5. Assembler et retourner `{ user, publicCircles, upcomingPublicMoments }`
+
+**Nouveaux ports :**
+```typescript
+// UserRepository
+getUserPublicProfile(publicId: string): Promise<PublicUser | null>
+// inclut hostedMomentsCount (count des Moments où l'user est HOST dans au moins un Circle)
+
+// CircleRepository
+getPublicCirclesForUser(userId: string): Promise<PublicCircleMembership[]>
+
+// MomentRepository
+getUpcomingPublicMomentsForUser(userId: string): Promise<PublicMomentRegistration[]>
+```
+
+---
+
+### 8.8 Composant `CircleMembersList` — évolution
+
+| Prop | Actuel | Nouveau |
+| --- | --- | --- |
+| `variant` | `"player"` ou `"host"` | Ajouter `"member-view"` |
+| `variant="member-view"` | — | Masque emails + bouton retrait, noms → `/u/[publicId]` |
+| `variant="player"` | Noms non cliquables | Noms → `/u/[publicId]` |
+| `variant="host"` | Noms non cliquables | Noms → `/u/[publicId]`, emails + retrait inchangés |
+
+---
+
+### 8.9 Composant `RegistrationsList` — évolution
+
+| Zone | Actuel | Nouveau |
+| --- | --- | --- |
+| Noms (`variant="public"`) | Texte statique | Lien `/u/[publicId]` si `isConnected`, texte sinon |
+| Noms (`variant="host"`) | Texte statique | Lien `/u/[publicId]` — emails et export CSV **inchangés** |
+| Bouton export CSV (`variant="host"`) | Présent | **Conservé sans modification** |
+| Emails (`variant="host"`) | Visibles | **Conservés sans modification** |
+
+---
+
+## 9. Nouvelles routes
+
+| Route | Type | Accès |
+| --- | --- | --- |
+| `/u/[publicId]` | Semi-publique | Utilisateurs connectés uniquement — redirect sign-in sinon |
+
+Exemple : `/u/jean-dupont-4821`
+
+---
+
+## 10. Nouveaux usecases & ports
+
+| Usecase | Port / méthode | Description |
+| --- | --- | --- |
+| `GetUserPublicProfile` | `UserRepository.getUserPublicProfile(publicId)` | Lookup par `publicId`, retourne données non-privées |
+| — | `CircleRepository.getPublicCirclesForUser(userId)` | Communautés publiques de l'utilisateur |
+| — | `MomentRepository.getUpcomingPublicMomentsForUser(userId)` | Événements publics à venir de l'utilisateur |
+
+**Note schema :** migration Prisma (`publicId` nullable) + script backfill `pnpm db:backfill-public-id` sur dev et prod.
+
+---
+
+## 11. Nouvelles chaînes i18n
+
+| Clé | FR | EN |
+| --- | --- | --- |
+| `Profile.memberSince` | `Membre depuis {date}` | `Member since {date}` |
+| `Profile.communities` | `Communautés ({count})` | `Communities ({count})` |
+| `Profile.upcomingEvents` | `Prochains événements ({count})` | `Upcoming events ({count})` |
+| `Profile.noUpcomingEvents` | `Aucun événement à venir` | `No upcoming events` |
+| `Profile.noCommunities` | `Aucune communauté publique` | `No public community` |
+| `Profile.editMyProfile` | `Modifier mon profil` | `Edit my profile` |
+| `Profile.viewMyProfile` | `Voir mon profil public` | `View my public profile` |
+| `Profile.itsYourProfile` | `C'est votre profil` | `This is your profile` |
+| `Profile.hostedEvents` | `{count} événement organisé` / `{count} événements organisés` | `{count} event organized` / `{count} events organized` |
+| `Circle.membersSection` | `Membres ({count})` | `Members ({count})` |
+| `Circle.seeAllMembers` | `Voir tous les membres` | `See all members` |
+| `Circle.loginToSeeMembers` | `Connecte-toi pour voir les membres` | `Sign in to see members` |
+
+---
+
+## 12. Ordre d'implémentation recommandé
+
+| Priorité | Feature | Complexité | Impact |
+| --- | --- | --- | --- |
+| 1 | F3 + F4 + F5 — Page profil `/u/[publicId]` + contenu enrichi | Moyenne | Fondation requise pour toutes les autres |
+| 2 | F2 — Noms cliquables sur page Événement | Faible | Quick win, page à fort trafic |
+| 3 | F1 — Membres sur page Communauté (connectés uniquement) | Moyenne | Fort impact viral |
+| 4 | F6 + F7 — Noms cliquables dans dashboard (Circle + Moment) | Faible | Cohérence UX |
+| 5 | F8 — Lien "Voir mon profil" sur dashboard profil | Très faible | Confort utilisateur |
+
+---
+
+## 13. Tests requis
+
+### Tests unitaires (Vitest)
+
+- `GetUserPublicProfile` usecase :
+  - Given user exists with public circles → returns correct profile
+  - Given user exists but all circles are private → returns empty circles array
+  - Given user has upcoming events in private circles → filters them out
+  - Given publicId doesn't exist → returns null
+  - Never returns email in profile data
+  - Given user has hosted moments → hostedMomentsCount reflects exact count
+  - Given user has never hosted → hostedMomentsCount is 0
+
+### Tests E2E (Playwright)
+
+**Membres (F1) :**
+- Un utilisateur connecté (non-membre) peut voir la liste des membres d'une communauté publique
+- Le compteur de membres est cliquable pour un utilisateur connecté → scroll vers la section membres
+- Le compteur de membres n'est pas cliquable pour un visiteur non connecté
+- Un visiteur non connecté voit le placeholder "Connecte-toi pour voir les membres"
+
+**Participants (F2) :**
+- Un visiteur non connecté voit la liste des participants en texte non cliquable
+- Un utilisateur connecté voit les noms des participants comme des liens cliquables
+
+**Profil (F3, F4, F5) :**
+- Un utilisateur connecté peut cliquer sur un membre et accéder à sa page profil
+- La page profil affiche les communautés publiques et les événements à venir
+- Un utilisateur non connecté accédant à `/u/[publicId]` est redirigé vers sign-in
+- Un utilisateur connecté voit le bandeau "C'est votre profil" sur son propre profil
+
+**Dashboard profil (F8) :**
+- Un utilisateur connecté voit le lien "Voir mon profil public" sous ses stats sur `/dashboard/profile`
+- Le lien pointe vers `/u/[publicId]` de l'utilisateur connecté
+
+**Sécurité :**
+- Les emails ne sont jamais visibles en dehors du contexte Organisateur
+- Une communauté privée ne montre pas ses membres à un utilisateur connecté non-membre
+
+---
+
+*Spec créée le 2026-03-10 — validée, prête à implémenter.*

--- a/spec/mockups/virality-circle-page.mockup.html
+++ b/spec/mockups/virality-circle-page.mockup.html
@@ -1,0 +1,838 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Mockup — Page Communauté publique — Viralité membres</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --background: #1c1929;
+      --card: #252235;
+      --border: #3d3850;
+      --foreground: #f0eff6;
+      --muted-foreground: #8885a0;
+      --primary: #e8437d;
+      --primary-10: rgba(232,67,125,0.1);
+      --primary-5: rgba(232,67,125,0.05);
+      --primary-40: rgba(232,67,125,0.4);
+      --radius: 0.5rem;
+    }
+
+    body {
+      font-family: 'Inter', system-ui, -apple-system, sans-serif;
+      background: var(--background);
+      color: var(--foreground);
+      min-height: 100vh;
+    }
+
+    /* ─── Bandeau mockup ─── */
+    .mockup-banner {
+      background: #0f0c1a;
+      border-bottom: 2px solid var(--primary-40);
+      padding: 10px 24px;
+      text-align: center;
+      font-size: 13px;
+      font-weight: 600;
+      color: #fff;
+      letter-spacing: 0.03em;
+      position: sticky;
+      top: 0;
+      z-index: 100;
+    }
+    .mockup-banner span {
+      color: var(--primary);
+    }
+
+    /* ─── Fake Nav ─── */
+    .fake-nav {
+      background: var(--card);
+      border-bottom: 1px solid var(--border);
+      padding: 0 32px;
+      height: 56px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+    .fake-nav .logo {
+      font-weight: 800;
+      font-size: 18px;
+      color: var(--primary);
+      letter-spacing: -0.02em;
+    }
+    .fake-nav .nav-links {
+      display: flex;
+      gap: 24px;
+      font-size: 14px;
+      color: var(--muted-foreground);
+    }
+    .fake-nav .nav-links span { cursor: pointer; }
+    .fake-nav .nav-links span:hover { color: var(--foreground); }
+    .fake-nav .nav-actions {
+      display: flex;
+      gap: 10px;
+    }
+    .btn-sm {
+      padding: 6px 14px;
+      border-radius: var(--radius);
+      font-size: 13px;
+      font-weight: 500;
+      cursor: pointer;
+      border: 1px solid var(--border);
+      background: transparent;
+      color: var(--foreground);
+    }
+    .btn-primary {
+      background: var(--primary);
+      color: #fff;
+      border-color: var(--primary);
+    }
+
+    /* ─── Layout principal ─── */
+    .page-container {
+      max-width: 1280px;
+      margin: 0 auto;
+      padding: 32px 32px 80px;
+    }
+
+    /* ─── Breadcrumb ─── */
+    .breadcrumb {
+      font-size: 13px;
+      color: var(--muted-foreground);
+      margin-bottom: 28px;
+      display: flex;
+      align-items: center;
+      gap: 6px;
+    }
+    .breadcrumb a {
+      color: var(--muted-foreground);
+      text-decoration: none;
+    }
+    .breadcrumb a:hover { color: var(--foreground); }
+    .breadcrumb .sep { color: var(--border); }
+    .breadcrumb .current { color: var(--foreground); font-weight: 500; }
+
+    /* ─── Two-col layout ─── */
+    .two-col {
+      display: flex;
+      gap: 40px;
+      align-items: flex-start;
+    }
+
+    /* ─── Colonne gauche ─── */
+    .sidebar {
+      width: 340px;
+      flex-shrink: 0;
+      position: sticky;
+      top: 80px;
+    }
+
+    .cover-square {
+      width: 100%;
+      aspect-ratio: 1/1;
+      border-radius: var(--radius);
+      background: linear-gradient(135deg, #e8437d 0%, #9b59b6 50%, #3498db 100%);
+      margin-bottom: 20px;
+      overflow: hidden;
+      position: relative;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .cover-square .cover-label {
+      font-size: 40px;
+      font-weight: 800;
+      color: rgba(255,255,255,0.9);
+      letter-spacing: -0.02em;
+    }
+
+    .sidebar-card {
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 20px;
+      margin-bottom: 14px;
+    }
+
+    .hosts-section {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      margin-bottom: 16px;
+    }
+    .hosts-avatars {
+      display: flex;
+    }
+    .avatar {
+      width: 36px;
+      height: 36px;
+      border-radius: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 13px;
+      font-weight: 700;
+      color: #fff;
+      border: 2px solid var(--card);
+      flex-shrink: 0;
+    }
+    .avatar-green  { background: linear-gradient(135deg, #27ae60, #1abc9c); }
+    .avatar-blue   { background: linear-gradient(135deg, #2980b9, #3498db); }
+    .avatar-orange { background: linear-gradient(135deg, #e67e22, #f39c12); }
+    .avatar-violet { background: linear-gradient(135deg, #8e44ad, #9b59b6); }
+    .avatar-red    { background: linear-gradient(135deg, #c0392b, #e74c3c); }
+    .avatar-pink   { background: linear-gradient(135deg, #e8437d, #c0325d); }
+
+    .hosts-avatars .avatar:not(:first-child) { margin-left: -10px; }
+    .hosts-info { font-size: 13px; color: var(--muted-foreground); }
+    .hosts-info strong { color: var(--foreground); font-weight: 600; display: block; font-size: 14px; }
+
+    /* ─── Stats ─── */
+    .stats-row {
+      display: flex;
+      gap: 0;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      overflow: hidden;
+      margin-bottom: 14px;
+    }
+    .stat-box {
+      flex: 1;
+      padding: 14px 10px;
+      text-align: center;
+      border-right: 1px solid var(--border);
+    }
+    .stat-box:last-child { border-right: none; }
+    .stat-number {
+      font-size: 22px;
+      font-weight: 700;
+      color: var(--foreground);
+      line-height: 1;
+      display: block;
+      margin-bottom: 4px;
+    }
+    .stat-label {
+      font-size: 12px;
+      color: var(--muted-foreground);
+    }
+
+    /* ─── NOUVEAU : stat membre cliquable ─── */
+    .stat-number-link {
+      color: var(--primary);
+      text-decoration: underline dotted;
+      cursor: pointer;
+      font-size: 22px;
+      font-weight: 700;
+      line-height: 1;
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      margin-bottom: 4px;
+    }
+    .stat-arrow {
+      font-size: 14px;
+      color: var(--primary);
+      opacity: 0.8;
+    }
+
+    /* ─── Badges ─── */
+    .badge-row {
+      display: flex;
+      gap: 8px;
+      flex-wrap: wrap;
+      margin-bottom: 14px;
+    }
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 5px;
+      padding: 4px 10px;
+      border-radius: 20px;
+      font-size: 12px;
+      font-weight: 500;
+    }
+    .badge-outline-primary {
+      border: 1px solid var(--primary-40);
+      color: var(--primary);
+      background: var(--primary-5);
+    }
+    .badge-outline-muted {
+      border: 1px solid var(--border);
+      color: var(--muted-foreground);
+      background: transparent;
+    }
+
+    /* ─── Boutons sidebar ─── */
+    .btn-sidebar {
+      width: 100%;
+      padding: 10px;
+      border-radius: var(--radius);
+      font-size: 14px;
+      font-weight: 500;
+      cursor: pointer;
+      transition: all 0.15s;
+      text-align: center;
+      display: block;
+    }
+    .btn-sidebar-primary {
+      background: var(--primary);
+      color: #fff;
+      border: none;
+      margin-bottom: 8px;
+    }
+    .btn-sidebar-outline {
+      background: transparent;
+      color: var(--muted-foreground);
+      border: 1px solid var(--border);
+    }
+
+    /* ─── Colonne droite ─── */
+    .main-col {
+      flex: 1;
+      min-width: 0;
+    }
+
+    .orga-line {
+      font-size: 13px;
+      color: var(--muted-foreground);
+      margin-bottom: 8px;
+    }
+    .orga-line a { color: var(--primary); text-decoration: none; }
+
+    .circle-title {
+      font-size: 30px;
+      font-weight: 800;
+      letter-spacing: -0.02em;
+      color: var(--foreground);
+      margin-bottom: 16px;
+      line-height: 1.15;
+    }
+
+    .description {
+      font-size: 15px;
+      color: var(--muted-foreground);
+      line-height: 1.65;
+      margin-bottom: 24px;
+    }
+
+    .sep { border: none; border-top: 1px solid var(--border); margin: 24px 0; }
+
+    /* ─── Meta rows ─── */
+    .meta-grid {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      margin-bottom: 0;
+    }
+    .meta-row {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      font-size: 14px;
+    }
+    .meta-icon {
+      width: 32px;
+      height: 32px;
+      border-radius: 8px;
+      background: var(--primary-10);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 15px;
+      flex-shrink: 0;
+    }
+    .meta-label { color: var(--muted-foreground); font-size: 13px; }
+    .meta-value { color: var(--foreground); font-weight: 500; }
+
+    /* ─── Onglets ─── */
+    .tabs {
+      display: flex;
+      gap: 4px;
+      border-bottom: 1px solid var(--border);
+      margin-bottom: 20px;
+    }
+    .tab {
+      padding: 10px 18px;
+      font-size: 14px;
+      font-weight: 500;
+      color: var(--muted-foreground);
+      cursor: pointer;
+      border-bottom: 2px solid transparent;
+      margin-bottom: -1px;
+    }
+    .tab.active {
+      color: var(--foreground);
+      border-bottom-color: var(--primary);
+    }
+
+    /* ─── Cartes événement ─── */
+    .event-card {
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 16px 18px;
+      margin-bottom: 12px;
+      display: flex;
+      align-items: center;
+      gap: 16px;
+      cursor: pointer;
+      transition: border-color 0.15s;
+    }
+    .event-card:hover { border-color: var(--primary-40); }
+
+    .event-date-badge {
+      background: var(--primary-10);
+      border: 1px solid var(--primary-40);
+      border-radius: 8px;
+      padding: 8px 12px;
+      text-align: center;
+      flex-shrink: 0;
+      min-width: 52px;
+    }
+    .event-date-badge .month {
+      font-size: 11px;
+      color: var(--primary);
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+    }
+    .event-date-badge .day {
+      font-size: 22px;
+      font-weight: 800;
+      color: var(--foreground);
+      line-height: 1.1;
+    }
+
+    .event-info { flex: 1; min-width: 0; }
+    .event-title {
+      font-size: 15px;
+      font-weight: 600;
+      color: var(--foreground);
+      margin-bottom: 4px;
+    }
+    .event-meta {
+      font-size: 13px;
+      color: var(--muted-foreground);
+      display: flex;
+      gap: 14px;
+    }
+
+    .event-arrow {
+      color: var(--muted-foreground);
+      font-size: 18px;
+    }
+
+    /* ─── Section membres ─── */
+    .section-header {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      margin-bottom: 18px;
+    }
+    .section-title {
+      font-size: 18px;
+      font-weight: 700;
+      color: var(--foreground);
+    }
+    .badge-count {
+      display: inline-flex;
+      align-items: center;
+      padding: 2px 9px;
+      border-radius: 20px;
+      font-size: 12px;
+      font-weight: 600;
+      border: 1px solid var(--border);
+      color: var(--muted-foreground);
+      background: transparent;
+    }
+
+    .member-row {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      padding: 10px 0;
+      border-bottom: 1px solid var(--border);
+    }
+    .member-row:last-child { border-bottom: none; }
+
+    .crown-icon {
+      color: var(--primary);
+      font-size: 14px;
+      width: 18px;
+      text-align: center;
+      flex-shrink: 0;
+    }
+    .crown-placeholder { width: 18px; flex-shrink: 0; }
+
+    .member-name-link {
+      color: var(--primary);
+      text-decoration: underline;
+      cursor: pointer;
+      font-size: 14px;
+      font-weight: 500;
+    }
+    .member-name-link:hover { opacity: 0.85; }
+
+    .member-name {
+      font-size: 14px;
+      font-weight: 500;
+      color: var(--foreground);
+    }
+
+    .more-members {
+      font-size: 13px;
+      color: var(--muted-foreground);
+      padding: 12px 0 0;
+      font-style: italic;
+    }
+
+    .btn-full-outline {
+      width: 100%;
+      padding: 11px;
+      border-radius: var(--radius);
+      border: 1px solid var(--border);
+      background: transparent;
+      color: var(--foreground);
+      font-size: 14px;
+      font-weight: 500;
+      cursor: pointer;
+      margin-top: 16px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 6px;
+      transition: border-color 0.15s;
+    }
+    .btn-full-outline:hover { border-color: var(--primary-40); color: var(--primary); }
+
+    /* ─── État non-connecté membres ─── */
+    .locked-state {
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 28px 24px;
+      text-align: center;
+    }
+    .lock-icon {
+      font-size: 28px;
+      color: var(--muted-foreground);
+      margin-bottom: 10px;
+      display: block;
+    }
+    .locked-text {
+      font-size: 14px;
+      color: var(--muted-foreground);
+      margin-bottom: 16px;
+    }
+
+    /* ─── Séparateur de vue mockup ─── */
+    .mockup-view-sep {
+      border: none;
+      border-top: 2px dashed #e8437d55;
+      margin: 48px 0 32px;
+      position: relative;
+    }
+    .mockup-view-sep::after {
+      content: '— Vue non-connecté —';
+      position: absolute;
+      top: -11px;
+      left: 50%;
+      transform: translateX(-50%);
+      background: var(--background);
+      padding: 0 16px;
+      font-size: 12px;
+      font-weight: 600;
+      color: var(--primary);
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      white-space: nowrap;
+    }
+
+  </style>
+</head>
+<body>
+
+<!-- ─── Bandeau mockup ─── -->
+<div class="mockup-banner">
+  Mockup —
+  <span>Page Communauté publique</span>
+  — Viralité : membres visibles (connecté &amp; non-connecté)
+</div>
+
+<!-- ─── Fausse nav ─── -->
+<nav class="fake-nav">
+  <div class="logo">The Playground</div>
+  <div class="nav-links">
+    <span>Mon espace</span>
+    <span>Découvrir</span>
+  </div>
+  <div class="nav-actions">
+    <button class="btn-sm btn-primary">Marie D.</button>
+  </div>
+</nav>
+
+<!-- ─── Contenu principal ─── -->
+<div class="page-container">
+
+  <!-- Breadcrumb -->
+  <div class="breadcrumb">
+    <a href="#">Découvrir</a>
+    <span class="sep">›</span>
+    <span class="current">Tech Paris</span>
+  </div>
+
+  <div class="two-col">
+
+    <!-- ═══════════════════════════════════════ -->
+    <!-- COLONNE GAUCHE                          -->
+    <!-- ═══════════════════════════════════════ -->
+    <aside class="sidebar">
+
+      <!-- Cover carré -->
+      <div class="cover-square">
+        <span class="cover-label">TP</span>
+      </div>
+
+      <!-- Card principale sidebar -->
+      <div class="sidebar-card">
+
+        <!-- Hosts -->
+        <div class="hosts-section">
+          <div class="hosts-avatars">
+            <div class="avatar avatar-green">MD</div>
+            <div class="avatar avatar-blue">TB</div>
+          </div>
+          <div class="hosts-info">
+            <strong>Tech Paris</strong>
+            Organisé par Marie D. &amp; Thomas B.
+          </div>
+        </div>
+
+        <!-- Stats avec compteur membre cliquable -->
+        <div class="stats-row">
+            <!-- Stat membres — cliquable -->
+            <div class="stat-box">
+              <a class="stat-number-link" href="#members-section" title="Voir les membres">
+                42
+                <span class="stat-arrow">→</span>
+              </a>
+              <div class="stat-label">Membres</div>
+            </div>
+            <!-- Stat événements -->
+            <div class="stat-box">
+              <span class="stat-number">18</span>
+              <div class="stat-label">Événements</div>
+            </div>
+        </div>
+
+        <!-- Badges statut -->
+        <div class="badge-row" style="margin-top: 14px;">
+          <span class="badge badge-outline-primary">👑 Organisateur</span>
+          <span class="badge badge-outline-primary">✓ Membre</span>
+        </div>
+
+        <!-- Boutons -->
+        <button class="btn-sidebar btn-sidebar-outline">Quitter la communauté</button>
+
+      </div>
+
+    </aside>
+
+    <!-- ═══════════════════════════════════════ -->
+    <!-- COLONNE DROITE                          -->
+    <!-- ═══════════════════════════════════════ -->
+    <main class="main-col">
+
+      <!-- Organisé par -->
+      <div class="orga-line">
+        Organisé par <a href="#">Marie Dupont</a> &amp; <a href="#">Thomas Bernard</a>
+      </div>
+
+      <!-- Titre -->
+      <h1 class="circle-title">Tech Paris</h1>
+
+      <!-- Description -->
+      <p class="description">
+        La communauté tech parisienne pour les développeurs, designers et entrepreneurs.
+        Rejoignez-nous pour des soirées networking, workshops pratiques et talks d'experts.
+        Plus de 40 membres actifs depuis janvier 2025.
+      </p>
+
+      <hr class="sep" />
+
+      <!-- Meta rows -->
+      <div class="meta-grid">
+        <div class="meta-row">
+          <div class="meta-icon">🏷️</div>
+          <div>
+            <div class="meta-label">Catégorie</div>
+            <div class="meta-value">Tech &amp; Développement</div>
+          </div>
+        </div>
+        <div class="meta-row">
+          <div class="meta-icon">📍</div>
+          <div>
+            <div class="meta-label">Ville</div>
+            <div class="meta-value">Paris, France</div>
+          </div>
+        </div>
+        <div class="meta-row">
+          <div class="meta-icon">🔓</div>
+          <div>
+            <div class="meta-label">Visibilité</div>
+            <div class="meta-value">Publique</div>
+          </div>
+        </div>
+        <div class="meta-row">
+          <div class="meta-icon">👥</div>
+          <div>
+            <div class="meta-label">Membres</div>
+            <div class="meta-value">42 membres</div>
+          </div>
+        </div>
+        <div class="meta-row">
+          <div class="meta-icon">📅</div>
+          <div>
+            <div class="meta-label">Créée le</div>
+            <div class="meta-value">15 jan. 2025</div>
+          </div>
+        </div>
+      </div>
+
+      <hr class="sep" />
+
+      <!-- Onglets événements -->
+      <div class="tabs">
+        <div class="tab active">À venir</div>
+        <div class="tab">Passés</div>
+      </div>
+
+      <!-- Événements -->
+      <div class="event-card">
+        <div class="event-date-badge">
+          <div class="month">Mar</div>
+          <div class="day">15</div>
+        </div>
+        <div class="event-info">
+          <div class="event-title">Soirée JS &amp; Pizza</div>
+          <div class="event-meta">
+            <span>🕖 19h00</span>
+            <span>📍 Station F, Paris</span>
+            <span>👥 28 inscrits</span>
+          </div>
+        </div>
+        <div class="event-arrow">›</div>
+      </div>
+
+      <div class="event-card">
+        <div class="event-date-badge">
+          <div class="month">Mar</div>
+          <div class="day">22</div>
+        </div>
+        <div class="event-info">
+          <div class="event-title">Workshop React 19 — Nouveautés &amp; Server Components</div>
+          <div class="event-meta">
+            <span>🕑 14h00</span>
+            <span>📍 Le Wagon, Paris</span>
+            <span>👥 12 inscrits</span>
+          </div>
+        </div>
+        <div class="event-arrow">›</div>
+      </div>
+
+      <!-- ─────────────────────────────────────────── -->
+      <!-- SECTION MEMBRES — Vue connectée            -->
+      <!-- ─────────────────────────────────────────── -->
+      <hr class="sep" />
+
+      <div id="members-section">
+
+          <div class="section-header">
+            <span class="section-title">Membres</span>
+            <span class="badge-count">42</span>
+          </div>
+
+          <!-- Ligne 1 — Organisateur -->
+          <div class="member-row">
+            <span class="crown-icon" title="Organisateur">♛</span>
+            <div class="avatar avatar-green" style="width:32px;height:32px;font-size:12px;">MD</div>
+            <a class="member-name-link" href="#">Marie Dupont</a>
+            <span class="badge badge-outline-primary" style="margin-left: auto; font-size:11px;">Organisateur</span>
+          </div>
+
+          <!-- Ligne 2 — Organisateur -->
+          <div class="member-row">
+            <span class="crown-icon" title="Organisateur">♛</span>
+            <div class="avatar avatar-blue" style="width:32px;height:32px;font-size:12px;">TB</div>
+            <a class="member-name-link" href="#">Thomas Bernard</a>
+            <span class="badge badge-outline-primary" style="margin-left: auto; font-size:11px;">Organisateur</span>
+          </div>
+
+          <!-- Ligne 3 — Membre -->
+          <div class="member-row">
+            <span class="crown-placeholder"></span>
+            <div class="avatar avatar-orange" style="width:32px;height:32px;font-size:12px;">AL</div>
+            <a class="member-name-link" href="#">Alice Leroy</a>
+          </div>
+
+          <!-- Ligne 4 — Membre -->
+          <div class="member-row">
+            <span class="crown-placeholder"></span>
+            <div class="avatar avatar-violet" style="width:32px;height:32px;font-size:12px;">JM</div>
+            <a class="member-name-link" href="#">Jean Martin</a>
+          </div>
+
+          <!-- Ligne 5 — Membre -->
+          <div class="member-row">
+            <span class="crown-placeholder"></span>
+            <div class="avatar avatar-red" style="width:32px;height:32px;font-size:12px;">SC</div>
+            <a class="member-name-link" href="#">Sophie Chen</a>
+          </div>
+
+          <!-- More -->
+          <div class="more-members">
+            + 37 autres membres
+          </div>
+
+          <!-- CTA -->
+          <button class="btn-full-outline">
+            Voir tous les membres →
+          </button>
+
+      </div>
+
+      <!-- ─────────────────────────────────────────── -->
+      <!-- SÉPARATEUR VUE NON-CONNECTÉ                -->
+      <!-- ─────────────────────────────────────────── -->
+      <hr class="mockup-view-sep" />
+
+      <!-- ─────────────────────────────────────────── -->
+      <!-- SECTION MEMBRES — Vue non-connectée        -->
+      <!-- ─────────────────────────────────────────── -->
+      <div>
+
+          <div class="section-header">
+            <span class="section-title">Membres</span>
+            <span class="badge-count">42</span>
+          </div>
+
+          <!-- État verrouillé -->
+          <div class="locked-state">
+            <span class="lock-icon">🔒</span>
+            <p class="locked-text">
+              Connecte-toi pour voir les membres de cette communauté.
+            </p>
+            <button class="btn-full-outline" style="margin-top: 0;">
+              Se connecter
+            </button>
+          </div>
+
+      </div>
+
+    </main>
+  </div>
+</div>
+
+</body>
+</html>

--- a/spec/mockups/virality-dashboard-profile.mockup.html
+++ b/spec/mockups/virality-dashboard-profile.mockup.html
@@ -1,0 +1,523 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Mockup — Dashboard Profil — F8 : lien « Voir mon profil public »</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #1c1929;
+      color: #f0eff6;
+      min-height: 100vh;
+    }
+
+    /* ── Barre de titre mockup ── */
+    .mockup-bar {
+      width: 100%;
+      background: #252235;
+      border-bottom: 1px solid #3d3850;
+      padding: 10px 24px;
+      color: #8885a0;
+      font-size: 13px;
+    }
+
+    /* ── Header ── */
+    .header {
+      position: sticky;
+      top: 0;
+      height: 56px;
+      background: rgba(28, 25, 41, 0.85);
+      backdrop-filter: blur(12px);
+      border-bottom: 1px solid #3d3850;
+      z-index: 100;
+      display: flex;
+      align-items: center;
+    }
+    .header-inner {
+      max-width: 1024px;
+      width: 100%;
+      margin: 0 auto;
+      padding: 0 16px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    /* Logo */
+    .logo {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      text-decoration: none;
+    }
+    .logo-icon {
+      width: 24px;
+      height: 24px;
+      background: linear-gradient(135deg, #ec4899, #8b5cf6);
+      border-radius: 5px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+    }
+    .logo-text {
+      font-size: 15px;
+      font-weight: 800;
+      letter-spacing: -0.4px;
+      color: #f0eff6;
+    }
+    .logo-text span { color: #e8437d; }
+
+    /* Nav */
+    .nav {
+      display: flex;
+      align-items: center;
+      gap: 24px;
+    }
+    .nav-item {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 14px;
+      text-decoration: none;
+      cursor: pointer;
+    }
+    .nav-item.muted { color: #8885a0; }
+    .nav-item.active { color: #f0eff6; }
+
+    /* Actions droite */
+    .header-actions {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+    }
+    .icon-btn {
+      background: none;
+      border: none;
+      cursor: pointer;
+      color: #8885a0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 4px;
+    }
+    .avatar-sm {
+      width: 32px;
+      height: 32px;
+      border-radius: 50%;
+      background: linear-gradient(135deg, #ec4899, #8b5cf6);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 12px;
+      font-weight: 600;
+      color: white;
+      cursor: pointer;
+      flex-shrink: 0;
+    }
+
+    /* ── Contenu principal ── */
+    .main {
+      padding-top: 32px;
+      padding-bottom: 48px;
+    }
+    .main-inner {
+      max-width: 1024px;
+      margin: 0 auto;
+      padding: 0 16px;
+    }
+    .profile-wrapper {
+      max-width: 512px;
+      margin: 0 auto;
+    }
+
+    /* Breadcrumb */
+    .breadcrumb {
+      font-size: 14px;
+      margin-bottom: 24px;
+      color: #8885a0;
+    }
+    .breadcrumb .current {
+      color: #f0eff6;
+      font-weight: 500;
+    }
+
+    /* Header profil */
+    .profile-header {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      text-align: center;
+      gap: 12px;
+    }
+    .avatar-wrap {
+      position: relative;
+      width: 96px;
+      height: 96px;
+    }
+    .avatar-lg {
+      width: 96px;
+      height: 96px;
+      border-radius: 50%;
+      background: linear-gradient(135deg, #ec4899, #8b5cf6);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 24px;
+      font-weight: 700;
+      color: white;
+    }
+    .avatar-edit-btn {
+      position: absolute;
+      bottom: 2px;
+      right: 2px;
+      width: 24px;
+      height: 24px;
+      border-radius: 50%;
+      background: #252235;
+      border: 1px solid #3d3850;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+    }
+
+    .profile-name {
+      font-size: 24px;
+      font-weight: 700;
+      color: #f0eff6;
+    }
+    .profile-email {
+      font-size: 14px;
+      color: #8885a0;
+    }
+    .profile-stats {
+      font-size: 12px;
+      color: #8885a0;
+    }
+
+    /* Lien profil public — modifié */
+    .public-profile-link-wrap {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      margin-top: 4px;
+      position: relative;
+    }
+    .public-profile-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      color: #e8437d;
+      font-size: 14px;
+      text-decoration: underline dotted;
+      cursor: pointer;
+    }
+    /* Séparateur */
+    .divider {
+      border: none;
+      border-top: 1px solid #3d3850;
+      margin: 24px 0;
+    }
+    .divider-sm {
+      border: none;
+      border-top: 1px solid #3d3850;
+      margin: 20px 0;
+    }
+
+    /* Pill tabs */
+    .pill-tabs {
+      display: inline-flex;
+      border: 1px solid #3d3850;
+      border-radius: 9999px;
+      padding: 4px;
+      gap: 0;
+    }
+    .pill-tab {
+      padding: 4px 16px;
+      font-size: 14px;
+      border-radius: 9999px;
+      cursor: pointer;
+      border: none;
+      background: none;
+    }
+    .pill-tab.active {
+      background: #f0eff6;
+      color: #1c1929;
+      font-weight: 500;
+    }
+    .pill-tab.inactive {
+      color: #8885a0;
+    }
+
+    /* Card formulaire */
+    .form-card {
+      background: #252235;
+      border: 1px solid #3d3850;
+      border-radius: 12px;
+      padding: 20px;
+      margin-top: 20px;
+    }
+    .section-label {
+      font-size: 11px;
+      color: #8885a0;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      margin-bottom: 16px;
+    }
+
+    .form-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 12px;
+    }
+    .form-field label {
+      display: block;
+      font-size: 12px;
+      color: #8885a0;
+      margin-bottom: 4px;
+    }
+    .form-input {
+      width: 100%;
+      background: #1c1929;
+      border: 1px solid #3d3850;
+      border-radius: 6px;
+      padding: 8px 12px;
+      color: #f0eff6;
+      font-size: 14px;
+      outline: none;
+    }
+
+    .btn-save {
+      width: 100%;
+      margin-top: 16px;
+      background: #e8437d;
+      color: white;
+      border: none;
+      border-radius: 6px;
+      padding: 10px;
+      font-size: 14px;
+      font-weight: 500;
+      cursor: pointer;
+    }
+
+    /* Info rows */
+    .info-row {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      margin-bottom: 8px;
+    }
+    .info-icon-wrap {
+      width: 36px;
+      height: 36px;
+      background: rgba(232, 67, 125, 0.1);
+      border-radius: 8px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+    }
+    .info-content .info-label {
+      font-size: 12px;
+      color: #8885a0;
+    }
+    .info-content .info-value {
+      font-size: 14px;
+      color: #f0eff6;
+    }
+
+    /* Zone de danger */
+    .danger-desc {
+      font-size: 14px;
+      color: #8885a0;
+      margin-bottom: 12px;
+    }
+    .btn-danger {
+      background: transparent;
+      border: 1px solid rgba(239, 68, 68, 0.4);
+      color: #ef4444;
+      border-radius: 6px;
+      padding: 8px 16px;
+      font-size: 14px;
+      cursor: pointer;
+    }
+  </style>
+</head>
+<body>
+
+  <!-- Barre de titre mockup -->
+  <div class="mockup-bar">
+    Mockup — Dashboard Profil — F8 : lien « Voir mon profil public »
+  </div>
+
+  <!-- Header -->
+  <header class="header">
+    <div class="header-inner">
+
+      <!-- Logo -->
+      <a class="logo" href="#">
+        <div class="logo-icon">
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+            <polygon points="3,2 10,6 3,10" fill="white"/>
+          </svg>
+        </div>
+        <span class="logo-text">the <span>playground</span></span>
+      </a>
+
+      <!-- Nav -->
+      <nav class="nav">
+        <a class="nav-item muted" href="#">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="12" cy="12" r="10"/>
+            <polygon points="16.24,7.76 14.12,14.12 7.76,16.24 9.88,9.88"/>
+          </svg>
+          Découvrir
+        </a>
+        <a class="nav-item active" href="#">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/>
+            <rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/>
+          </svg>
+          Mon espace
+        </a>
+      </nav>
+
+      <!-- Actions droite -->
+      <div class="header-actions">
+        <button class="icon-btn" title="Thème">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="12" cy="12" r="5"/>
+            <line x1="12" y1="1" x2="12" y2="3"/>
+            <line x1="12" y1="21" x2="12" y2="23"/>
+            <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/>
+            <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/>
+            <line x1="1" y1="12" x2="3" y2="12"/>
+            <line x1="21" y1="12" x2="23" y2="12"/>
+            <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/>
+            <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+          </svg>
+        </button>
+        <div class="avatar-sm">JD</div>
+      </div>
+
+    </div>
+  </header>
+
+  <!-- Contenu principal -->
+  <main class="main">
+    <div class="main-inner">
+      <div class="profile-wrapper">
+
+        <!-- Breadcrumb -->
+        <div class="breadcrumb">
+          <span>Mon espace</span>
+          <span style="margin: 0 4px;">›</span>
+          <span class="current">Mon profil</span>
+        </div>
+
+        <!-- Header profil -->
+        <div class="profile-header">
+
+          <div class="avatar-wrap">
+            <div class="avatar-lg">JD</div>
+            <div class="avatar-edit-btn">
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#8885a0" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/>
+                <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/>
+              </svg>
+            </div>
+          </div>
+
+          <div class="profile-name">Jean Dupont</div>
+          <div class="profile-email">jean@example.com</div>
+          <div class="profile-stats">3 communautés · 12 événements</div>
+
+          <!-- Lien profil public -->
+          <div class="public-profile-link-wrap">
+            <a class="public-profile-link" href="#">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>
+                <polyline points="15 3 21 3 21 9"/>
+                <line x1="10" y1="14" x2="21" y2="3"/>
+              </svg>
+              Voir mon profil public
+            </a>
+          </div>
+
+        </div>
+
+        <!-- Séparateur -->
+        <hr class="divider" />
+
+        <!-- Pill tabs -->
+        <div class="pill-tabs">
+          <button class="pill-tab active">Mon profil</button>
+          <button class="pill-tab inactive">Notifications</button>
+        </div>
+
+        <!-- Formulaire -->
+        <div class="form-card">
+          <div class="section-label">Informations personnelles</div>
+
+          <div class="form-grid">
+            <div class="form-field">
+              <label>Prénom</label>
+              <input class="form-input" type="text" value="Jean" readonly />
+            </div>
+            <div class="form-field">
+              <label>Nom</label>
+              <input class="form-input" type="text" value="Dupont" readonly />
+            </div>
+          </div>
+
+          <button class="btn-save">Enregistrer</button>
+
+          <hr class="divider-sm" />
+
+          <div class="section-label">Informations du compte</div>
+
+          <div class="info-row">
+            <div class="info-icon-wrap">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#e8437d" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/>
+                <polyline points="22,6 12,13 2,6"/>
+              </svg>
+            </div>
+            <div class="info-content">
+              <div class="info-label">Email</div>
+              <div class="info-value">jean@example.com</div>
+            </div>
+          </div>
+
+          <div class="info-row">
+            <div class="info-icon-wrap">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#e8437d" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <rect x="3" y="4" width="18" height="18" rx="2" ry="2"/>
+                <line x1="16" y1="2" x2="16" y2="6"/>
+                <line x1="8" y1="2" x2="8" y2="6"/>
+                <line x1="3" y1="10" x2="21" y2="10"/>
+              </svg>
+            </div>
+            <div class="info-content">
+              <div class="info-label">Membre depuis</div>
+              <div class="info-value">Février 2026</div>
+            </div>
+          </div>
+
+          <hr class="divider-sm" />
+
+          <div class="section-label">Zone de danger</div>
+          <p class="danger-desc">La suppression de votre compte est irréversible. Toutes vos données seront effacées.</p>
+          <button class="btn-danger">Supprimer mon compte</button>
+
+        </div>
+
+      </div>
+    </div>
+  </main>
+
+</body>
+</html>

--- a/spec/mockups/virality-moment-page.mockup.html
+++ b/spec/mockups/virality-moment-page.mockup.html
@@ -1,0 +1,545 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Mockup — Page Événement publique — Viralité : participants</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --background: #1c1929;
+      --card: #252235;
+      --border: #3d3850;
+      --foreground: #f0eff6;
+      --muted-foreground: #8885a0;
+      --primary: #e8437d;
+      --primary-10: rgba(232, 67, 125, 0.1);
+      --radius: 0.5rem;
+    }
+
+    body {
+      background: var(--background);
+      color: var(--foreground);
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      min-height: 100vh;
+      padding: 0 0 48px 0;
+    }
+
+    /* ── Bandeau ── */
+    .banner {
+      background: linear-gradient(90deg, #2a1f3d 0%, #1c1929 100%);
+      border-bottom: 1px solid var(--border);
+      padding: 12px 24px;
+      text-align: center;
+      font-size: 12px;
+      font-weight: 600;
+      color: var(--muted-foreground);
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      position: sticky;
+      top: 0;
+      z-index: 50;
+    }
+    .banner span {
+      color: var(--primary);
+    }
+
+    /* ── Layout principal ── */
+    .page-wrapper {
+      max-width: 1280px;
+      margin: 0 auto;
+      padding: 32px 24px 0;
+    }
+
+    /* ── En-tête événement (décoratif, réduit) ── */
+    .event-header {
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 20px 24px;
+      margin-bottom: 32px;
+      display: flex;
+      align-items: center;
+      gap: 20px;
+    }
+    .event-cover {
+      width: 72px;
+      height: 72px;
+      border-radius: var(--radius);
+      background: linear-gradient(135deg, #e8437d 0%, #7c3aed 100%);
+      flex-shrink: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 28px;
+    }
+    .event-meta { flex: 1; }
+    .event-title {
+      font-size: 20px;
+      font-weight: 700;
+      color: var(--foreground);
+      margin-bottom: 6px;
+    }
+    .event-details {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      font-size: 13px;
+      color: var(--muted-foreground);
+    }
+    .event-details span {
+      display: flex;
+      align-items: center;
+      gap: 5px;
+    }
+    .event-community {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      background: var(--primary-10);
+      color: var(--primary);
+      border-radius: 999px;
+      padding: 3px 10px;
+      font-size: 12px;
+      font-weight: 500;
+      text-decoration: none;
+    }
+
+    /* ── Titre de la section de comparaison ── */
+    .comparison-title {
+      font-size: 13px;
+      font-weight: 600;
+      color: var(--muted-foreground);
+      text-align: center;
+      margin-bottom: 20px;
+      letter-spacing: 0.03em;
+      text-transform: uppercase;
+    }
+
+    /* ── Colonnes côte à côte ── */
+    .columns {
+      display: grid;
+      grid-template-columns: 1fr 1px 1fr;
+      gap: 0;
+      align-items: start;
+    }
+    .column-divider {
+      background: var(--border);
+      align-self: stretch;
+      margin: 0 32px;
+    }
+
+    /* ── Label de colonne ── */
+    .column-label {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      margin-bottom: 16px;
+    }
+    .column-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      border-radius: 999px;
+      padding: 5px 12px;
+      font-size: 12px;
+      font-weight: 600;
+      letter-spacing: 0.02em;
+    }
+    .column-badge.unauthenticated {
+      background: rgba(136, 133, 160, 0.15);
+      color: var(--muted-foreground);
+      border: 1px solid rgba(136, 133, 160, 0.3);
+    }
+    .column-badge.authenticated {
+      background: rgba(232, 67, 125, 0.12);
+      color: var(--primary);
+      border: 1px solid rgba(232, 67, 125, 0.35);
+    }
+    .badge-dot {
+      width: 7px;
+      height: 7px;
+      border-radius: 50%;
+    }
+    .badge-dot.grey { background: var(--muted-foreground); }
+    .badge-dot.pink { background: var(--primary); }
+
+    /* ── Card participants ── */
+    .participants-card {
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      overflow: hidden;
+      position: relative;
+    }
+    .participants-card-header {
+      padding: 16px 20px;
+      border-bottom: 1px solid var(--border);
+      display: flex;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+    .section-title {
+      font-size: 15px;
+      font-weight: 600;
+      color: var(--foreground);
+      margin-right: 4px;
+    }
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      border-radius: 999px;
+      padding: 2px 9px;
+      font-size: 11px;
+      font-weight: 600;
+      white-space: nowrap;
+    }
+    .badge-primary {
+      background: var(--primary-10);
+      color: var(--primary);
+      border: 1px solid rgba(232, 67, 125, 0.25);
+    }
+    .badge-secondary {
+      background: rgba(136, 133, 160, 0.15);
+      color: var(--muted-foreground);
+      border: 1px solid rgba(136, 133, 160, 0.2);
+    }
+    .badge-outline {
+      background: transparent;
+      color: var(--muted-foreground);
+      border: 1px solid var(--border);
+    }
+
+    /* ── Liste participants ── */
+    .participants-list {
+      padding: 8px 0;
+    }
+    .participant-row {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      padding: 9px 20px;
+      transition: background 0.15s;
+    }
+    .participant-row.hover-demo {
+      background: var(--primary-10);
+      border-radius: 0;
+    }
+
+    /* Avatar */
+    .avatar {
+      width: 32px;
+      height: 32px;
+      border-radius: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 11px;
+      font-weight: 700;
+      flex-shrink: 0;
+      letter-spacing: 0.02em;
+    }
+    .avatar-ab { background: linear-gradient(135deg, #e8437d, #c0255f); color: #fff; }
+    .avatar-tc { background: linear-gradient(135deg, #7c3aed, #5b21b6); color: #fff; }
+    .avatar-ml { background: linear-gradient(135deg, #0891b2, #0e7490); color: #fff; }
+    .avatar-jd { background: linear-gradient(135deg, #059669, #047857); color: #fff; }
+    .avatar-sc { background: linear-gradient(135deg, #d97706, #b45309); color: #fff; }
+
+    /* Crown icon */
+    .crown {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      color: var(--primary);
+      font-size: 13px;
+      flex-shrink: 0;
+      margin-right: -4px;
+    }
+
+    /* Noms — état non connecté */
+    .name-plain {
+      font-size: 14px;
+      color: var(--foreground);
+      font-weight: 500;
+      flex: 1;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    /* Noms — état connecté */
+    .name-link {
+      font-size: 14px;
+      color: var(--primary);
+      font-weight: 500;
+      text-decoration: underline;
+      text-decoration-style: dotted;
+      text-underline-offset: 3px;
+      cursor: pointer;
+      flex: 1;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    /* Badge organisateur */
+    .badge-organizer {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      background: var(--primary-10);
+      color: var(--primary);
+      border: 1px solid rgba(232, 67, 125, 0.25);
+      border-radius: 999px;
+      padding: 1px 7px;
+      font-size: 10px;
+      font-weight: 600;
+      white-space: nowrap;
+    }
+
+    /* Bouton voir plus */
+    .btn-see-more {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 6px;
+      margin: 4px 20px 12px;
+      padding: 8px 16px;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      background: transparent;
+      color: var(--muted-foreground);
+      font-size: 13px;
+      font-weight: 500;
+      cursor: pointer;
+    }
+
+    /* ── Légende hover ── */
+    .hover-note {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      margin-top: 8px;
+      padding: 6px 10px;
+      background: var(--primary-10);
+      border: 1px solid rgba(232, 67, 125, 0.2);
+      border-radius: var(--radius);
+      font-size: 11px;
+      color: var(--primary);
+      font-weight: 500;
+    }
+    .hover-indicator {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background: var(--primary);
+      flex-shrink: 0;
+    }
+
+    /* ── Footer ── */
+    .footer-note {
+      margin-top: 40px;
+      text-align: center;
+      font-size: 11px;
+      color: #4a4560;
+      letter-spacing: 0.03em;
+    }
+
+    /* ── SVG icons inline ── */
+    .icon {
+      display: inline-block;
+      vertical-align: middle;
+    }
+  </style>
+</head>
+<body>
+
+  <!-- Bandeau -->
+  <div class="banner">
+    Mockup — Page Événement publique —
+    <span>Viralité : section Participants (non-connecté vs connecté)</span>
+  </div>
+
+  <div class="page-wrapper">
+
+    <!-- En-tête événement décoratif -->
+    <div class="event-header">
+      <div class="event-cover">🍕</div>
+      <div class="event-meta">
+        <div class="event-title">Soirée JS &amp; Pizza</div>
+        <div class="event-details">
+          <span>
+            <!-- Calendar icon -->
+            <svg class="icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+            Samedi 15 mars · 19h00 → 22h00
+          </span>
+          <span>
+            <!-- Pin icon -->
+            <svg class="icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"/><circle cx="12" cy="10" r="3"/></svg>
+            Station F, Paris
+          </span>
+          <a href="#" class="event-community">
+            <!-- Users icon -->
+            <svg class="icon" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
+            Tech Paris
+          </a>
+        </div>
+      </div>
+    </div>
+
+    <!-- Titre comparaison -->
+    <div class="comparison-title">Section « Participants » — 2 états</div>
+
+    <!-- Colonnes côte à côte -->
+    <div class="columns">
+
+      <!-- ── COLONNE GAUCHE : non connecté ── -->
+      <div>
+        <div class="column-label">
+          <span class="column-badge unauthenticated">
+            <span class="badge-dot grey"></span>
+            Visiteur non connecté
+          </span>
+        </div>
+
+        <div class="participants-card">
+          <!-- Header -->
+          <div class="participants-card-header">
+            <span class="section-title">Participants</span>
+            <span class="badge badge-primary">32 inscrits</span>
+            <span class="badge badge-secondary">5 en attente</span>
+            <span class="badge badge-outline">Capacité : 50</span>
+          </div>
+
+          <!-- Liste -->
+          <div class="participants-list">
+
+            <div class="participant-row">
+              <div class="avatar avatar-ab">AB</div>
+              <div class="name-plain">Alice Bernard</div>
+            </div>
+
+            <div class="participant-row">
+              <div class="avatar avatar-tc">TC</div>
+              <div class="name-plain">Thomas Chen</div>
+            </div>
+
+            <div class="participant-row">
+              <div class="avatar avatar-ml">ML</div>
+              <div class="name-plain">Marie Leroy</div>
+            </div>
+
+            <div class="participant-row">
+              <div class="avatar avatar-jd">JD</div>
+              <div class="name-plain">Jean Dupont</div>
+            </div>
+
+            <div class="participant-row">
+              <div class="avatar avatar-sc">SC</div>
+              <div class="name-plain">Sophie Cazal</div>
+            </div>
+
+          </div>
+
+          <button class="btn-see-more">
+            <!-- ChevronDown icon -->
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+            Voir plus (27)
+          </button>
+        </div>
+
+      </div>
+
+      <!-- ── Séparateur vertical ── -->
+      <div class="column-divider"></div>
+
+      <!-- ── COLONNE DROITE : connecté ── -->
+      <div style="position: relative;">
+        <div class="column-label">
+          <span class="column-badge authenticated">
+            <span class="badge-dot pink"></span>
+            Utilisateur connecté
+          </span>
+        </div>
+
+        <div class="participants-card" style="position: relative;">
+
+          <!-- Header (identique) -->
+          <div class="participants-card-header">
+            <span class="section-title">Participants</span>
+            <span class="badge badge-primary">32 inscrits</span>
+            <span class="badge badge-secondary">5 en attente</span>
+            <span class="badge badge-outline">Capacité : 50</span>
+          </div>
+
+          <!-- Liste avec liens -->
+          <div class="participants-list">
+
+            <!-- Alice Bernard — Organisatrice -->
+            <div class="participant-row">
+              <!-- Crown icon -->
+              <span class="crown">
+                <svg width="13" height="13" viewBox="0 0 24 24" fill="currentColor"><path d="M2 20h20v2H2zM2 17l4-8 6 4 6-9 4 8H2z"/></svg>
+              </span>
+              <div class="avatar avatar-ab">AB</div>
+              <a href="#" class="name-link">
+                Alice Bernard
+                <span class="badge-organizer">
+                  <svg width="9" height="9" viewBox="0 0 24 24" fill="currentColor"><path d="M2 20h20v2H2zM2 17l4-8 6 4 6-9 4 8H2z"/></svg>
+                  Organisatrice
+                </span>
+              </a>
+            </div>
+
+            <!-- Thomas Chen — hover simulé -->
+            <div class="participant-row hover-demo">
+              <div class="avatar avatar-tc">TC</div>
+              <a href="#" class="name-link">Thomas Chen</a>
+            </div>
+
+            <!-- Marie Leroy -->
+            <div class="participant-row">
+              <div class="avatar avatar-ml">ML</div>
+              <a href="#" class="name-link">Marie Leroy</a>
+            </div>
+
+            <!-- Jean Dupont -->
+            <div class="participant-row">
+              <div class="avatar avatar-jd">JD</div>
+              <a href="#" class="name-link">Jean Dupont</a>
+            </div>
+
+            <!-- Sophie Cazal -->
+            <div class="participant-row">
+              <div class="avatar avatar-sc">SC</div>
+              <a href="#" class="name-link">Sophie Cazal</a>
+            </div>
+
+          </div>
+
+          <button class="btn-see-more">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+            Voir plus (27)
+          </button>
+        </div>
+
+        <!-- Légende hover -->
+        <div class="hover-note">
+          <div class="hover-indicator"></div>
+          Hover simulé sur Thomas Chen — fond <code style="font-size:10px; opacity:0.8;">primary/10</code> arrondi
+        </div>
+
+      </div>
+
+    </div><!-- /columns -->
+
+    <div class="footer-note">
+      The Playground · spec/mockups/virality-moment-page.mockup.html · 2026-03-10
+    </div>
+
+  </div><!-- /page-wrapper -->
+
+</body>
+</html>

--- a/spec/mockups/virality-user-profile.mockup.html
+++ b/spec/mockups/virality-user-profile.mockup.html
@@ -1,0 +1,676 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Mockup — Page profil utilisateur /u/[publicId]</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --background: #1c1929;
+      --card: #252235;
+      --border: #3d3850;
+      --foreground: #f0eff6;
+      --muted-foreground: #8885a0;
+      --primary: #e8437d;
+      --primary-10: rgba(232, 67, 125, 0.1);
+      --primary-5: rgba(232, 67, 125, 0.05);
+      --primary-40: rgba(232, 67, 125, 0.4);
+      --radius: 0.5rem;
+    }
+
+    body {
+      background: #0e0d16;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      color: var(--foreground);
+      padding: 2rem 1rem 4rem;
+    }
+
+    /* ─── Bandeau mockup ─── */
+    .mockup-banner {
+      max-width: 1280px;
+      margin: 0 auto 2rem;
+      background: rgba(232, 67, 125, 0.12);
+      border: 1px solid var(--primary-40);
+      border-radius: var(--radius);
+      padding: 0.75rem 1.25rem;
+      font-size: 0.8rem;
+      font-weight: 600;
+      color: var(--primary);
+      letter-spacing: 0.03em;
+      text-transform: uppercase;
+    }
+
+    /* ─── Séparateur variantes ─── */
+    .variant-divider {
+      max-width: 1280px;
+      margin: 3rem auto 2.5rem;
+      display: flex;
+      align-items: center;
+      gap: 1.5rem;
+    }
+    .variant-divider::before,
+    .variant-divider::after {
+      content: '';
+      flex: 1;
+      height: 1px;
+      background: var(--border);
+    }
+    .variant-label {
+      font-size: 0.75rem;
+      font-weight: 600;
+      color: var(--muted-foreground);
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      white-space: nowrap;
+      border: 1px solid var(--border);
+      border-radius: 2rem;
+      padding: 0.3rem 1rem;
+    }
+
+    /* ─── Wrapper variante (simule la fenêtre navigateur) ─── */
+    .browser-window {
+      max-width: 1280px;
+      margin: 0 auto;
+      border-radius: 0.75rem;
+      overflow: hidden;
+      border: 1px solid var(--border);
+      box-shadow: 0 24px 64px rgba(0,0,0,0.5);
+    }
+
+    .browser-chrome {
+      background: #1a1726;
+      border-bottom: 1px solid var(--border);
+      padding: 0.6rem 1rem;
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+    }
+    .browser-dots {
+      display: flex;
+      gap: 0.35rem;
+    }
+    .browser-dot {
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+    }
+    .dot-red   { background: #ff5f57; }
+    .dot-yellow { background: #ffbd2e; }
+    .dot-green  { background: #28c840; }
+    .browser-url {
+      flex: 1;
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: 0.375rem;
+      padding: 0.3rem 0.75rem;
+      font-size: 0.78rem;
+      color: var(--muted-foreground);
+      font-family: 'SF Mono', 'Fira Code', monospace;
+    }
+
+    /* ─── Page background ─── */
+    .page-bg {
+      background: var(--background);
+      padding: 2.5rem 2rem 3rem;
+    }
+
+    /* ─── Layout centré max-w-2xl ─── */
+    .profile-container {
+      max-width: 672px; /* 2xl = 42rem */
+      margin: 0 auto;
+      display: flex;
+      flex-direction: column;
+      gap: 0;
+    }
+
+    /* ─── Bandeau "C'est votre profil" ─── */
+    .own-profile-banner {
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 0.875rem 1.125rem;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 1.75rem;
+      gap: 1rem;
+    }
+    .own-profile-banner-text {
+      font-size: 0.85rem;
+      color: var(--muted-foreground);
+      line-height: 1.4;
+    }
+    .own-profile-banner-link {
+      font-size: 0.85rem;
+      color: var(--primary);
+      text-decoration: none;
+      white-space: nowrap;
+      font-weight: 500;
+      display: flex;
+      align-items: center;
+      gap: 0.25rem;
+      flex-shrink: 0;
+    }
+    .own-profile-banner-link:hover { text-decoration: underline; }
+
+    /* ─── Header profil ─── */
+    .profile-header {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 0.75rem;
+      padding-bottom: 1.75rem;
+      text-align: center;
+    }
+
+    .avatar-lg {
+      width: 72px;
+      height: 72px;
+      border-radius: 50%;
+      background: linear-gradient(135deg, #e8437d, #7c3aed);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 1.25rem;
+      font-weight: 700;
+      color: #fff;
+      flex-shrink: 0;
+      box-shadow: 0 4px 16px rgba(232, 67, 125, 0.3);
+    }
+
+    .profile-name {
+      font-size: 1.5rem;
+      font-weight: 700;
+      color: var(--foreground);
+      line-height: 1.2;
+    }
+
+    .profile-meta {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 0.375rem;
+    }
+
+    .profile-url {
+      display: flex;
+      align-items: center;
+      gap: 0.35rem;
+      font-size: 0.8rem;
+      color: var(--muted-foreground);
+    }
+    .profile-since {
+      display: flex;
+      align-items: center;
+      gap: 0.35rem;
+      font-size: 0.8rem;
+      color: var(--muted-foreground);
+    }
+
+    /* ─── Séparateur ─── */
+    .sep {
+      height: 1px;
+      background: var(--border);
+      margin: 0;
+    }
+
+    /* ─── Section header ─── */
+    .section-header {
+      display: flex;
+      align-items: center;
+      gap: 0.625rem;
+      padding: 1.5rem 0 1rem;
+    }
+    .section-title {
+      font-size: 0.9rem;
+      font-weight: 600;
+      color: var(--foreground);
+    }
+    .badge-count {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 1.375rem;
+      height: 1.375rem;
+      padding: 0 0.4rem;
+      border: 1px solid var(--border);
+      border-radius: 2rem;
+      font-size: 0.72rem;
+      font-weight: 600;
+      color: var(--muted-foreground);
+    }
+
+    /* ─── Communautés list ─── */
+    .community-list {
+      display: flex;
+      flex-direction: column;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      overflow: hidden;
+    }
+
+    .community-row {
+      display: flex;
+      align-items: center;
+      gap: 0.875rem;
+      padding: 0.875rem 1rem;
+      cursor: pointer;
+      background: var(--card);
+      text-decoration: none;
+      color: inherit;
+      transition: background 0.15s ease;
+      border-bottom: 1px solid var(--border);
+    }
+    .community-row:last-child { border-bottom: none; }
+    .community-row:hover { background: #2c293e; }
+
+    .cover-sq {
+      width: 40px;
+      height: 40px;
+      border-radius: 0.375rem;
+      flex-shrink: 0;
+    }
+    .cover-rose   { background: linear-gradient(135deg, #e8437d, #f97316); }
+    .cover-violet { background: linear-gradient(135deg, #7c3aed, #4f46e5); }
+    .cover-green  { background: linear-gradient(135deg, #10b981, #06b6d4); }
+
+    .community-info {
+      flex: 1;
+      display: flex;
+      align-items: center;
+      gap: 0.625rem;
+      min-width: 0;
+    }
+    .community-name {
+      font-size: 0.875rem;
+      font-weight: 500;
+      color: var(--foreground);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .badge-role {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.25rem;
+      padding: 0.125rem 0.5rem;
+      border-radius: 2rem;
+      font-size: 0.68rem;
+      font-weight: 600;
+      white-space: nowrap;
+      flex-shrink: 0;
+    }
+    .badge-host {
+      border: 1px solid var(--primary-40);
+      color: var(--primary);
+      background: var(--primary-10);
+    }
+    .badge-player {
+      border: 1px solid var(--border);
+      color: var(--muted-foreground);
+      background: transparent;
+    }
+
+    .chevron-icon {
+      color: var(--muted-foreground);
+      flex-shrink: 0;
+      opacity: 0.6;
+    }
+
+    /* ─── Événements list ─── */
+    .event-list {
+      display: flex;
+      flex-direction: column;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      overflow: hidden;
+      margin-bottom: 2.5rem;
+    }
+
+    .event-row {
+      display: flex;
+      align-items: center;
+      gap: 0.875rem;
+      padding: 0.875rem 1rem;
+      cursor: pointer;
+      background: var(--card);
+      text-decoration: none;
+      color: inherit;
+      transition: background 0.15s ease;
+      border-bottom: 1px solid var(--border);
+    }
+    .event-row:last-child { border-bottom: none; }
+    .event-row:hover { background: #2c293e; }
+
+    .event-date-block {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      min-width: 90px;
+      gap: 0.1rem;
+    }
+    .event-date {
+      font-size: 0.8rem;
+      color: var(--muted-foreground);
+      white-space: nowrap;
+    }
+
+    .event-info {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      gap: 0.2rem;
+      min-width: 0;
+    }
+    .event-title {
+      font-size: 0.875rem;
+      font-weight: 500;
+      color: var(--foreground);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .event-community {
+      font-size: 0.72rem;
+      color: var(--primary);
+      font-weight: 500;
+    }
+
+    .calendar-icon-wrap {
+      width: 32px;
+      height: 32px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: var(--primary-10);
+      border-radius: 0.375rem;
+      flex-shrink: 0;
+    }
+
+    /* ─── Footer ─── */
+    .page-footer {
+      text-align: center;
+      padding-top: 2rem;
+      font-size: 0.72rem;
+      color: #4a4760;
+      letter-spacing: 0.02em;
+    }
+
+    /* ─── Icônes SVG inline ─── */
+    svg { display: inline-block; vertical-align: middle; }
+  </style>
+</head>
+<body>
+
+  <!-- ─── Bandeau mockup global ─── -->
+  <div class="mockup-banner">
+    Mockup — Nouvelle page /u/[publicId] — Page profil utilisateur public
+  </div>
+
+  <!-- ══════════════════════════════════════════════════════
+       VARIANTE A — Jean Dupont consulte son propre profil
+  ══════════════════════════════════════════════════════ -->
+
+  <div class="browser-window">
+    <div class="browser-chrome">
+      <div class="browser-dots">
+        <div class="browser-dot dot-red"></div>
+        <div class="browser-dot dot-yellow"></div>
+        <div class="browser-dot dot-green"></div>
+      </div>
+      <div class="browser-url">the-playground.fr/u/jean-dupont-4821</div>
+    </div>
+
+    <div class="page-bg">
+      <div class="profile-container">
+
+        <!-- Bandeau "C'est votre profil" -->
+        <div class="own-profile-banner">
+          <span class="own-profile-banner-text">
+            Voici votre profil tel qu'il est visible par les autres membres.
+          </span>
+          <a href="#" class="own-profile-banner-link">
+            Modifier mon profil
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+          </a>
+        </div>
+
+        <!-- Header profil -->
+        <div class="profile-header">
+          <div class="avatar-lg">JD</div>
+          <div class="profile-name">Jean Dupont</div>
+          <div class="profile-meta">
+            <div class="profile-url">
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="color:var(--muted-foreground)"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
+              /u/jean-dupont-4821
+            </div>
+            <div class="profile-since">
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="color:var(--muted-foreground)"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+              Membre depuis janvier 2025
+            </div>
+          </div>
+        </div>
+
+        <div class="sep"></div>
+
+        <!-- Section Communautés -->
+        <div class="section-header">
+          <span class="section-title">Communautés</span>
+          <span class="badge-count">3</span>
+        </div>
+
+        <div class="community-list">
+
+          <a href="#" class="community-row">
+            <div class="cover-sq cover-rose"></div>
+            <div class="community-info">
+              <span class="community-name">Tech Paris</span>
+              <span class="badge-role badge-host">
+                <svg width="10" height="10" viewBox="0 0 24 24" fill="currentColor"><path d="M2 21l4-8 6 4 6-8 4 11H2z"/></svg>
+                Organisateur
+              </span>
+            </div>
+            <svg class="chevron-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
+          </a>
+
+          <a href="#" class="community-row">
+            <div class="cover-sq cover-violet"></div>
+            <div class="community-info">
+              <span class="community-name">Yoga Montmartre</span>
+              <span class="badge-role badge-player">Participant</span>
+            </div>
+            <svg class="chevron-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
+          </a>
+
+          <a href="#" class="community-row">
+            <div class="cover-sq cover-green"></div>
+            <div class="community-info">
+              <span class="community-name">Design Thinking FR</span>
+              <span class="badge-role badge-player">Participant</span>
+            </div>
+            <svg class="chevron-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
+          </a>
+
+        </div>
+
+        <div class="sep" style="margin-top:0.25rem;"></div>
+
+        <!-- Section Prochains événements -->
+        <div class="section-header">
+          <span class="section-title">Prochains événements</span>
+          <span class="badge-count">2</span>
+        </div>
+
+        <div class="event-list">
+
+          <a href="#" class="event-row">
+            <div class="calendar-icon-wrap">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="color:var(--primary)"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+            </div>
+            <div class="event-date-block">
+              <span class="event-date">Mar 15 · 19h00</span>
+            </div>
+            <div class="event-info">
+              <span class="event-title">Soirée JS &amp; Pizza</span>
+              <span class="event-community">Tech Paris</span>
+            </div>
+            <svg class="chevron-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
+          </a>
+
+          <a href="#" class="event-row">
+            <div class="calendar-icon-wrap">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="color:var(--primary)"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+            </div>
+            <div class="event-date-block">
+              <span class="event-date">Mar 22 · 14h00</span>
+            </div>
+            <div class="event-info">
+              <span class="event-title">Workshop React 19</span>
+              <span class="event-community">Tech Paris</span>
+            </div>
+            <svg class="chevron-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
+          </a>
+
+        </div>
+
+        <!-- Footer discret -->
+        <div class="page-footer">Powered by The Playground</div>
+
+      </div>
+    </div>
+  </div><!-- end browser-window variante A -->
+
+  <!-- ─── Séparateur entre variantes ─── -->
+  <div class="variant-divider">
+    <span class="variant-label">Variante A ci-dessus — Jean Dupont consulte son propre profil &nbsp;·&nbsp; Variante B ci-dessous — Alice Leroy consulte le profil de Jean Dupont</span>
+  </div>
+
+  <!-- ══════════════════════════════════════════════════════
+       VARIANTE B — Alice Leroy consulte le profil de Jean Dupont
+  ══════════════════════════════════════════════════════ -->
+
+  <div class="browser-window">
+    <div class="browser-chrome">
+      <div class="browser-dots">
+        <div class="browser-dot dot-red"></div>
+        <div class="browser-dot dot-yellow"></div>
+        <div class="browser-dot dot-green"></div>
+      </div>
+      <div class="browser-url">the-playground.fr/u/jean-dupont-4821</div>
+    </div>
+
+    <div class="page-bg">
+      <div class="profile-container">
+
+        <!-- PAS de bandeau "C'est votre profil" dans la variante B -->
+
+        <!-- Header profil -->
+        <div class="profile-header">
+          <div class="avatar-lg">JD</div>
+          <div class="profile-name">Jean Dupont</div>
+          <div class="profile-meta">
+            <div class="profile-url">
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="color:var(--muted-foreground)"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
+              /u/jean-dupont-4821
+            </div>
+            <div class="profile-since">
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="color:var(--muted-foreground)"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+              Membre depuis janvier 2025
+            </div>
+          </div>
+        </div>
+
+        <div class="sep"></div>
+
+        <!-- Section Communautés -->
+        <div class="section-header">
+          <span class="section-title">Communautés</span>
+          <span class="badge-count">3</span>
+        </div>
+
+        <div class="community-list">
+
+          <a href="#" class="community-row">
+            <div class="cover-sq cover-rose"></div>
+            <div class="community-info">
+              <span class="community-name">Tech Paris</span>
+              <span class="badge-role badge-host">
+                <svg width="10" height="10" viewBox="0 0 24 24" fill="currentColor"><path d="M2 21l4-8 6 4 6-8 4 11H2z"/></svg>
+                Organisateur
+              </span>
+            </div>
+            <svg class="chevron-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
+          </a>
+
+          <a href="#" class="community-row">
+            <div class="cover-sq cover-violet"></div>
+            <div class="community-info">
+              <span class="community-name">Yoga Montmartre</span>
+              <span class="badge-role badge-player">Participant</span>
+            </div>
+            <svg class="chevron-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
+          </a>
+
+          <a href="#" class="community-row">
+            <div class="cover-sq cover-green"></div>
+            <div class="community-info">
+              <span class="community-name">Design Thinking FR</span>
+              <span class="badge-role badge-player">Participant</span>
+            </div>
+            <svg class="chevron-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
+          </a>
+
+        </div>
+
+        <div class="sep" style="margin-top:0.25rem;"></div>
+
+        <!-- Section Prochains événements -->
+        <div class="section-header">
+          <span class="section-title">Prochains événements</span>
+          <span class="badge-count">2</span>
+        </div>
+
+        <div class="event-list">
+
+          <a href="#" class="event-row">
+            <div class="calendar-icon-wrap">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="color:var(--primary)"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+            </div>
+            <div class="event-date-block">
+              <span class="event-date">Mar 15 · 19h00</span>
+            </div>
+            <div class="event-info">
+              <span class="event-title">Soirée JS &amp; Pizza</span>
+              <span class="event-community">Tech Paris</span>
+            </div>
+            <svg class="chevron-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
+          </a>
+
+          <a href="#" class="event-row">
+            <div class="calendar-icon-wrap">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="color:var(--primary)"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+            </div>
+            <div class="event-date-block">
+              <span class="event-date">Mar 22 · 14h00</span>
+            </div>
+            <div class="event-info">
+              <span class="event-title">Workshop React 19</span>
+              <span class="event-community">Tech Paris</span>
+            </div>
+            <svg class="chevron-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
+          </a>
+
+        </div>
+
+        <!-- Footer discret -->
+        <div class="page-footer">Powered by The Playground</div>
+
+      </div>
+    </div>
+  </div><!-- end browser-window variante B -->
+
+</body>
+</html>

--- a/src/app/[locale]/(routes)/dashboard/(app)/(main)/profile/page.tsx
+++ b/src/app/[locale]/(routes)/dashboard/(app)/(main)/profile/page.tsx
@@ -77,6 +77,14 @@ export default async function ProfilePage({
         <p className="text-muted-foreground text-xs">
           {circles.length} {t("edit.circles")} · {momentCount} {t("edit.moments")}
         </p>
+        {user.publicId && (
+          <Link
+            href={`/u/${user.publicId}`}
+            className="text-xs text-primary underline-offset-4 hover:underline"
+          >
+            ↗ {t("publicProfile.viewMyProfile")}
+          </Link>
+        )}
       </div>
 
       {/* Separator */}

--- a/src/app/[locale]/(routes)/u/[publicId]/layout.tsx
+++ b/src/app/[locale]/(routes)/u/[publicId]/layout.tsx
@@ -1,0 +1,18 @@
+import { SiteHeader } from "@/components/site-header";
+import { SiteFooter } from "@/components/site-footer";
+
+export default function UserProfileLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex min-h-screen flex-col">
+      <SiteHeader />
+      <main className="mx-auto w-full max-w-5xl flex-1 px-4 py-8">
+        {children}
+      </main>
+      <SiteFooter />
+    </div>
+  );
+}

--- a/src/app/[locale]/(routes)/u/[publicId]/loading.tsx
+++ b/src/app/[locale]/(routes)/u/[publicId]/loading.tsx
@@ -1,0 +1,30 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function UserProfileLoading() {
+  return (
+    <div className="mx-auto max-w-lg space-y-8">
+      {/* Header */}
+      <div className="flex flex-col items-center gap-3">
+        <Skeleton className="size-20 rounded-full" />
+        <Skeleton className="h-7 w-40" />
+        <Skeleton className="h-4 w-28" />
+      </div>
+
+      {/* Communautés */}
+      <div className="space-y-4">
+        <Skeleton className="h-4 w-32" />
+        {[1, 2, 3].map((i) => (
+          <Skeleton key={i} className="h-16 w-full rounded-lg" />
+        ))}
+      </div>
+
+      {/* Événements */}
+      <div className="space-y-4">
+        <Skeleton className="h-4 w-44" />
+        {[1, 2].map((i) => (
+          <Skeleton key={i} className="h-14 w-full rounded-lg" />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/[locale]/(routes)/u/[publicId]/page.tsx
+++ b/src/app/[locale]/(routes)/u/[publicId]/page.tsx
@@ -10,8 +10,7 @@ import { getUserPublicProfile } from "@/domain/usecases/get-user-public-profile"
 import { Link } from "@/i18n/navigation";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import { Crown } from "lucide-react";
+import { ChevronRight, Crown } from "lucide-react";
 import { formatLongDate } from "@/lib/format-date";
 
 export default async function UserPublicProfilePage({
@@ -27,6 +26,7 @@ export default async function UserPublicProfilePage({
   }
 
   const t = await getTranslations("Profile.publicProfile");
+  const tDashboard = await getTranslations("Dashboard");
 
   const result = await getUserPublicProfile(
     { publicId },
@@ -57,13 +57,14 @@ export default async function UserPublicProfilePage({
 
   return (
     <div className="mx-auto max-w-lg space-y-8">
-      {/* Bandeau profil propre */}
+      {/* Fil d'ariane — uniquement pour son propre profil */}
       {isOwnProfile && (
-        <div className="rounded-lg border bg-primary/5 px-4 py-3 flex items-center justify-between gap-3">
-          <p className="text-sm text-muted-foreground">{t("itsYourProfile")}</p>
-          <Button variant="outline" size="sm" asChild>
-            <Link href="/dashboard/profile">{t("editMyProfile")}</Link>
-          </Button>
+        <div className="text-muted-foreground flex items-center gap-1 text-sm">
+          <Link href="/dashboard/profile" className="hover:text-foreground transition-colors">
+            {tDashboard("title")}
+          </Link>
+          <ChevronRight className="size-3.5" />
+          <span className="text-foreground font-medium">{t("itsYourProfile")}</span>
         </div>
       )}
 

--- a/src/app/[locale]/(routes)/u/[publicId]/page.tsx
+++ b/src/app/[locale]/(routes)/u/[publicId]/page.tsx
@@ -11,7 +11,7 @@ import { Link } from "@/i18n/navigation";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { ChevronRight, Crown } from "lucide-react";
-import { formatLongDate } from "@/lib/format-date";
+import { formatLongDate, formatMonthYear } from "@/lib/format-date";
 
 export default async function UserPublicProfilePage({
   params,
@@ -39,9 +39,8 @@ export default async function UserPublicProfilePage({
 
   if (!result) notFound();
 
-  const { user, publicCircles, upcomingPublicMoments } = result;
+  const { user, internalUserId, publicCircles, upcomingPublicMoments } = result;
 
-  const internalUserId = await prismaUserRepository.findUserIdByPublicId(publicId);
   const isOwnProfile = internalUserId === session.user.id;
 
   const fullName = [user.firstName, user.lastName].filter(Boolean).join(" ");
@@ -50,10 +49,7 @@ export default async function UserPublicProfilePage({
     .join("")
     .toUpperCase();
 
-  const memberSince = new Intl.DateTimeFormat(locale === "fr" ? "fr-FR" : "en-GB", {
-    month: "long",
-    year: "numeric",
-  }).format(user.memberSince);
+  const memberSince = formatMonthYear(user.memberSince, locale);
 
   return (
     <div className="mx-auto max-w-lg space-y-8">

--- a/src/app/[locale]/(routes)/u/[publicId]/page.tsx
+++ b/src/app/[locale]/(routes)/u/[publicId]/page.tsx
@@ -1,0 +1,165 @@
+import { notFound, redirect } from "next/navigation";
+import { getTranslations } from "next-intl/server";
+import { auth } from "@/infrastructure/auth/auth.config";
+import {
+  prismaUserRepository,
+  prismaCircleRepository,
+  prismaMomentRepository,
+} from "@/infrastructure/repositories";
+import { getUserPublicProfile } from "@/domain/usecases/get-user-public-profile";
+import { Link } from "@/i18n/navigation";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Crown } from "lucide-react";
+import { formatLongDate } from "@/lib/format-date";
+
+export default async function UserPublicProfilePage({
+  params,
+}: {
+  params: Promise<{ publicId: string; locale: string }>;
+}) {
+  const { publicId, locale } = await params;
+
+  const session = await auth();
+  if (!session?.user) {
+    redirect(`/${locale}/auth/sign-in`);
+  }
+
+  const t = await getTranslations("Profile.publicProfile");
+
+  const result = await getUserPublicProfile(
+    { publicId },
+    {
+      userRepository: prismaUserRepository,
+      circleRepository: prismaCircleRepository,
+      momentRepository: prismaMomentRepository,
+    }
+  );
+
+  if (!result) notFound();
+
+  const { user, publicCircles, upcomingPublicMoments } = result;
+
+  const internalUserId = await prismaUserRepository.findUserIdByPublicId(publicId);
+  const isOwnProfile = internalUserId === session.user.id;
+
+  const fullName = [user.firstName, user.lastName].filter(Boolean).join(" ");
+  const initials = [user.firstName?.[0], user.lastName?.[0]]
+    .filter(Boolean)
+    .join("")
+    .toUpperCase();
+
+  const memberSince = new Intl.DateTimeFormat(locale === "fr" ? "fr-FR" : "en-GB", {
+    month: "long",
+    year: "numeric",
+  }).format(user.memberSince);
+
+  return (
+    <div className="mx-auto max-w-lg space-y-8">
+      {/* Bandeau profil propre */}
+      {isOwnProfile && (
+        <div className="rounded-lg border bg-primary/5 px-4 py-3 flex items-center justify-between gap-3">
+          <p className="text-sm text-muted-foreground">{t("itsYourProfile")}</p>
+          <Button variant="outline" size="sm" asChild>
+            <Link href="/dashboard/profile">{t("editMyProfile")}</Link>
+          </Button>
+        </div>
+      )}
+
+      {/* Header utilisateur */}
+      <div className="flex flex-col items-center gap-3 text-center">
+        <Avatar className="size-20">
+          {user.image && <AvatarImage src={user.image} alt={fullName} />}
+          <AvatarFallback className="text-2xl font-semibold bg-gradient-to-br from-pink-500 to-violet-500 text-white">
+            {initials || "?"}
+          </AvatarFallback>
+        </Avatar>
+
+        <div className="space-y-0.5">
+          <h1 className="text-2xl font-bold tracking-tight">{fullName}</h1>
+          <p className="text-xs text-muted-foreground font-mono">/u/{publicId}</p>
+        </div>
+
+        <div className="flex flex-col items-center gap-1 text-sm text-muted-foreground">
+          <span>{t("memberSince", { date: memberSince })}</span>
+          {user.hostedMomentsCount > 0 && (
+            <span>{t("hostedEvents", { count: user.hostedMomentsCount })}</span>
+          )}
+        </div>
+      </div>
+
+      {/* Section Communautés */}
+      {publicCircles.length > 0 && (
+        <section className="space-y-3">
+          <h2 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+            {t("communities", { count: publicCircles.length })}
+          </h2>
+          <div className="space-y-2">
+            {publicCircles.map((membership) => (
+              <Link
+                key={membership.circleSlug}
+                href={`/circles/${membership.circleSlug}`}
+                className="flex items-center gap-3 rounded-lg border p-3 hover:bg-muted/50 transition-colors"
+              >
+                {membership.circleCover ? (
+                  <div
+                    className="size-10 shrink-0 rounded-md bg-cover bg-center"
+                    style={{ backgroundImage: `url(${membership.circleCover})` }}
+                  />
+                ) : (
+                  <div className="size-10 shrink-0 rounded-md bg-gradient-to-br from-pink-500 to-violet-500" />
+                )}
+
+                <p className="flex-1 min-w-0 text-sm font-medium truncate">
+                  {membership.circleName}
+                </p>
+
+                <Badge
+                  variant={membership.role === "HOST" ? "default" : "secondary"}
+                  className="shrink-0 gap-1"
+                >
+                  {membership.role === "HOST" && <Crown className="size-3" />}
+                  {membership.role === "HOST" ? t("roleHost") : t("rolePlayer")}
+                </Badge>
+              </Link>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* Section Prochains événements */}
+      {upcomingPublicMoments.length > 0 && (
+        <section className="space-y-3">
+          <h2 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+            {t("upcomingEvents", { count: upcomingPublicMoments.length })}
+          </h2>
+          <div className="space-y-2">
+            {upcomingPublicMoments.map((reg) => (
+              <Link
+                key={reg.momentSlug}
+                href={`/m/${reg.momentSlug}`}
+                className="flex items-center justify-between gap-3 rounded-lg border p-3 hover:bg-muted/50 transition-colors"
+              >
+                <div className="min-w-0">
+                  <p className="text-sm font-medium truncate">{reg.momentTitle}</p>
+                  <p className="text-xs text-muted-foreground truncate">{reg.circleName}</p>
+                </div>
+                <p className="text-xs text-muted-foreground shrink-0">
+                  {formatLongDate(reg.momentDate, locale)}
+                </p>
+              </Link>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* État vide */}
+      {publicCircles.length === 0 && upcomingPublicMoments.length === 0 && (
+        <p className="text-center text-sm text-muted-foreground py-8">
+          {t("noCommunities")}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/app/[locale]/(routes)/u/[publicId]/page.tsx
+++ b/src/app/[locale]/(routes)/u/[publicId]/page.tsx
@@ -73,10 +73,7 @@ export default async function UserPublicProfilePage({
           </AvatarFallback>
         </Avatar>
 
-        <div className="space-y-0.5">
-          <h1 className="text-2xl font-bold tracking-tight">{fullName}</h1>
-          <p className="text-xs text-muted-foreground font-mono">/u/{publicId}</p>
-        </div>
+        <h1 className="text-2xl font-bold tracking-tight">{fullName}</h1>
 
         <div className="flex flex-col items-center gap-1 text-sm text-muted-foreground">
           <span>{t("memberSince", { date: memberSince })}</span>

--- a/src/domain/models/user.ts
+++ b/src/domain/models/user.ts
@@ -1,5 +1,28 @@
 export type UserRole = "USER" | "ADMIN";
 
+export type PublicUser = {
+  publicId: string;
+  firstName: string;
+  lastName: string;
+  image: string | null;
+  memberSince: Date;
+  hostedMomentsCount: number;
+};
+
+export type PublicCircleMembership = {
+  circleSlug: string;
+  circleName: string;
+  circleCover: string | null;
+  role: "HOST" | "PLAYER";
+};
+
+export type PublicMomentRegistration = {
+  momentSlug: string;
+  momentTitle: string;
+  momentDate: Date;
+  circleName: string;
+};
+
 export type DashboardMode = "PARTICIPANT" | "ORGANIZER";
 
 export type NotificationPreferences = {
@@ -24,6 +47,7 @@ export type User = {
   notifyNewFollower: boolean;
   notifyNewMomentInCircle: boolean;
   dashboardMode: DashboardMode | null;
+  publicId: string | null;
   createdAt: Date;
   updatedAt: Date;
 };

--- a/src/domain/ports/repositories/circle-repository.ts
+++ b/src/domain/ports/repositories/circle-repository.ts
@@ -1,4 +1,5 @@
 import type { Circle, CircleMembership, CircleMemberRole, CircleMemberWithUser, CircleWithRole, CircleCategory, CoverImageAttribution, CircleFollow, DashboardCircle } from "@/domain/models/circle";
+import type { PublicCircleMembership } from "@/domain/models/user";
 
 export type CreateCircleInput = {
   name: string;
@@ -86,4 +87,6 @@ export interface CircleRepository {
   findFollowers(circleId: string): Promise<CircleFollowerInfo[]>;
   /** Membres du Circle (PLAYER ou HOST) à notifier pour un nouvel événement, en excluant le créateur */
   findPlayersForNewMomentNotification(circleId: string, excludeUserId: string): Promise<CircleFollowerInfo[]>;
+  /** Communautés publiques dont l'utilisateur est membre — pour la page profil public. */
+  getPublicCirclesForUser(userId: string): Promise<PublicCircleMembership[]>;
 }

--- a/src/domain/ports/repositories/moment-repository.ts
+++ b/src/domain/ports/repositories/moment-repository.ts
@@ -1,5 +1,6 @@
 import type { Moment, LocationType, MomentStatus, CoverImageAttribution, HostMomentSummary } from "@/domain/models/moment";
 import type { CircleCategory } from "@/domain/models/circle";
+import type { PublicMomentRegistration } from "@/domain/models/user";
 
 export type CreateMomentInput = {
   slug: string;
@@ -98,4 +99,6 @@ export interface MomentRepository {
   findAllByHostUserId(hostUserId: string): Promise<{ upcoming: HostMomentSummary[]; past: HostMomentSummary[] }>;
   /** Marque un Moment comme ayant été diffusé (broadcast email envoyé). */
   markBroadcastSent(momentId: string): Promise<void>;
+  /** Événements à venir dans des Circles publics auxquels l'utilisateur est inscrit (REGISTERED) — pour la page profil public. */
+  getUpcomingPublicMomentsForUser(userId: string): Promise<PublicMomentRegistration[]>;
 }

--- a/src/domain/ports/repositories/user-repository.ts
+++ b/src/domain/ports/repositories/user-repository.ts
@@ -25,10 +25,12 @@ export interface UserRepository {
   ): Promise<NotificationPreferences>;
   updateDashboardMode(userId: string, mode: DashboardMode): Promise<void>;
   findAdminEmails(): Promise<string[]>;
-  /** Lookup par publicId — retourne les données publiques de l'utilisateur (jamais l'email). */
-  getPublicUserByPublicId(publicId: string): Promise<PublicUser | null>;
-  /** Retourne l'id interne de l'utilisateur à partir de son publicId (pour les jointures internes). */
-  findUserIdByPublicId(publicId: string): Promise<string | null>;
+  /**
+   * Lookup par publicId — retourne les données publiques + l'id interne en une seule requête.
+   * L'id interne est nécessaire pour les jointures downstream (circles, moments) mais ne doit
+   * pas être exposé en dehors de la couche app.
+   */
+  resolvePublicProfile(publicId: string): Promise<{ user: PublicUser; internalUserId: string } | null>;
   /** Génère et persiste un publicId pour l'utilisateur (si absent). */
   ensurePublicId(userId: string, firstName: string | null, lastName: string | null): Promise<string>;
 }

--- a/src/domain/ports/repositories/user-repository.ts
+++ b/src/domain/ports/repositories/user-repository.ts
@@ -1,4 +1,4 @@
-import type { User, NotificationPreferences, DashboardMode } from "@/domain/models/user";
+import type { User, NotificationPreferences, DashboardMode, PublicUser } from "@/domain/models/user";
 
 export type UpdateProfileInput = {
   firstName: string;
@@ -25,4 +25,10 @@ export interface UserRepository {
   ): Promise<NotificationPreferences>;
   updateDashboardMode(userId: string, mode: DashboardMode): Promise<void>;
   findAdminEmails(): Promise<string[]>;
+  /** Lookup par publicId — retourne les données publiques de l'utilisateur (jamais l'email). */
+  getPublicUserByPublicId(publicId: string): Promise<PublicUser | null>;
+  /** Retourne l'id interne de l'utilisateur à partir de son publicId (pour les jointures internes). */
+  findUserIdByPublicId(publicId: string): Promise<string | null>;
+  /** Génère et persiste un publicId pour l'utilisateur (si absent). */
+  ensurePublicId(userId: string, firstName: string | null, lastName: string | null): Promise<string>;
 }

--- a/src/domain/usecases/__tests__/get-user-public-profile.test.ts
+++ b/src/domain/usecases/__tests__/get-user-public-profile.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi } from "vitest";
+import { getUserPublicProfile } from "@/domain/usecases/get-user-public-profile";
+import {
+  createMockUserRepository,
+  makePublicUser,
+} from "./helpers/mock-user-repository";
+import { createMockCircleRepository } from "./helpers/mock-circle-repository";
+import { createMockMomentRepository } from "./helpers/mock-moment-repository";
+import type { PublicCircleMembership, PublicMomentRegistration } from "@/domain/models/user";
+
+const PUBLIC_ID = "jean-dupont-4821";
+const INTERNAL_USER_ID = "user-123";
+
+function makeDeps(
+  overrides: {
+    publicUser?: ReturnType<typeof makePublicUser> | null;
+    internalUserId?: string | null;
+    circles?: PublicCircleMembership[];
+    moments?: PublicMomentRegistration[];
+  } = {}
+) {
+  const publicUser = overrides.publicUser !== undefined ? overrides.publicUser : makePublicUser();
+  const internalUserId = overrides.internalUserId !== undefined ? overrides.internalUserId : INTERNAL_USER_ID;
+
+  return {
+    userRepository: createMockUserRepository({
+      getPublicUserByPublicId: vi.fn().mockResolvedValue(publicUser),
+      findUserIdByPublicId: vi.fn().mockResolvedValue(internalUserId),
+    }),
+    circleRepository: createMockCircleRepository({
+      getPublicCirclesForUser: vi.fn().mockResolvedValue(overrides.circles ?? []),
+    }),
+    momentRepository: createMockMomentRepository({
+      getUpcomingPublicMomentsForUser: vi.fn().mockResolvedValue(overrides.moments ?? []),
+    }),
+  };
+}
+
+describe("GetUserPublicProfile", () => {
+  describe("given a valid publicId for an existing user", () => {
+    it("should return the user profile with public circles and upcoming moments", async () => {
+      const circles: PublicCircleMembership[] = [
+        { circleSlug: "tech-paris", circleName: "Tech Paris", circleCover: null, role: "HOST" },
+      ];
+      const moments: PublicMomentRegistration[] = [
+        {
+          momentSlug: "soiree-js",
+          momentTitle: "Soirée JS & Pizza",
+          momentDate: new Date("2026-04-01"),
+          circleName: "Tech Paris",
+        },
+      ];
+
+      const deps = makeDeps({ circles, moments });
+      const result = await getUserPublicProfile({ publicId: PUBLIC_ID }, deps);
+
+      expect(result).not.toBeNull();
+      expect(result!.user.publicId).toBe("jean-dupont-4821");
+      expect(result!.publicCircles).toHaveLength(1);
+      expect(result!.publicCircles[0].role).toBe("HOST");
+      expect(result!.upcomingPublicMoments).toHaveLength(1);
+      expect(result!.upcomingPublicMoments[0].momentTitle).toBe("Soirée JS & Pizza");
+    });
+
+    it("should return empty arrays when user has no public circles", async () => {
+      const deps = makeDeps({ circles: [], moments: [] });
+      const result = await getUserPublicProfile({ publicId: PUBLIC_ID }, deps);
+
+      expect(result!.publicCircles).toHaveLength(0);
+      expect(result!.upcomingPublicMoments).toHaveLength(0);
+    });
+
+    it("should return correct hostedMomentsCount from the PublicUser", async () => {
+      const userWithHostedMoments = makePublicUser({ hostedMomentsCount: 15 });
+      const deps = makeDeps({ publicUser: userWithHostedMoments });
+      const result = await getUserPublicProfile({ publicId: PUBLIC_ID }, deps);
+
+      expect(result!.user.hostedMomentsCount).toBe(15);
+    });
+
+    it("should return hostedMomentsCount of 0 when user has never hosted", async () => {
+      const userNeverHosted = makePublicUser({ hostedMomentsCount: 0 });
+      const deps = makeDeps({ publicUser: userNeverHosted });
+      const result = await getUserPublicProfile({ publicId: PUBLIC_ID }, deps);
+
+      expect(result!.user.hostedMomentsCount).toBe(0);
+    });
+
+    it("should never expose the user email in the returned profile", async () => {
+      const deps = makeDeps();
+      const result = await getUserPublicProfile({ publicId: PUBLIC_ID }, deps);
+
+      expect(result).not.toBeNull();
+      expect(result!.user).not.toHaveProperty("email");
+    });
+  });
+
+  describe("given a publicId that does not exist", () => {
+    it("should return null", async () => {
+      const deps = makeDeps({ publicUser: null, internalUserId: null });
+      const result = await getUserPublicProfile({ publicId: "unknown-id-9999" }, deps);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("given a valid publicId but userId resolution fails", () => {
+    it("should return null when findUserIdByPublicId returns null", async () => {
+      const deps = makeDeps({ internalUserId: null });
+      const result = await getUserPublicProfile({ publicId: PUBLIC_ID }, deps);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("given user with private circles only", () => {
+    it("should return empty circles array (filtering is done in the repository)", async () => {
+      // Le filtrage public/privé est la responsabilité du repository (getPublicCirclesForUser).
+      // Le usecase reçoit déjà la liste filtrée — on vérifie que le usecase retourne ce qu'il reçoit.
+      const deps = makeDeps({ circles: [] });
+      const result = await getUserPublicProfile({ publicId: PUBLIC_ID }, deps);
+
+      expect(result!.publicCircles).toHaveLength(0);
+    });
+  });
+});

--- a/src/domain/usecases/__tests__/get-user-public-profile.test.ts
+++ b/src/domain/usecases/__tests__/get-user-public-profile.test.ts
@@ -22,10 +22,11 @@ function makeDeps(
   const publicUser = overrides.publicUser !== undefined ? overrides.publicUser : makePublicUser();
   const internalUserId = overrides.internalUserId !== undefined ? overrides.internalUserId : INTERNAL_USER_ID;
 
+  const resolved = publicUser && internalUserId ? { user: publicUser, internalUserId } : null;
+
   return {
     userRepository: createMockUserRepository({
-      getPublicUserByPublicId: vi.fn().mockResolvedValue(publicUser),
-      findUserIdByPublicId: vi.fn().mockResolvedValue(internalUserId),
+      resolvePublicProfile: vi.fn().mockResolvedValue(resolved),
     }),
     circleRepository: createMockCircleRepository({
       getPublicCirclesForUser: vi.fn().mockResolvedValue(overrides.circles ?? []),
@@ -104,9 +105,9 @@ describe("GetUserPublicProfile", () => {
     });
   });
 
-  describe("given a valid publicId but userId resolution fails", () => {
-    it("should return null when findUserIdByPublicId returns null", async () => {
-      const deps = makeDeps({ internalUserId: null });
+  describe("given a valid publicId but resolvePublicProfile returns null", () => {
+    it("should return null", async () => {
+      const deps = makeDeps({ publicUser: null, internalUserId: null });
       const result = await getUserPublicProfile({ publicId: PUBLIC_ID }, deps);
 
       expect(result).toBeNull();

--- a/src/domain/usecases/__tests__/helpers/mock-circle-repository.ts
+++ b/src/domain/usecases/__tests__/helpers/mock-circle-repository.ts
@@ -29,6 +29,7 @@ export function createMockCircleRepository(
     findFollowers: vi.fn<CircleRepository["findFollowers"]>().mockResolvedValue([]),
     findPlayersForNewMomentNotification: vi.fn<CircleRepository["findPlayersForNewMomentNotification"]>().mockResolvedValue([]),
     findByInviteToken: vi.fn<CircleRepository["findByInviteToken"]>().mockResolvedValue(null),
+    getPublicCirclesForUser: vi.fn<CircleRepository["getPublicCirclesForUser"]>().mockResolvedValue([]),
     ...overrides,
   };
 }

--- a/src/domain/usecases/__tests__/helpers/mock-moment-repository.ts
+++ b/src/domain/usecases/__tests__/helpers/mock-moment-repository.ts
@@ -20,6 +20,7 @@ export function createMockMomentRepository(
     findPastByHostUserId: vi.fn<MomentRepository["findPastByHostUserId"]>().mockResolvedValue([]),
     findAllByHostUserId: vi.fn<MomentRepository["findAllByHostUserId"]>().mockResolvedValue({ upcoming: [], past: [] }),
     markBroadcastSent: vi.fn<MomentRepository["markBroadcastSent"]>().mockResolvedValue(undefined),
+    getUpcomingPublicMomentsForUser: vi.fn<MomentRepository["getUpcomingPublicMomentsForUser"]>().mockResolvedValue([]),
     ...overrides,
   };
 }

--- a/src/domain/usecases/__tests__/helpers/mock-user-repository.ts
+++ b/src/domain/usecases/__tests__/helpers/mock-user-repository.ts
@@ -22,11 +22,8 @@ export function createMockUserRepository(
       .mockResolvedValue(makeNotificationPreferences()),
     updateDashboardMode: vi.fn<UserRepository["updateDashboardMode"]>().mockResolvedValue(undefined),
     findAdminEmails: vi.fn<UserRepository["findAdminEmails"]>().mockResolvedValue([]),
-    getPublicUserByPublicId: vi
-      .fn<UserRepository["getPublicUserByPublicId"]>()
-      .mockResolvedValue(null),
-    findUserIdByPublicId: vi
-      .fn<UserRepository["findUserIdByPublicId"]>()
+    resolvePublicProfile: vi
+      .fn<UserRepository["resolvePublicProfile"]>()
       .mockResolvedValue(null),
     ensurePublicId: vi
       .fn<UserRepository["ensurePublicId"]>()

--- a/src/domain/usecases/__tests__/helpers/mock-user-repository.ts
+++ b/src/domain/usecases/__tests__/helpers/mock-user-repository.ts
@@ -1,5 +1,5 @@
 import type { UserRepository } from "@/domain/ports/repositories/user-repository";
-import type { User, NotificationPreferences } from "@/domain/models/user";
+import type { User, NotificationPreferences, PublicUser } from "@/domain/models/user";
 import { vi } from "vitest";
 
 export function createMockUserRepository(
@@ -22,6 +22,15 @@ export function createMockUserRepository(
       .mockResolvedValue(makeNotificationPreferences()),
     updateDashboardMode: vi.fn<UserRepository["updateDashboardMode"]>().mockResolvedValue(undefined),
     findAdminEmails: vi.fn<UserRepository["findAdminEmails"]>().mockResolvedValue([]),
+    getPublicUserByPublicId: vi
+      .fn<UserRepository["getPublicUserByPublicId"]>()
+      .mockResolvedValue(null),
+    findUserIdByPublicId: vi
+      .fn<UserRepository["findUserIdByPublicId"]>()
+      .mockResolvedValue(null),
+    ensurePublicId: vi
+      .fn<UserRepository["ensurePublicId"]>()
+      .mockResolvedValue("test-user-1234"),
     ...overrides,
   };
 }
@@ -42,8 +51,21 @@ export function makeUser(overrides: Partial<User> = {}): User {
     notifyNewFollower: true,
     notifyNewMomentInCircle: true,
     dashboardMode: null,
+    publicId: "test-user-1234",
     createdAt: new Date("2026-01-01"),
     updatedAt: new Date("2026-01-01"),
+    ...overrides,
+  };
+}
+
+export function makePublicUser(overrides: Partial<PublicUser> = {}): PublicUser {
+  return {
+    publicId: "jean-dupont-4821",
+    firstName: "Jean",
+    lastName: "Dupont",
+    image: null,
+    memberSince: new Date("2026-01-01"),
+    hostedMomentsCount: 0,
     ...overrides,
   };
 }

--- a/src/domain/usecases/get-user-public-profile.ts
+++ b/src/domain/usecases/get-user-public-profile.ts
@@ -1,0 +1,44 @@
+import type { PublicUser, PublicCircleMembership, PublicMomentRegistration } from "@/domain/models/user";
+import type { UserRepository } from "@/domain/ports/repositories/user-repository";
+import type { CircleRepository } from "@/domain/ports/repositories/circle-repository";
+import type { MomentRepository } from "@/domain/ports/repositories/moment-repository";
+
+type GetUserPublicProfileInput = {
+  publicId: string;
+};
+
+type GetUserPublicProfileDeps = {
+  userRepository: UserRepository;
+  circleRepository: CircleRepository;
+  momentRepository: MomentRepository;
+};
+
+export type UserPublicProfile = {
+  user: PublicUser;
+  publicCircles: PublicCircleMembership[];
+  upcomingPublicMoments: PublicMomentRegistration[];
+};
+
+export async function getUserPublicProfile(
+  input: GetUserPublicProfileInput,
+  deps: GetUserPublicProfileDeps
+): Promise<UserPublicProfile | null> {
+  const { userRepository, circleRepository, momentRepository } = deps;
+
+  const user = await userRepository.getPublicUserByPublicId(input.publicId);
+  if (!user) return null;
+
+  // userId n'est pas dans PublicUser — on doit le résoudre via le publicId
+  // Le repository getPublicUserByPublicId retourne les données publiques,
+  // mais les requêtes suivantes ont besoin de l'userId interne.
+  // On le récupère via une méthode dédiée sur le UserRepository.
+  const internalUserId = await userRepository.findUserIdByPublicId(input.publicId);
+  if (!internalUserId) return null;
+
+  const [publicCircles, upcomingPublicMoments] = await Promise.all([
+    circleRepository.getPublicCirclesForUser(internalUserId),
+    momentRepository.getUpcomingPublicMomentsForUser(internalUserId),
+  ]);
+
+  return { user, publicCircles, upcomingPublicMoments };
+}

--- a/src/domain/usecases/get-user-public-profile.ts
+++ b/src/domain/usecases/get-user-public-profile.ts
@@ -15,6 +15,8 @@ type GetUserPublicProfileDeps = {
 
 export type UserPublicProfile = {
   user: PublicUser;
+  /** Id interne — fourni à la couche app pour le contrôle isOwnProfile, ne pas exposer au client. */
+  internalUserId: string;
   publicCircles: PublicCircleMembership[];
   upcomingPublicMoments: PublicMomentRegistration[];
 };
@@ -25,20 +27,15 @@ export async function getUserPublicProfile(
 ): Promise<UserPublicProfile | null> {
   const { userRepository, circleRepository, momentRepository } = deps;
 
-  const user = await userRepository.getPublicUserByPublicId(input.publicId);
-  if (!user) return null;
+  const resolved = await userRepository.resolvePublicProfile(input.publicId);
+  if (!resolved) return null;
 
-  // userId n'est pas dans PublicUser — on doit le résoudre via le publicId
-  // Le repository getPublicUserByPublicId retourne les données publiques,
-  // mais les requêtes suivantes ont besoin de l'userId interne.
-  // On le récupère via une méthode dédiée sur le UserRepository.
-  const internalUserId = await userRepository.findUserIdByPublicId(input.publicId);
-  if (!internalUserId) return null;
+  const { user, internalUserId } = resolved;
 
   const [publicCircles, upcomingPublicMoments] = await Promise.all([
     circleRepository.getPublicCirclesForUser(internalUserId),
     momentRepository.getUpcomingPublicMomentsForUser(internalUserId),
   ]);
 
-  return { user, publicCircles, upcomingPublicMoments };
+  return { user, internalUserId, publicCircles, upcomingPublicMoments };
 }

--- a/src/infrastructure/auth/auth.config.ts
+++ b/src/infrastructure/auth/auth.config.ts
@@ -8,6 +8,7 @@ import { Resend } from "resend";
 import { MagicLinkEmail } from "@/infrastructure/services/email/templates/magic-link";
 import { isUploadedUrl } from "@/lib/blob";
 import { captureServerEvent } from "@/lib/posthog-server";
+import { prismaUserRepository } from "@/infrastructure/repositories/prisma-user-repository";
 
 export const { handlers, auth, signIn, signOut } = NextAuth({
   debug: process.env.NODE_ENV !== "production",
@@ -98,6 +99,25 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         }
       } catch (err) {
         console.error("[AUTH] PostHog user_signed_up tracking failed (non-blocking):", err);
+      }
+
+      // Génération du publicId si absent — non bloquant
+      try {
+        if (user.id) {
+          const dbUser = await prisma.user.findUnique({
+            where: { id: user.id },
+            select: { publicId: true, firstName: true, lastName: true },
+          });
+          if (dbUser && !dbUser.publicId) {
+            await prismaUserRepository.ensurePublicId(
+              user.id,
+              dbUser.firstName,
+              dbUser.lastName
+            );
+          }
+        }
+      } catch (err) {
+        console.error("[AUTH] publicId generation failed (non-blocking):", err);
       }
 
       return true;

--- a/src/infrastructure/repositories/prisma-circle-repository.ts
+++ b/src/infrastructure/repositories/prisma-circle-repository.ts
@@ -8,6 +8,7 @@ import type {
   CircleFollowerInfo,
 } from "@/domain/ports/repositories/circle-repository";
 import type { Circle, CircleCategory, CircleMembership, CircleMemberRole, CircleMemberWithUser, CircleWithRole, CoverImageAttribution, CircleFollow, DashboardCircle } from "@/domain/models/circle";
+import type { PublicCircleMembership } from "@/domain/models/user";
 import type { Circle as PrismaCircle, CircleMembership as PrismaMembership } from "@prisma/client";
 
 function toDomainCircle(record: PrismaCircle): Circle {
@@ -425,6 +426,41 @@ export const prismaCircleRepository: CircleRepository = {
       email: r.user.email,
       firstName: r.user.firstName,
       lastName: r.user.lastName,
+    }));
+  },
+
+  async getPublicCirclesForUser(userId: string): Promise<PublicCircleMembership[]> {
+    const memberships = await prisma.circleMembership.findMany({
+      where: { userId },
+      include: {
+        circle: {
+          select: {
+            slug: true,
+            name: true,
+            coverImage: true,
+            visibility: true,
+          },
+        },
+      },
+      orderBy: { joinedAt: "asc" },
+    });
+
+    // Filtre : uniquement les Circles publics
+    const publicMemberships = memberships.filter(
+      (m) => m.circle.visibility === "PUBLIC"
+    );
+
+    // Tri : HOSTs d'abord, puis PLAYERs — alpha dans chaque groupe
+    publicMemberships.sort((a, b) => {
+      if (a.role !== b.role) return a.role === "HOST" ? -1 : 1;
+      return a.circle.name.localeCompare(b.circle.name);
+    });
+
+    return publicMemberships.map((m) => ({
+      circleSlug: m.circle.slug,
+      circleName: m.circle.name,
+      circleCover: m.circle.coverImage,
+      role: m.role as "HOST" | "PLAYER",
     }));
   },
 };

--- a/src/infrastructure/repositories/prisma-moment-repository.ts
+++ b/src/infrastructure/repositories/prisma-moment-repository.ts
@@ -8,6 +8,7 @@ import type {
   UpcomingCircleMoment,
 } from "@/domain/ports/repositories/moment-repository";
 import type { Moment, CoverImageAttribution, HostMomentSummary } from "@/domain/models/moment";
+import type { PublicMomentRegistration } from "@/domain/models/user";
 import type { Moment as PrismaMoment } from "@prisma/client";
 
 function toDomainMoment(record: PrismaMoment): Moment {
@@ -357,6 +358,39 @@ export const prismaMomentRepository: MomentRepository = {
         name: m.circle.name,
         coverImage: m.circle.coverImage ?? null,
       },
+    }));
+  },
+
+  async getUpcomingPublicMomentsForUser(userId: string): Promise<PublicMomentRegistration[]> {
+    const now = new Date();
+    const registrations = await prisma.registration.findMany({
+      where: {
+        userId,
+        status: "REGISTERED",
+        moment: {
+          status: "PUBLISHED",
+          startsAt: { gt: now },
+          circle: { visibility: "PUBLIC" },
+        },
+      },
+      include: {
+        moment: {
+          select: {
+            slug: true,
+            title: true,
+            startsAt: true,
+            circle: { select: { name: true } },
+          },
+        },
+      },
+      orderBy: { moment: { startsAt: "asc" } },
+    });
+
+    return registrations.map((r) => ({
+      momentSlug: r.moment.slug,
+      momentTitle: r.moment.title,
+      momentDate: r.moment.startsAt,
+      circleName: r.moment.circle.name,
     }));
   },
 };

--- a/src/infrastructure/repositories/prisma-user-repository.ts
+++ b/src/infrastructure/repositories/prisma-user-repository.ts
@@ -169,10 +169,13 @@ export const prismaUserRepository: UserRepository = {
     return records.map((r) => r.email).filter(Boolean) as string[];
   },
 
-  async getPublicUserByPublicId(publicId: string): Promise<PublicUser | null> {
+  async resolvePublicProfile(
+    publicId: string
+  ): Promise<{ user: PublicUser; internalUserId: string } | null> {
     const record = await prisma.user.findUnique({
       where: { publicId },
       select: {
+        id: true,
         publicId: true,
         firstName: true,
         lastName: true,
@@ -182,11 +185,7 @@ export const prismaUserRepository: UserRepository = {
           where: { role: "HOST" },
           select: {
             circle: {
-              select: {
-                _count: {
-                  select: { moments: true },
-                },
-              },
+              select: { _count: { select: { moments: true } } },
             },
           },
         },
@@ -201,21 +200,16 @@ export const prismaUserRepository: UserRepository = {
     );
 
     return {
-      publicId: record.publicId,
-      firstName: record.firstName ?? "",
-      lastName: record.lastName ?? "",
-      image: record.image,
-      memberSince: record.createdAt,
-      hostedMomentsCount,
+      user: {
+        publicId: record.publicId,
+        firstName: record.firstName ?? "",
+        lastName: record.lastName ?? "",
+        image: record.image,
+        memberSince: record.createdAt,
+        hostedMomentsCount,
+      },
+      internalUserId: record.id,
     };
-  },
-
-  async findUserIdByPublicId(publicId: string): Promise<string | null> {
-    const record = await prisma.user.findUnique({
-      where: { publicId },
-      select: { id: true },
-    });
-    return record?.id ?? null;
   },
 
   async ensurePublicId(

--- a/src/infrastructure/repositories/prisma-user-repository.ts
+++ b/src/infrastructure/repositories/prisma-user-repository.ts
@@ -4,7 +4,8 @@ import type {
   UpdateProfileInput,
   UpdateNotificationPreferencesInput,
 } from "@/domain/ports/repositories/user-repository";
-import type { User, NotificationPreferences, DashboardMode } from "@/domain/models/user";
+import type { User, NotificationPreferences, DashboardMode, PublicUser } from "@/domain/models/user";
+import { generatePublicId } from "@/lib/public-id";
 import type { User as PrismaUser } from "@prisma/client";
 
 function toDomainUser(record: PrismaUser): User {
@@ -23,6 +24,7 @@ function toDomainUser(record: PrismaUser): User {
     notifyNewFollower: record.notifyNewFollower,
     notifyNewMomentInCircle: record.notifyNewMomentInCircle,
     dashboardMode: record.dashboardMode as DashboardMode | null,
+    publicId: record.publicId ?? null,
     createdAt: record.createdAt,
     updatedAt: record.updatedAt,
   };
@@ -165,5 +167,85 @@ export const prismaUserRepository: UserRepository = {
       select: { email: true },
     });
     return records.map((r) => r.email).filter(Boolean) as string[];
+  },
+
+  async getPublicUserByPublicId(publicId: string): Promise<PublicUser | null> {
+    const record = await prisma.user.findUnique({
+      where: { publicId },
+      select: {
+        publicId: true,
+        firstName: true,
+        lastName: true,
+        image: true,
+        createdAt: true,
+        memberships: {
+          where: { role: "HOST" },
+          select: {
+            circle: {
+              select: {
+                _count: {
+                  select: { moments: true },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!record || !record.publicId) return null;
+
+    const hostedMomentsCount = record.memberships.reduce(
+      (sum, m) => sum + m.circle._count.moments,
+      0
+    );
+
+    return {
+      publicId: record.publicId,
+      firstName: record.firstName ?? "",
+      lastName: record.lastName ?? "",
+      image: record.image,
+      memberSince: record.createdAt,
+      hostedMomentsCount,
+    };
+  },
+
+  async findUserIdByPublicId(publicId: string): Promise<string | null> {
+    const record = await prisma.user.findUnique({
+      where: { publicId },
+      select: { id: true },
+    });
+    return record?.id ?? null;
+  },
+
+  async ensurePublicId(
+    userId: string,
+    firstName: string | null,
+    lastName: string | null
+  ): Promise<string> {
+    const existing = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { publicId: true },
+    });
+
+    if (existing?.publicId) return existing.publicId;
+
+    // Générer avec retry jusqu'à 10 fois en cas de collision
+    for (let attempt = 0; attempt < 10; attempt++) {
+      const candidate = generatePublicId(firstName, lastName);
+      const conflict = await prisma.user.findUnique({
+        where: { publicId: candidate },
+        select: { id: true },
+      });
+      if (!conflict) {
+        await prisma.user.update({
+          where: { id: userId },
+          data: { publicId: candidate },
+        });
+        return candidate;
+      }
+    }
+
+    throw new Error(`[ensurePublicId] Impossible de générer un publicId unique pour l'utilisateur ${userId}`);
   },
 };

--- a/src/lib/format-date.ts
+++ b/src/lib/format-date.ts
@@ -86,6 +86,15 @@ export function isSameDayInParis(a: Date, b: Date): boolean {
   return fmt.format(a) === fmt.format(b);
 }
 
+/** "mars 2025" / "March 2025" — utilisé pour les dates de type "Membre depuis" */
+export function formatMonthYear(date: Date, locale: string): string {
+  return new Intl.DateTimeFormat(toIntlLocale(locale), {
+    timeZone: TIMEZONE,
+    month: "long",
+    year: "numeric",
+  }).format(date);
+}
+
 /** "25 février 2026" / "25 February 2026" */
 export function formatLongDate(date: Date, locale: string): string {
   return new Intl.DateTimeFormat(toIntlLocale(locale), {

--- a/src/lib/public-id.ts
+++ b/src/lib/public-id.ts
@@ -1,0 +1,24 @@
+import { generateSlug } from "@/lib/slug";
+
+/**
+ * Génère un publicId lisible pour un utilisateur.
+ * Format : {prénom-nom}-{nombre aléatoire 4 chiffres}
+ * Exemple : jean-dupont-4821
+ *
+ * Si firstName/lastName sont vides, fallback sur user-{5 chiffres}.
+ */
+export function generatePublicId(
+  firstName: string | null,
+  lastName: string | null
+): string {
+  const random = Math.floor(1000 + Math.random() * 9000);
+
+  const base = [firstName, lastName].filter(Boolean).join(" ").trim();
+
+  if (!base) {
+    return `user-${Math.floor(10000 + Math.random() * 90000)}`;
+  }
+
+  const slug = generateSlug(base);
+  return `${slug}-${random}`;
+}


### PR DESCRIPTION
## Summary

- **Nouveau champ `publicId`** sur le modèle `User` (format `prénom-nom-xxxx`, généré automatiquement à chaque sign-in)
- **Nouvelle page `/u/[publicId]`** (auth guard — connectés uniquement) : avatar, nom, stat "membre depuis", communautés publiques, prochains événements publics
- **Fil d'ariane** sur son propre profil (`Mon espace → C'est votre profil`), bandeau absent sur le profil d'un autre
- **Dashboard profil** : lien discret "Voir mon profil public" sous les stats
- **Backfill** : `pnpm db:backfill-public-id` / `:prod` pour les utilisateurs existants (déjà exécuté en dev)
- **Architecture hexagonale** : usecase `GetUserPublicProfile`, port `resolvePublicProfile` (une seule requête DB), 3 nouveaux ports downstream
- **i18n** FR/EN : toutes les nouvelles chaînes dans `Profile.publicProfile.*`
- **Tests** : 8 cas unitaires `GetUserPublicProfile`, mocks mis à jour

## Test plan

- [ ] Se connecter → aller sur `/dashboard/profile` → vérifier la présence du lien "Voir mon profil public"
- [ ] Cliquer sur le lien → vérifier la page profil avec fil d'ariane `Mon espace → C'est votre profil`
- [ ] Vérifier que la page affiche les communautés publiques et les prochains événements
- [ ] Copier l'URL `/u/[publicId]` → ouvrir en navigation privée → vérifier la redirection vers sign-in
- [ ] Se connecter avec un autre compte → accéder à l'URL → vérifier l'absence du fil d'ariane
- [ ] Vérifier qu'aucun email n'est visible sur la page profil public
- [ ] `pnpm db:push:prod` + `pnpm db:backfill-public-id:prod` à faire avant le merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)