### PR TITLE
feat(admin): notifier les admins à la complétion de l'onboarding

### DIFF
--- a/src/app/[locale]/(routes)/dashboard/(onboarding)/profile/setup/page.tsx
+++ b/src/app/[locale]/(routes)/dashboard/(onboarding)/profile/setup/page.tsx
@@ -7,7 +7,7 @@ import { shouldRedirectFromSetup } from "@/lib/onboarding";
 import { safeCallbackUrl } from "@/lib/url";
 import { getTranslations } from "next-intl/server";
 import { ProfileForm } from "@/components/profile/profile-form";
-import { updateProfileAction } from "@/app/actions/profile";
+import { completeOnboardingAction } from "@/app/actions/profile";
 import { AvatarUpload } from "@/components/profile/avatar-upload";
 
 function parseName(name: string | null): { firstName: string; lastName: string } {
@@ -67,7 +67,7 @@ export default async function ProfileSetupPage() {
       <ProfileForm
         user={{ firstName, lastName }}
         mode="setup"
-        action={updateProfileAction}
+        action={completeOnboardingAction}
         callbackUrl={callbackUrl}
       />
     </div>

--- a/src/app/actions/profile.ts
+++ b/src/app/actions/profile.ts
@@ -10,6 +10,7 @@ import { DomainError } from "@/domain/errors";
 import { signOut } from "@/infrastructure/auth/auth.config";
 import { vercelBlobStorageService } from "@/infrastructure/services/storage/vercel-blob-storage-service";
 import { isUploadedUrl } from "@/lib/blob";
+import { createResendEmailService } from "@/infrastructure/services";
 import type { User, NotificationPreferences } from "@/domain/models/user";
 import type { ActionResult } from "./types";
 
@@ -50,6 +51,59 @@ export async function updateProfileAction(
     }
     Sentry.captureException(error);
     return { success: false, error: "An unexpected error occurred", code: "INTERNAL_ERROR" };
+  }
+}
+
+export async function completeOnboardingAction(
+  formData: FormData
+): Promise<ActionResult<User>> {
+  const result = await updateProfileAction(formData);
+
+  if (result.success) {
+    // Fire-and-forget : notifier les admins du nouvel utilisateur
+    void notifyAdminNewUser(result.data);
+  }
+
+  return result;
+}
+
+async function notifyAdminNewUser(user: User): Promise<void> {
+  try {
+    const adminEmails = await prismaUserRepository.findAdminEmails();
+    const recipients = adminEmails.filter((email) => email !== user.email);
+    if (recipients.length === 0) return;
+
+    const emailService = createResendEmailService();
+    const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
+    const adminUsersUrl = `${appUrl}/admin/users`;
+    const userName = [user.firstName, user.lastName].filter(Boolean).join(" ") || user.email;
+    const registeredAt = new Date().toLocaleDateString("fr-FR", {
+      day: "numeric",
+      month: "long",
+      year: "numeric",
+    });
+
+    await Promise.allSettled(
+      recipients.map((to) =>
+        emailService.sendAdminNewUser({
+          to,
+          userName,
+          userEmail: user.email,
+          registeredAt,
+          adminUsersUrl,
+          strings: {
+            subject: `[Admin] Nouvel utilisateur — ${userName}`,
+            heading: "Nouvel utilisateur sur The Playground",
+            message: `${userName} vient de compléter son inscription.`,
+            ctaLabel: "Voir les utilisateurs dans l'admin",
+            footer:
+              "Vous recevez cet email car vous êtes administrateur de The Playground.",
+          },
+        })
+      )
+    );
+  } catch (error) {
+    console.error("[notifyAdminNewUser] Échec :", error);
   }
 }
 

--- a/src/app/actions/profile.ts
+++ b/src/app/actions/profile.ts
@@ -10,9 +10,13 @@ import { DomainError } from "@/domain/errors";
 import { signOut } from "@/infrastructure/auth/auth.config";
 import { vercelBlobStorageService } from "@/infrastructure/services/storage/vercel-blob-storage-service";
 import { isUploadedUrl } from "@/lib/blob";
+import { after } from "next/server";
 import { createResendEmailService } from "@/infrastructure/services";
+import { formatLongDate } from "@/lib/format-date";
 import type { User, NotificationPreferences } from "@/domain/models/user";
 import type { ActionResult } from "./types";
+
+const emailService = createResendEmailService();
 
 const ACCEPTED_TYPES = ["image/jpeg", "image/png", "image/webp", "image/gif"];
 const MAX_SIZE_BYTES = 5 * 1024 * 1024; // 5 Mo — filet de sécurité (le resize côté client ramène à ~50 Ko)
@@ -61,50 +65,52 @@ export async function completeOnboardingAction(
 
   if (result.success) {
     // Fire-and-forget : notifier les admins du nouvel utilisateur
-    void notifyAdminNewUser(result.data);
+    after(async () => {
+      try {
+        await notifyAdminNewUser(result.data);
+      } catch (e) {
+        Sentry.captureException(e);
+      }
+    });
   }
 
   return result;
 }
 
 async function notifyAdminNewUser(user: User): Promise<void> {
-  try {
-    const adminEmails = await prismaUserRepository.findAdminEmails();
-    const recipients = adminEmails.filter((email) => email !== user.email);
-    if (recipients.length === 0) return;
+  const adminEmails = await prismaUserRepository.findAdminEmails();
+  const recipients = adminEmails.filter((email) => email !== user.email);
+  if (recipients.length === 0) return;
 
-    const emailService = createResendEmailService();
-    const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
-    const adminUsersUrl = `${appUrl}/admin/users`;
-    const userName = [user.firstName, user.lastName].filter(Boolean).join(" ") || user.email;
-    const registeredAt = new Date().toLocaleDateString("fr-FR", {
-      day: "numeric",
-      month: "long",
-      year: "numeric",
-    });
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
+  const adminUsersUrl = `${appUrl}/admin/users`;
+  const userName = [user.firstName, user.lastName].filter(Boolean).join(" ") || user.email;
+  const registeredAt = formatLongDate(new Date(), "fr");
 
-    await Promise.allSettled(
-      recipients.map((to) =>
-        emailService.sendAdminNewUser({
-          to,
-          userName,
-          userEmail: user.email,
-          registeredAt,
-          adminUsersUrl,
-          strings: {
-            subject: `[Admin] Nouvel utilisateur — ${userName}`,
-            heading: "Nouvel utilisateur sur The Playground",
-            message: `${userName} vient de compléter son inscription.`,
-            ctaLabel: "Voir les utilisateurs dans l'admin",
-            footer:
-              "Vous recevez cet email car vous êtes administrateur de The Playground.",
-          },
-        })
-      )
-    );
-  } catch (error) {
-    console.error("[notifyAdminNewUser] Échec :", error);
-  }
+  const results = await Promise.allSettled(
+    recipients.map((to) =>
+      emailService.sendAdminNewUser({
+        to,
+        userName,
+        userEmail: user.email,
+        registeredAt,
+        adminUsersUrl,
+        strings: {
+          subject: `[Admin] Nouvel utilisateur — ${userName}`,
+          heading: "Nouvel utilisateur sur The Playground",
+          message: `${userName} vient de compléter son inscription.`,
+          ctaLabel: "Voir les utilisateurs dans l'admin",
+          footer: "Vous recevez cet email car vous êtes administrateur de The Playground.",
+        },
+      })
+    )
+  );
+
+  results.forEach((result, i) => {
+    if (result.status === "rejected") {
+      console.error(`[notifyAdminNewUser] Échec envoi email admin ${recipients[i]}:`, result.reason);
+    }
+  });
 }
 
 export async function deleteAccountAction(): Promise<ActionResult> {

--- a/src/domain/ports/services/email-service.ts
+++ b/src/domain/ports/services/email-service.ts
@@ -245,6 +245,21 @@ export type AdminEntityCreatedEmailData = {
   };
 };
 
+export type AdminNewUserEmailData = {
+  to: string;
+  userName: string;
+  userEmail: string;
+  registeredAt: string; // Date pré-formatée
+  adminUsersUrl: string;
+  strings: {
+    subject: string;
+    heading: string;
+    message: string;
+    ctaLabel: string;
+    footer: string;
+  };
+};
+
 // --- Port interface ---
 
 export interface EmailService {
@@ -263,4 +278,5 @@ export interface EmailService {
   sendBroadcastMoment(data: BroadcastMomentEmailData): Promise<void>;
   sendAdminEntityCreated(data: AdminEntityCreatedEmailData): Promise<void>;
   sendCircleInvitation(data: CircleInvitationEmailData): Promise<void>;
+  sendAdminNewUser(data: AdminNewUserEmailData): Promise<void>;
 }

--- a/src/domain/usecases/__tests__/helpers/mock-email-service.ts
+++ b/src/domain/usecases/__tests__/helpers/mock-email-service.ts
@@ -18,6 +18,7 @@ export function createMockEmailService(
     sendBroadcastMoment: vi.fn().mockResolvedValue(undefined),
     sendAdminEntityCreated: vi.fn().mockResolvedValue(undefined),
     sendCircleInvitation: vi.fn().mockResolvedValue(undefined),
+    sendAdminNewUser: vi.fn().mockResolvedValue(undefined),
     ...overrides,
   };
 }

--- a/src/infrastructure/services/email/resend-email-service.ts
+++ b/src/infrastructure/services/email/resend-email-service.ts
@@ -14,6 +14,7 @@ import type {
   BroadcastMomentEmailData,
   AdminEntityCreatedEmailData,
   CircleInvitationEmailData,
+  AdminNewUserEmailData,
 } from "@/domain/ports/services/email-service";
 import { RegistrationConfirmationEmail } from "./templates/registration-confirmation";
 import { WaitlistPromotionEmail } from "./templates/waitlist-promotion";
@@ -27,6 +28,7 @@ import { HostMomentCreatedEmail } from "./templates/host-moment-created";
 import { BroadcastMomentEmail } from "./templates/broadcast-moment";
 import { AdminEntityCreatedEmail } from "./templates/admin-entity-created";
 import { CircleInvitationEmail } from "./templates/circle-invitation";
+import { AdminNewUserEmail } from "./templates/admin-new-user";
 
 function getBaseUrl(): string {
   return process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
@@ -221,6 +223,15 @@ export function createResendEmailService(): EmailService {
         to: data.to,
         subject: data.strings.subject,
         react: CircleInvitationEmail({ ...data, baseUrl }),
+      });
+    },
+
+    async sendAdminNewUser(data: AdminNewUserEmailData): Promise<void> {
+      await send({
+        from,
+        to: data.to,
+        subject: data.strings.subject,
+        react: AdminNewUserEmail({ ...data, baseUrl }),
       });
     },
   };

--- a/src/infrastructure/services/email/templates/admin-new-user.tsx
+++ b/src/infrastructure/services/email/templates/admin-new-user.tsx
@@ -1,0 +1,92 @@
+import { Button, Section, Text } from "@react-email/components";
+import * as React from "react";
+import { EmailLayout } from "./components/email-layout";
+import type { AdminNewUserEmailData } from "@/domain/ports/services/email-service";
+
+type Props = AdminNewUserEmailData & {
+  baseUrl: string;
+};
+
+export function AdminNewUserEmail({
+  userName,
+  userEmail,
+  registeredAt,
+  adminUsersUrl,
+  strings,
+}: Props) {
+  return (
+    <EmailLayout preview={strings.subject} footer={strings.footer}>
+      <Text style={heading}>{strings.heading}</Text>
+
+      <Text style={message}>{strings.message}</Text>
+
+      <Section style={infoCard}>
+        <Text style={infoLabel}>Nom</Text>
+        <Text style={infoValue}>{userName}</Text>
+        <Text style={infoLabel}>Email</Text>
+        <Text style={infoValue}>{userEmail}</Text>
+        <Text style={infoLabel}>Inscrit le</Text>
+        <Text style={infoValue}>{registeredAt}</Text>
+      </Section>
+
+      <Section style={ctaSection}>
+        <Button style={ctaButton} href={adminUsersUrl}>
+          {strings.ctaLabel}
+        </Button>
+      </Section>
+    </EmailLayout>
+  );
+}
+
+const heading: React.CSSProperties = {
+  fontSize: "16px",
+  fontWeight: 600,
+  color: "#18181b",
+  margin: "0 0 16px 0",
+  lineHeight: "24px",
+};
+
+const message: React.CSSProperties = {
+  fontSize: "14px",
+  color: "#52525b",
+  margin: "0 0 20px 0",
+  lineHeight: "22px",
+};
+
+const infoCard: React.CSSProperties = {
+  backgroundColor: "#f4f4f5",
+  borderRadius: "8px",
+  padding: "12px 16px",
+  marginBottom: "24px",
+};
+
+const infoLabel: React.CSSProperties = {
+  fontSize: "11px",
+  fontWeight: 600,
+  color: "#71717a",
+  textTransform: "uppercase" as const,
+  letterSpacing: "0.05em",
+  margin: "8px 0 2px 0",
+};
+
+const infoValue: React.CSSProperties = {
+  fontSize: "14px",
+  color: "#18181b",
+  fontWeight: 500,
+  margin: "0 0 4px 0",
+};
+
+const ctaSection: React.CSSProperties = {
+  textAlign: "center" as const,
+};
+
+const ctaButton: React.CSSProperties = {
+  background: "linear-gradient(135deg, #ec4899, #8b5cf6)",
+  color: "#ffffff",
+  fontSize: "14px",
+  fontWeight: 600,
+  borderRadius: "8px",
+  padding: "12px 32px",
+  textDecoration: "none",
+  display: "inline-block",
+};


### PR DESCRIPTION
## Résumé

- Ajout d'un email de notification admin envoyé quand un nouvel utilisateur complète son onboarding (profil setup)
- Nouveau template react-email `admin-new-user` (même style que les emails admin existants)
- Action dédiée `completeOnboardingAction` — wrappeur autour de `updateProfileAction` + fire-and-forget via `after()`
- Contenu : nom complet, email, date d'inscription, lien CTA vers `/admin/users`

## Fichiers modifiés

- `src/domain/ports/services/email-service.ts` — nouveau type `AdminNewUserEmailData` + méthode `sendAdminNewUser`
- `src/infrastructure/services/email/templates/admin-new-user.tsx` — template react-email
- `src/infrastructure/services/email/resend-email-service.ts` — implémentation `sendAdminNewUser`
- `src/app/actions/profile.ts` — `completeOnboardingAction` + `notifyAdminNewUser`
- `src/app/[locale]/(routes)/dashboard/(onboarding)/profile/setup/page.tsx` — utilise `completeOnboardingAction`
- `src/domain/usecases/__tests__/helpers/mock-email-service.ts` — mock mis à jour

## Plan de test

- [ ] Créer un nouveau compte (magic link ou OAuth)
- [ ] Compléter le profil sur la page setup
- [ ] Vérifier que l'admin reçoit un email `[Admin] Nouvel utilisateur — Prénom Nom`
- [ ] Vérifier que l'admin lui-même ne reçoit pas l'email s'il complète son propre onboarding
- [ ] Vérifier que les comptes `@demo.playground` ne déclenchent pas d'email (filtre `isDemoEmail`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)