### PR TITLE
feat(explorer): explorer rating — score interne pour trier Communautés et événements

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "db:backfill-dashboard-mode:prod": "bash scripts/backfill-dashboard-mode-prod.sh",
     "db:backfill-public-id": "tsx scripts/backfill-public-id.ts",
     "db:backfill-public-id:prod": "bash scripts/backfill-public-id-prod.sh",
+    "db:backfill-is-demo": "tsx scripts/backfill-explorer-is-demo.ts",
+    "db:backfill-is-demo:prod": "bash scripts/backfill-explorer-is-demo-prod.sh",
     "db:subscribe-demo-to-the-spark:prod": "bash scripts/db-subscribe-demo-to-the-spark-prod.sh",
     "db:seed-covers": "tsx scripts/seed-covers.ts",
     "db:seed-covers:execute": "tsx scripts/seed-covers.ts --execute",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -167,7 +167,7 @@ model Circle {
   stripeConnectAccountId String?
   inviteToken           String?          @unique @map("invite_token")
   // Explorer scoring
-  isDemo               Boolean   @default(false)   @map("is_demo")
+  isDemo               Boolean   @default(false)
   excludedFromExplorer Boolean   @default(false)   @map("excluded_from_explorer")
   overrideScore        Int?                         @map("override_score")
   explorerScore        Int       @default(0)        @map("explorer_score")

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -166,6 +166,8 @@ model Circle {
   city                  String?
   stripeConnectAccountId String?
   inviteToken           String?          @unique @map("invite_token")
+  isDemo                Boolean          @default(false) @map("is_demo")
+  excludedFromExplorer  Boolean          @default(false) @map("excluded_from_explorer")
 
   // Explorer scoring
   isDemo               Boolean   @default(false)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -167,6 +167,13 @@ model Circle {
   stripeConnectAccountId String?
   inviteToken           String?          @unique @map("invite_token")
 
+  // Explorer scoring
+  isDemo               Boolean   @default(false)
+  excludedFromExplorer Boolean   @default(false)   @map("excluded_from_explorer")
+  overrideScore        Int?                         @map("override_score")
+  explorerScore        Int       @default(0)        @map("explorer_score")
+  scoreUpdatedAt       DateTime?                    @map("score_updated_at")
+
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
@@ -178,6 +185,8 @@ model Circle {
   // WHERE visibility = 'PUBLIC' — couvert par le préfixe visibility
   // WHERE visibility = 'PUBLIC' AND category = ? — couvert par l'index complet
   @@index([visibility, category])
+  // Index sur explorerScore : utilisé dans ORDER BY explorer_score DESC (Explorer)
+  @@index([explorerScore])
   @@map("circles")
 }
 
@@ -222,6 +231,9 @@ model Moment {
   status                MomentStatus @default(PUBLISHED)
   broadcastSentAt       DateTime?
 
+  // Explorer scoring
+  explorerScore Int @default(0) @map("explorer_score")
+
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
@@ -237,6 +249,8 @@ model Moment {
   @@index([status, startsAt])
   // Index sur (circleId, status) : utilisé dans findPublic (circles avec moments à venir)
   @@index([circleId, status])
+  // Index sur explorerScore : utilisé dans ORDER BY explorer_score DESC (Explorer)
+  @@index([explorerScore])
   @@map("moments")
 }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -166,11 +166,8 @@ model Circle {
   city                  String?
   stripeConnectAccountId String?
   inviteToken           String?          @unique @map("invite_token")
-  isDemo                Boolean          @default(false) @map("is_demo")
-  excludedFromExplorer  Boolean          @default(false) @map("excluded_from_explorer")
-
   // Explorer scoring
-  isDemo               Boolean   @default(false)
+  isDemo               Boolean   @default(false)   @map("is_demo")
   excludedFromExplorer Boolean   @default(false)   @map("excluded_from_explorer")
   overrideScore        Int?                         @map("override_score")
   explorerScore        Int       @default(0)        @map("explorer_score")

--- a/scripts/backfill-explorer-is-demo-prod.sh
+++ b/scripts/backfill-explorer-is-demo-prod.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────
+# db:backfill-is-demo:prod
+# Met isDemo = true sur les Circles de démo en
+# production (identifiés par le domaine @demo.playground
+# du host).
+#
+# Idempotent : ne touche pas les Circles déjà à true.
+#
+# Usage: pnpm db:backfill-is-demo:prod
+# ─────────────────────────────────────────────
+
+set -euo pipefail
+
+# Load env vars
+if [ -f .env.local ]; then
+  export $(grep -E '^(NEON_API_KEY|NEON_PROJECT_ID|NEON_PROD_BRANCH_ID)=' .env.local | xargs)
+fi
+
+if [ -z "${NEON_API_KEY:-}" ] || [ -z "${NEON_PROJECT_ID:-}" ] || [ -z "${NEON_PROD_BRANCH_ID:-}" ]; then
+  echo "❌ Missing NEON_API_KEY, NEON_PROJECT_ID, or NEON_PROD_BRANCH_ID in .env.local"
+  exit 1
+fi
+
+API="https://console.neon.tech/api/v2/projects/${NEON_PROJECT_ID}"
+AUTH="Authorization: Bearer ${NEON_API_KEY}"
+
+echo "🔍 Fetching production connection string..."
+
+RESPONSE=$(curl -s -H "$AUTH" "${API}/connection_uri?branch_id=${NEON_PROD_BRANCH_ID}&pooled=true&database_name=neondb&role_name=neondb_owner")
+PROD_URL=$(echo "$RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin)['uri'])")
+
+if [ -z "$PROD_URL" ]; then
+  echo "❌ Could not retrieve production connection string."
+  exit 1
+fi
+
+echo ""
+echo "⚠️  Vous êtes sur le point de backfiller isDemo en PRODUCTION."
+echo "   Branch : production (${NEON_PROD_BRANCH_ID})"
+echo "   Règle  : Circles dont le HOST a un email @demo.playground → isDemo = true"
+echo "   Scope  : uniquement les Circles avec isDemo = false"
+echo ""
+read -p "   Continuer ? (y/N) " -n 1 -r
+echo ""
+
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+  echo "   Annulé."
+  exit 0
+fi
+
+echo ""
+echo "🌱 Backfill de isDemo en production..."
+DATABASE_URL="${PROD_URL}" npx tsx scripts/backfill-explorer-is-demo.ts

--- a/scripts/backfill-explorer-is-demo.ts
+++ b/scripts/backfill-explorer-is-demo.ts
@@ -1,0 +1,69 @@
+/**
+ * Backfill du champ isDemo pour les Circles de démo existants en production.
+ *
+ * Identifie les Circles dont le host principal a un email @demo.playground
+ * et met isDemo = true sur ces Circles.
+ *
+ * Idempotent : ne touche pas les Circles dont isDemo est déjà à true.
+ *
+ * Usage dev  : pnpm db:backfill-is-demo
+ * Usage prod : pnpm db:backfill-is-demo:prod
+ */
+
+import { config } from "dotenv";
+config({ path: ".env.local" });
+
+import { PrismaClient } from "@prisma/client";
+import { PrismaNeon } from "@prisma/adapter-neon";
+
+if (!process.env.DATABASE_URL) {
+  console.error("❌ DATABASE_URL non défini.");
+  process.exit(1);
+}
+
+const prisma = new PrismaClient({
+  adapter: new PrismaNeon({ connectionString: process.env.DATABASE_URL }),
+});
+
+async function main() {
+  // Trouve les Circles dont au moins un HOST a un email @demo.playground
+  const demoCircles = await prisma.circle.findMany({
+    where: {
+      isDemo: false,
+      memberships: {
+        some: {
+          role: "HOST",
+          user: { email: { endsWith: "@demo.playground" } },
+        },
+      },
+    },
+    select: { id: true, name: true, slug: true },
+  });
+
+  if (demoCircles.length === 0) {
+    console.log("✅ Aucun Circle démo à mettre à jour. Rien à faire.");
+    return;
+  }
+
+  console.log(`\n🔍 ${demoCircles.length} Circle(s) démo trouvé(s) — backfill en cours...\n`);
+
+  for (const circle of demoCircles) {
+    console.log(`  · ${circle.name} (${circle.slug})`);
+  }
+
+  const circleIds = demoCircles.map((c) => c.id);
+
+  const result = await prisma.circle.updateMany({
+    where: { id: { in: circleIds } },
+    data: { isDemo: true },
+  });
+
+  console.log(`\n✅ Backfill terminé — ${result.count} Circle(s) mis à jour avec isDemo = true.\n`);
+}
+
+main()
+  .catch((e) => {
+    console.error("❌ Erreur :", e);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/scripts/db-seed-demo-data.ts
+++ b/scripts/db-seed-demo-data.ts
@@ -807,6 +807,7 @@ async function main() {
         visibility: circleData.visibility,
         category: circleData.category,
         city: circleData.city ?? null,
+        isDemo: true,
       },
       update: {
         name: circleData.name,
@@ -814,6 +815,7 @@ async function main() {
         visibility: circleData.visibility,
         category: circleData.category,
         city: circleData.city ?? null,
+        isDemo: true,
       },
     });
 

--- a/spec/feature-explorer-rating.md
+++ b/spec/feature-explorer-rating.md
@@ -31,35 +31,50 @@ Une communauté récente mais active peut dépasser une communauté ancienne mai
 Avant tout calcul de score, les entités suivantes sont **exclues de l'affichage** :
 
 - Communautés dont le Host a un email `@test.playground`
-- Communautés dont le Host a un email `@demo.playground`
 - Événements appartenant à ces mêmes communautés
 
 Ces entités n'apparaissent jamais sur Explorer, quel que soit leur score.
 
+> Les communautés `@demo.playground` ne sont **pas** exclues — elles apparaissent mélangées dans la liste avec un badge "Démo" et un score capé à 30. Voir section dédiée ci-dessous.
+
+---
+
+## Communautés et événements démo (`@demo.playground`)
+
+Les communautés démo ne sont pas exclues — elles apparaissent sur Explorer mais avec un traitement spécifique :
+
+### Champ DB
+
+```prisma
+model Circle {
+  isDemo  Boolean  @default(false)
+}
+```
+
+Les communautés seedées avec `@demo.playground` ont `isDemo: true`.
+
+### Comportement
+
+- **Score capé à 30/100** → score calculé normalement puis plafonné à 30, quel que soit le résultat brut. Les vraies communautés actives (score > 30) passent naturellement devant. Les démos restent visibles et mélangées avec les vraies communautés peu actives.
+- **Badge "Démo"** affiché sur les cards Explorer — Communautés ET événements appartenant à un Circle `isDemo: true`
+- **Exclues du pool "À la une"** automatiquement
+
+```
+score_circle = isDemo
+  ? Math.min(Math.round((raw_score / 205) * 100), 30)   // capé à 30
+  : Math.round((raw_score / 205) * 100)                  // normal
+```
+
+### Rationale
+
+- Les démos sont parfaitement seedées (cover, membres, events) → score brut ~90/100 sans cap. Elles domineraient Explorer sans plafonnement.
+- Cap à 30 : mélangées au milieu, jamais en tête. Descendent progressivement quand le vrai catalogue grossit — sans action manuelle.
+- Badge "Démo" : transparence maintenue pour les visiteurs.
+- Cap tuneable : valeur initiale conservative, à ajuster selon la densité du catalogue.
+
 ---
 
 ## Score Communauté (Circle)
-
-> Session 1 — signaux en cours de définition
-
-### Tableau des signaux
-
-| Signal | Poids | Type | Logique |
-|---|---|---|---|
-| Cover image renseignée | **Fort** | Binaire | Communauté qui rend bien visuellement — investissement de l'organisateur |
-| Description ≥ seuil min | **Fort** | Binaire | La description est obligatoire donc elle existe, le seuil filtre les "test" / "essai" / une ligne |
-| Événement passé avec ≥ 1 inscrit | **Fort** | Binaire | Preuve que la communauté a réellement eu lieu — le signal le plus fort |
-| Prochain événement publié (upcoming) | **Fort** | Binaire | Communauté vivante, pas abandonnée après création |
-| Nombre de membres réels (hors host) | **Fort** | Quantitatif | Une communauté de test reste souvent à 0 membres |
-| Nombre d'événements passés | **Moyen** | Quantitatif | Historique d'activité — différencie une communauté établie d'une nouvelle |
-| Ancienneté > N jours | **Moyen** | Binaire | Filtre les comptes créés aujourd'hui — seuil à définir (7 jours ?) |
-| Catégorie renseignée | **Faible** | Binaire | Signe de soin — les tests sautent souvent ce champ |
-| Ville renseignée | **Faible** | Binaire | Idem |
-
-> **Questions ouvertes** :
-> - Seuil description : combien de caractères ? (proposition : 150 chars)
-> - Seuil ancienneté : 7 jours ? 14 jours ?
-> - Plafonnement des signaux quantitatifs (membres, événements passés) ? ex: log(n) pour éviter qu'une grosse communauté écrase tout
 
 ### Seuil d'affichage sur Explorer
 
@@ -90,7 +105,7 @@ score_circle = Math.round((raw_score / 205) * 100)   // normalisé 0–100
 #### Signaux binaires (max 75 pts — 37%)
 
 | Signal | Pts | Condition |
-|---|---|---|
+| --- | --- | --- |
 | Événement passé avec ≥ 1 inscrit | **+20** | Preuve d'existence réelle |
 | Cover image | **+18** | `coverImageUrl != null` |
 | Prochain événement publié | **+15** | status `PUBLISHED` + `startsAt > now` |
@@ -101,14 +116,14 @@ score_circle = Math.round((raw_score / 205) * 100)   // normalisé 0–100
 #### Signaux quantitatifs (max 130 pts — 63%)
 
 | Signal | Formule | Cap | Plafond atteint à |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | Membres (hors host) | `n × 8` | **80 pts** | ≥ 10 membres |
 | Événements passés | `n × 10` | **50 pts** | ≥ 5 événements passés |
 
 #### Cas concrets
 
 | Profil | Score brut | Score /100 |
-|---|---|---|
+| --- | --- | --- |
 | Coquille vide (0 membres, 0 events) | — | **non affichée** |
 | Nouvelle communauté soignée, 0 membres, 1 event à venir | 55 | **27** |
 | Communauté avec 3 membres, cover, 1 event passé, 1 à venir | 99 | **48** |
@@ -138,7 +153,7 @@ score_moment = Math.round(score_circle * 0.5 + moment_raw * 0.5)  // normalisé 
 #### Signaux propres à l'événement (raw max 100 pts → contribue 0–50 pts au score final)
 
 | Signal | Formule / Pts | Cap | Plafond atteint à |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | Nombre d'inscrits | `n × 7` | **70 pts** | ≥ 10 inscrits |
 | Cover image | **+15** | — | — |
 | Description ≥ 30 caractères | **+10** | — | — |
@@ -146,7 +161,8 @@ score_moment = Math.round(score_circle * 0.5 + moment_raw * 0.5)  // normalisé 
 
 #### Règle d'exclusion
 
-Même règle que pour les Communautés : événements dont le host a un email `@test.playground` ou `@demo.playground` exclus via filtre `WHERE`.
+Événements dont le host a un email `@test.playground` : exclus via filtre `WHERE`.
+Événements d'un Circle `isDemo: true` : affichés avec badge "Démo", score capé à 30.
 
 ---
 
@@ -170,12 +186,15 @@ Une seule condition : **avoir une cover image** (`coverImageUrl != null`).
 
 Rationale : la cover garantit que les 3 cards rendent visuellement bien. C'est aussi un signal d'effort minimal de l'organisateur. La condition est simple, compréhensible, et constitue un pool large dès le lancement.
 
-Les communautés `excludedFromExplorer: true` sont exclues du pool.
+Les communautés `excludedFromExplorer: true` et `isDemo: true` sont exclues du pool.
 
 ### Mécanique
 
 ```
-pool = communautés PUBLIC avec coverImageUrl != null ET excludedFromExplorer = false
+pool = communautés PUBLIC
+       avec coverImageUrl != null
+       ET excludedFromExplorer = false
+       ET isDemo = false
 sélection = 3 éléments tirés aléatoirement, seed = date du jour (YYYY-MM-DD)
 ```
 
@@ -214,13 +233,13 @@ Géré exclusivement depuis le backend admin (`/admin/*`), pas accessible aux or
 
 Deux écrans dédiés :
 
-**1. Liste Explorer (`/admin/explorer`)**
+**1. Liste Explorer (****`/admin/explorer`****)**
 - Tableau des Communautés publiques avec leur score calculé en temps réel
 - Colonne `overrideScore` (éditable inline)
 - Toggle `excludedFromExplorer` (bouton on/off)
 - Filtre rapide : "Exclues" / "Boostées" / "Toutes"
 
-**2. Détail Communauté (`/admin/circles/[id]`)**
+**2. Détail Communauté (****`/admin/circles/[id]`****)**
 - Section "Visibilité Explorer" dans le panneau admin existant
 - Champ `overrideScore` (input 0–100, vide = automatique)
 - Toggle exclusion avec confirmation
@@ -230,23 +249,90 @@ Deux écrans dédiés :
 
 ## Architecture technique
 
-> À définir après la finalisation de la formule
+### Stratégie : batch quotidien
+
+Le score est **persisté en DB** et recalculé chaque nuit. La requête Explorer se réduit à un `ORDER BY explorer_score DESC` sur index — aucune agrégation à la volée.
+
+**Fréquence** : 1x/jour à **3h00** (heure creuse).
+**Décalage acceptable** : max 24h — une communauté qui gagne des membres peut attendre le lendemain.
+
+### Champs DB
+
+```prisma
+model Circle {
+  explorerScore   Int       @default(0)  // 0–100, recalculé chaque nuit
+  scoreUpdatedAt  DateTime?              // timestamp du dernier calcul (debug/admin)
+  // + champs déjà spécifiés : isDemo, excludedFromExplorer, overrideScore
+}
+
+model Moment {
+  explorerScore   Int       @default(0)  // 0–100, recalculé chaque nuit
+}
+```
+
+### Vercel Cron Job
+
+```json
+// vercel.json
+{
+  "crons": [{
+    "path": "/api/cron/recalculate-scores",
+    "schedule": "0 3 * * *"
+  }]
+}
+```
+
+Route protégée par header `Authorization: Bearer CRON_SECRET` (injecté automatiquement par Vercel).
+
+### Séquence d'exécution du job
+
+```
+1. Charger toutes les Circles PUBLIC non exclues
+   (avec agrégats : memberCount, pastEventCount, hasCover, etc.)
+
+2. Pour chaque Circle :
+   a. Calculer raw_score
+   b. Normaliser → score 0–100
+   c. Si isDemo → Math.min(score, 30)
+   d. Si overrideScore != null → utiliser overrideScore directement
+   e. Écrire explorerScore + scoreUpdatedAt
+
+3. Charger tous les Moments PUBLISHED à venir (circle PUBLIC, non exclu)
+   (avec agrégats : registrantCount, hasCover, hasLocation, etc.)
+
+4. Pour chaque Moment :
+   a. Récupérer explorerScore du Circle parent (déjà calculé à l'étape 2)
+   b. Calculer moment_raw
+   c. score_moment = round(score_circle * 0.5 + moment_raw * 0.5)
+   d. Si circle.isDemo → Math.min(score_moment, 30)
+   e. Écrire explorerScore
+
+5. Logger : nb circles mis à jour, nb moments mis à jour, durée
+```
+
+### Ce qui reste temps réel
+
+La section **"À la une"** : random seedé par date sur une petite pool (`WHERE coverImageUrl != null AND isDemo = false AND excludedFromExplorer = false`). Calculé à la requête, aucune agrégation lourde — quelques ms.
+
+### Évolutivité
+
+Passer à 2x/jour ou 4x/jour si nécessaire : modifier uniquement le `schedule` cron, aucun changement d'architecture.
 
 ---
 
 ## Décisions prises
 
 | Date | Décision |
-|---|---|
+| --- | --- |
 | 2026-03-13 | Score interne non exposé aux utilisateurs — invisible, uniquement pour le tri |
-| 2026-03-13 | Exclusion absolue des emails @test.playground et @demo.playground |
+| 2026-03-13 | Exclusion absolue : @test.playground uniquement — jamais affichés sur Explorer |
 | 2026-03-13 | Score Communauté et score Événement découplés (dans une certaine mesure) |
 | 2026-03-13 | Cover image = signal fort (visibilité des communautés qui rendent bien) |
 | 2026-03-13 | Description = signal fort avec seuil minimum de longueur (filtre les descriptions "test") |
 | 2026-03-13 | Seuil description : 30 caractères |
 | 2026-03-13 | Seuil ancienneté : 1 jour (filtre les comptes du jour uniquement) |
-| 2026-03-13 | Score normalisé 0–100 : `Math.round((raw_score / 200) * 100)` |
-| 2026-03-13 | Binaire = 65% du score max (plancher qualité), quantitatif = 35% (différenciateur entre vraies communautés) |
+| 2026-03-13 | Score normalisé 0–100 : `Math.round((raw_score / 205) * 100)` |
+| 2026-03-13 | Binaire = 37% du score max, quantitatif = 63% — les métriques d'activité dominent |
 | 2026-03-13 | Quantitatif : plafond linéaire `min(n × coeff, cap)` — simple à raisonner, évite la dominance des très grandes communautés |
 | 2026-03-13 | Ville supprimée des signaux — non pertinente comme signal de qualité |
 | 2026-03-13 | Catégorie : signal faible → moyen (+7 pts) |
@@ -259,3 +345,9 @@ Deux écrans dédiés :
 | 2026-03-13 | Seuil "à la une" volontairement bas (cover only) pour garantir un pool large au lancement |
 | 2026-03-13 | Override admin : `excludedFromExplorer` (boolean) + `overrideScore` (Int?) sur Circle uniquement |
 | 2026-03-13 | Override géré exclusivement depuis le backend admin (/admin/*) — deux écrans : liste Explorer + détail Circle |
+| 2026-03-13 | Communautés @demo.playground : `isDemo: true`, score capé à 30/100, badge "Démo" sur cards Communauté ET Événement |
+| 2026-03-13 | Cap démo à 30 provisoire — à tuner selon la densité du catalogue au lancement |
+| 2026-03-13 | Démos mélangées dans la liste (pas reléguées en fin) — donnent de la consistance à Explorer pendant le lancement |
+| 2026-03-13 | Architecture : batch quotidien à 3h00 via Vercel Cron — score persisté en DB, requête Explorer = ORDER BY index |
+| 2026-03-13 | Champs DB : `explorerScore Int` + `scoreUpdatedAt DateTime?` sur Circle, `explorerScore Int` sur Moment |
+| 2026-03-13 | Section "À la une" reste temps réel (random sur petite pool, aucune agrégation) |

--- a/src/app/api/cron/recalculate-scores/route.ts
+++ b/src/app/api/cron/recalculate-scores/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/infrastructure/db/prisma";
+import { excludeTestHostFilter } from "@/infrastructure/db/explorer-filters";
 import {
   calculateCircleScore,
   calculateMomentScore,
@@ -23,156 +24,151 @@ export async function POST(request: NextRequest) {
   const startedAt = Date.now();
   const now = new Date();
 
-  // 2. Calcul des scores Communautés (étape 1 & 2)
-  const circles = await prisma.circle.findMany({
-    where: {
-      visibility: "PUBLIC",
-      excludedFromExplorer: false,
-      NOT: {
-        memberships: {
-          some: {
-            role: "HOST",
-            user: { email: { endsWith: "@test.playground" } },
-          },
-        },
-      },
-    },
-    select: {
-      id: true,
-      description: true,
-      coverImage: true,
-      category: true,
-      createdAt: true,
-      isDemo: true,
-      overrideScore: true,
-      _count: {
-        select: {
-          memberships: { where: { role: "PLAYER" } },
-        },
-      },
-      moments: {
-        select: {
-          status: true,
-          startsAt: true,
-          _count: {
-            select: {
-              registrations: { where: { status: "REGISTERED" } },
-            },
-          },
-        },
-      },
-    },
-  });
-
-  const circleScoreMap = new Map<string, number>();
-
-  await Promise.all(
-    circles.map((circle) => {
-      const pastMoments = circle.moments.filter((m) => m.status === "PAST");
-      const hasPastEventWithRegistrant = pastMoments.some(
-        (m) => m._count.registrations > 0
-      );
-      const pastEventCount = pastMoments.length;
-      const hasUpcomingEvent = circle.moments.some(
-        (m) => m.status === "PUBLISHED" && m.startsAt > now
-      );
-
-      const score = calculateCircleScore({
-        description: circle.description,
-        coverImage: circle.coverImage,
-        category: circle.category,
-        createdAt: circle.createdAt,
-        isDemo: circle.isDemo,
-        overrideScore: circle.overrideScore,
-        memberCount: circle._count.memberships,
-        pastEventCount,
-        hasPastEventWithRegistrant,
-        hasUpcomingEvent,
-      });
-
-      circleScoreMap.set(circle.id, score);
-
-      return prisma.circle.update({
-        where: { id: circle.id },
-        data: { explorerScore: score, scoreUpdatedAt: now },
-      });
-    })
-  );
-
-  const circlesDuration = Date.now() - startedAt;
-  console.log(
-    `[recalculate-scores] Circles: ${circles.length} mis à jour en ${circlesDuration}ms`
-  );
-
-  // 3. Calcul des scores événements (étape 3 & 4)
-  const moments = await prisma.moment.findMany({
-    where: {
-      status: "PUBLISHED",
-      startsAt: { gte: now },
-      circle: {
+  try {
+    // 2. Calcul des scores Communautés (étape 1 & 2)
+    const circles = await prisma.circle.findMany({
+      where: {
         visibility: "PUBLIC",
         excludedFromExplorer: false,
-        NOT: {
-          memberships: {
-            some: {
-              role: "HOST",
-              user: { email: { endsWith: "@test.playground" } },
+        NOT: excludeTestHostFilter(),
+      },
+      select: {
+        id: true,
+        description: true,
+        coverImage: true,
+        category: true,
+        createdAt: true,
+        isDemo: true,
+        overrideScore: true,
+        _count: {
+          select: {
+            memberships: { where: { role: "PLAYER" } },
+          },
+        },
+        moments: {
+          select: {
+            status: true,
+            startsAt: true,
+            _count: {
+              select: {
+                registrations: { where: { status: "REGISTERED" } },
+              },
             },
           },
         },
       },
-    },
-    select: {
-      id: true,
-      description: true,
-      coverImage: true,
-      locationName: true,
-      circle: {
-        select: {
-          id: true,
-          explorerScore: true,
-          isDemo: true,
+    });
+
+    const circleScoreMap = new Map<string, number>();
+
+    await prisma.$transaction(
+      circles.map((circle) => {
+        const pastMoments = circle.moments.filter((m) => m.status === "PAST");
+        const hasPastEventWithRegistrant = pastMoments.some(
+          (m) => m._count.registrations > 0
+        );
+        const pastEventCount = pastMoments.length;
+        const hasUpcomingEvent = circle.moments.some(
+          (m) => m.status === "PUBLISHED" && m.startsAt > now
+        );
+
+        const score = calculateCircleScore({
+          description: circle.description,
+          coverImage: circle.coverImage,
+          category: circle.category,
+          createdAt: circle.createdAt,
+          isDemo: circle.isDemo,
+          overrideScore: circle.overrideScore,
+          memberCount: circle._count.memberships,
+          pastEventCount,
+          hasPastEventWithRegistrant,
+          hasUpcomingEvent,
+        });
+
+        circleScoreMap.set(circle.id, score);
+
+        return prisma.circle.update({
+          where: { id: circle.id },
+          data: { explorerScore: score, scoreUpdatedAt: now },
+        });
+      })
+    );
+
+    const circlesDuration = Date.now() - startedAt;
+    console.log(
+      `[recalculate-scores] Circles: ${circles.length} mis à jour en ${circlesDuration}ms`
+    );
+
+    // 3. Calcul des scores événements (étape 3 & 4)
+    const moments = await prisma.moment.findMany({
+      where: {
+        status: "PUBLISHED",
+        startsAt: { gte: now },
+        circle: {
+          visibility: "PUBLIC",
+          excludedFromExplorer: false,
+          NOT: excludeTestHostFilter(),
         },
       },
-      _count: {
-        select: {
-          registrations: { where: { status: "REGISTERED" } },
+      select: {
+        id: true,
+        description: true,
+        coverImage: true,
+        locationName: true,
+        circle: {
+          select: {
+            id: true,
+            explorerScore: true,
+            isDemo: true,
+          },
+        },
+        _count: {
+          select: {
+            registrations: { where: { status: "REGISTERED" } },
+          },
         },
       },
-    },
-  });
+    });
 
-  await Promise.all(
-    moments.map((moment) => {
-      // Priorité au score fraîchement calculé en mémoire, fallback sur la valeur persistée
-      const circleScore =
-        circleScoreMap.get(moment.circle.id) ?? moment.circle.explorerScore ?? 0;
+    await prisma.$transaction(
+      moments.map((moment) => {
+        // Priorité au score fraîchement calculé en mémoire, fallback sur la valeur persistée
+        const circleScore =
+          circleScoreMap.get(moment.circle.id) ?? moment.circle.explorerScore ?? 0;
 
-      const score = calculateMomentScore({
-        description: moment.description,
-        coverImage: moment.coverImage,
-        locationName: moment.locationName,
-        registrantCount: moment._count.registrations,
-        circleScore,
-        circleIsDemo: moment.circle.isDemo,
-      });
+        const score = calculateMomentScore({
+          description: moment.description,
+          coverImage: moment.coverImage,
+          locationName: moment.locationName,
+          registrantCount: moment._count.registrations,
+          circleScore,
+          circleIsDemo: moment.circle.isDemo,
+        });
 
-      return prisma.moment.update({
-        where: { id: moment.id },
-        data: { explorerScore: score },
-      });
-    })
-  );
+        return prisma.moment.update({
+          where: { id: moment.id },
+          data: { explorerScore: score },
+        });
+      })
+    );
 
-  const totalDuration = Date.now() - startedAt;
-  console.log(
-    `[recalculate-scores] Moments: ${moments.length} mis à jour en ${totalDuration}ms`
-  );
+    const totalDuration = Date.now() - startedAt;
+    console.log(
+      `[recalculate-scores] Moments: ${moments.length} mis à jour en ${totalDuration}ms`
+    );
 
-  return NextResponse.json({
-    success: true,
-    circles: circles.length,
-    moments: moments.length,
-    durationMs: totalDuration,
-  });
+    return NextResponse.json({
+      success: true,
+      circles: circles.length,
+      moments: moments.length,
+      durationMs: totalDuration,
+    });
+  } catch (error) {
+    const duration = Date.now() - startedAt;
+    console.error(`[recalculate-scores] Erreur après ${duration}ms :`, error);
+    return NextResponse.json(
+      { error: "Score recalculation failed" },
+      { status: 500 }
+    );
+  }
 }

--- a/src/app/api/cron/recalculate-scores/route.ts
+++ b/src/app/api/cron/recalculate-scores/route.ts
@@ -1,0 +1,178 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/infrastructure/db/prisma";
+import {
+  calculateCircleScore,
+  calculateMomentScore,
+} from "@/infrastructure/services/explorer-score.service";
+
+/**
+ * POST /api/cron/recalculate-scores
+ *
+ * Batch quotidien de recalcul des scores Explorer pour les Communautés et événements publics.
+ * Déclenché chaque nuit à 3h via Vercel Cron (vercel.json).
+ *
+ * Protection : header Authorization: Bearer CRON_SECRET
+ */
+export async function POST(request: NextRequest) {
+  // 1. Auth check
+  const authHeader = request.headers.get("authorization");
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const startedAt = Date.now();
+  const now = new Date();
+
+  // 2. Calcul des scores Communautés (étape 1 & 2)
+  const circles = await prisma.circle.findMany({
+    where: {
+      visibility: "PUBLIC",
+      excludedFromExplorer: false,
+      NOT: {
+        memberships: {
+          some: {
+            role: "HOST",
+            user: { email: { endsWith: "@test.playground" } },
+          },
+        },
+      },
+    },
+    select: {
+      id: true,
+      description: true,
+      coverImage: true,
+      category: true,
+      createdAt: true,
+      isDemo: true,
+      overrideScore: true,
+      _count: {
+        select: {
+          memberships: { where: { role: "PLAYER" } },
+        },
+      },
+      moments: {
+        select: {
+          status: true,
+          startsAt: true,
+          _count: {
+            select: {
+              registrations: { where: { status: "REGISTERED" } },
+            },
+          },
+        },
+      },
+    },
+  });
+
+  const circleScoreMap = new Map<string, number>();
+
+  await Promise.all(
+    circles.map((circle) => {
+      const pastMoments = circle.moments.filter((m) => m.status === "PAST");
+      const hasPastEventWithRegistrant = pastMoments.some(
+        (m) => m._count.registrations > 0
+      );
+      const pastEventCount = pastMoments.length;
+      const hasUpcomingEvent = circle.moments.some(
+        (m) => m.status === "PUBLISHED" && m.startsAt > now
+      );
+
+      const score = calculateCircleScore({
+        description: circle.description,
+        coverImage: circle.coverImage,
+        category: circle.category,
+        createdAt: circle.createdAt,
+        isDemo: circle.isDemo,
+        overrideScore: circle.overrideScore,
+        memberCount: circle._count.memberships,
+        pastEventCount,
+        hasPastEventWithRegistrant,
+        hasUpcomingEvent,
+      });
+
+      circleScoreMap.set(circle.id, score);
+
+      return prisma.circle.update({
+        where: { id: circle.id },
+        data: { explorerScore: score, scoreUpdatedAt: now },
+      });
+    })
+  );
+
+  const circlesDuration = Date.now() - startedAt;
+  console.log(
+    `[recalculate-scores] Circles: ${circles.length} mis à jour en ${circlesDuration}ms`
+  );
+
+  // 3. Calcul des scores événements (étape 3 & 4)
+  const moments = await prisma.moment.findMany({
+    where: {
+      status: "PUBLISHED",
+      startsAt: { gte: now },
+      circle: {
+        visibility: "PUBLIC",
+        excludedFromExplorer: false,
+        NOT: {
+          memberships: {
+            some: {
+              role: "HOST",
+              user: { email: { endsWith: "@test.playground" } },
+            },
+          },
+        },
+      },
+    },
+    select: {
+      id: true,
+      description: true,
+      coverImage: true,
+      locationName: true,
+      circle: {
+        select: {
+          id: true,
+          explorerScore: true,
+          isDemo: true,
+        },
+      },
+      _count: {
+        select: {
+          registrations: { where: { status: "REGISTERED" } },
+        },
+      },
+    },
+  });
+
+  await Promise.all(
+    moments.map((moment) => {
+      // Priorité au score fraîchement calculé en mémoire, fallback sur la valeur persistée
+      const circleScore =
+        circleScoreMap.get(moment.circle.id) ?? moment.circle.explorerScore ?? 0;
+
+      const score = calculateMomentScore({
+        description: moment.description,
+        coverImage: moment.coverImage,
+        locationName: moment.locationName,
+        registrantCount: moment._count.registrations,
+        circleScore,
+        circleIsDemo: moment.circle.isDemo,
+      });
+
+      return prisma.moment.update({
+        where: { id: moment.id },
+        data: { explorerScore: score },
+      });
+    })
+  );
+
+  const totalDuration = Date.now() - startedAt;
+  console.log(
+    `[recalculate-scores] Moments: ${moments.length} mis à jour en ${totalDuration}ms`
+  );
+
+  return NextResponse.json({
+    success: true,
+    circles: circles.length,
+    moments: moments.length,
+    durationMs: totalDuration,
+  });
+}

--- a/src/domain/ports/repositories/circle-repository.ts
+++ b/src/domain/ports/repositories/circle-repository.ts
@@ -50,6 +50,8 @@ export type PublicCircle = {
     title: string;
     startsAt: Date;
   } | null;
+  isDemo: boolean;
+  explorerScore: number;
 };
 
 export type CircleFollowerInfo = {

--- a/src/domain/ports/repositories/circle-repository.ts
+++ b/src/domain/ports/repositories/circle-repository.ts
@@ -61,6 +61,20 @@ export type CircleFollowerInfo = {
   lastName: string | null;
 };
 
+export type FeaturedCircle = {
+  id: string;
+  slug: string;
+  name: string;
+  description: string;
+  category: CircleCategory | null;
+  customCategory: string | null;
+  city: string | null;
+  coverImage: string; // non-null garanti (condition du pool)
+  coverImageAttribution: CoverImageAttribution | null;
+  memberCount: number;
+  upcomingMomentCount: number;
+};
+
 export interface CircleRepository {
   create(input: CreateCircleInput): Promise<Circle>;
   findByInviteToken(token: string): Promise<Circle | null>;
@@ -95,4 +109,6 @@ export interface CircleRepository {
   findPlayersForNewMomentNotification(circleId: string, excludeUserId: string): Promise<CircleFollowerInfo[]>;
   /** Communautés publiques dont l'utilisateur est membre — pour la page profil public. */
   getPublicCirclesForUser(userId: string): Promise<PublicCircleMembership[]>;
+  /** 3 communautés sélectionnées aléatoirement (seed = date du jour) pour la section "À la une". */
+  findFeatured(): Promise<FeaturedCircle[]>;
 }

--- a/src/domain/ports/repositories/moment-repository.ts
+++ b/src/domain/ports/repositories/moment-repository.ts
@@ -59,11 +59,13 @@ export type PublicMoment = {
   locationName: string | null;
   registrationCount: number;
   capacity: number | null;
+  explorerScore: number;
   circle: {
     slug: string;
     name: string;
     category: CircleCategory | null;
     city: string | null;
+    isDemo: boolean;
   };
 };
 

--- a/src/domain/usecases/__tests__/get-featured-circles.test.ts
+++ b/src/domain/usecases/__tests__/get-featured-circles.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi } from "vitest";
+import { getFeaturedCircles } from "@/domain/usecases/get-featured-circles";
+import { createMockCircleRepository } from "./helpers/mock-circle-repository";
+import type { FeaturedCircle } from "@/domain/ports/repositories/circle-repository";
+
+function makeFeaturedCircle(overrides: Partial<FeaturedCircle> = {}): FeaturedCircle {
+  return {
+    id: "circle-1",
+    slug: "tech-paris",
+    name: "Tech Paris",
+    description: "Tech community in Paris",
+    category: "TECH",
+    customCategory: null,
+    city: "Paris",
+    coverImage: "https://example.com/cover.jpg",
+    coverImageAttribution: null,
+    memberCount: 42,
+    upcomingMomentCount: 3,
+    ...overrides,
+  };
+}
+
+describe("getFeaturedCircles", () => {
+  describe("given circles in the featured pool", () => {
+    it("should return featured circles from repository", async () => {
+      const featured = [
+        makeFeaturedCircle({ id: "circle-1", slug: "tech-paris" }),
+        makeFeaturedCircle({ id: "circle-2", slug: "design-lyon", city: "Lyon" }),
+        makeFeaturedCircle({ id: "circle-3", slug: "startup-bordeaux", city: "Bordeaux" }),
+      ];
+      const circleRepository = createMockCircleRepository({
+        findFeatured: vi.fn().mockResolvedValue(featured),
+      });
+
+      const result = await getFeaturedCircles({ circleRepository });
+
+      expect(circleRepository.findFeatured).toHaveBeenCalledOnce();
+      expect(result).toEqual(featured);
+      expect(result).toHaveLength(3);
+    });
+  });
+
+  describe("given an empty featured pool", () => {
+    it("should return empty array when pool is empty", async () => {
+      const circleRepository = createMockCircleRepository({
+        findFeatured: vi.fn().mockResolvedValue([]),
+      });
+
+      const result = await getFeaturedCircles({ circleRepository });
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("given fewer than 3 eligible circles", () => {
+    it("should return fewer than 3 if pool has fewer than 3 eligible circles", async () => {
+      const featured = [
+        makeFeaturedCircle({ id: "circle-1", slug: "tech-paris" }),
+        makeFeaturedCircle({ id: "circle-2", slug: "design-lyon", city: "Lyon" }),
+      ];
+      const circleRepository = createMockCircleRepository({
+        findFeatured: vi.fn().mockResolvedValue(featured),
+      });
+
+      const result = await getFeaturedCircles({ circleRepository });
+
+      expect(result).toHaveLength(2);
+      expect(result[0].slug).toBe("tech-paris");
+      expect(result[1].slug).toBe("design-lyon");
+    });
+  });
+});

--- a/src/domain/usecases/__tests__/get-public-circles.test.ts
+++ b/src/domain/usecases/__tests__/get-public-circles.test.ts
@@ -17,6 +17,8 @@ function makePublicCircle(overrides: Partial<PublicCircle> = {}): PublicCircle {
     memberCount: 42,
     upcomingMomentCount: 3,
     nextMoment: { title: "Meetup React", startsAt: new Date("2026-03-15T18:00:00Z") },
+    isDemo: false,
+    explorerScore: 0,
     ...overrides,
   };
 }

--- a/src/domain/usecases/__tests__/get-public-upcoming-moments.test.ts
+++ b/src/domain/usecases/__tests__/get-public-upcoming-moments.test.ts
@@ -21,7 +21,9 @@ function makePublicMoment(overrides: Partial<PublicMoment> = {}): PublicMoment {
       name: "Tech Paris",
       category: "TECH",
       city: "Paris",
+      isDemo: false,
     },
+    explorerScore: 0,
     ...overrides,
   };
 }

--- a/src/domain/usecases/__tests__/helpers/mock-circle-repository.ts
+++ b/src/domain/usecases/__tests__/helpers/mock-circle-repository.ts
@@ -31,6 +31,7 @@ export function createMockCircleRepository(
     findPlayersForNewMomentNotification: vi.fn<CircleRepository["findPlayersForNewMomentNotification"]>().mockResolvedValue([]),
     findByInviteToken: vi.fn<CircleRepository["findByInviteToken"]>().mockResolvedValue(null),
     getPublicCirclesForUser: vi.fn<CircleRepository["getPublicCirclesForUser"]>().mockResolvedValue([]),
+    findFeatured: vi.fn<CircleRepository["findFeatured"]>().mockResolvedValue([]),
     ...overrides,
   };
 }

--- a/src/domain/usecases/get-featured-circles.ts
+++ b/src/domain/usecases/get-featured-circles.ts
@@ -1,0 +1,11 @@
+import type { CircleRepository, FeaturedCircle } from "@/domain/ports/repositories/circle-repository";
+
+type GetFeaturedCirclesDeps = {
+  circleRepository: CircleRepository;
+};
+
+export async function getFeaturedCircles(
+  deps: GetFeaturedCirclesDeps
+): Promise<FeaturedCircle[]> {
+  return deps.circleRepository.findFeatured();
+}

--- a/src/infrastructure/db/explorer-filters.ts
+++ b/src/infrastructure/db/explorer-filters.ts
@@ -1,0 +1,24 @@
+/**
+ * Filtres Prisma partagés pour la page Explorer.
+ *
+ * Centralise les règles d'exclusion appliquées dans les repositories Explorer
+ * et la cron route de recalcul des scores.
+ */
+
+/** Suffixe email des comptes de test — jamais affichés sur Explorer. */
+export const TEST_EMAIL_SUFFIX = "@test.playground";
+
+/**
+ * Retourne le filtre Prisma excluant les Circles dont le Host est un compte de test.
+ * À combiner dans le champ `NOT` d'un `circle.findMany()`.
+ */
+export function excludeTestHostFilter() {
+  return {
+    memberships: {
+      some: {
+        role: "HOST" as const,
+        user: { email: { endsWith: TEST_EMAIL_SUFFIX } },
+      },
+    },
+  };
+}

--- a/src/infrastructure/repositories/prisma-circle-repository.ts
+++ b/src/infrastructure/repositories/prisma-circle-repository.ts
@@ -6,7 +6,9 @@ import type {
   PublicCircleFilters,
   PublicCircle,
   CircleFollowerInfo,
+  FeaturedCircle,
 } from "@/domain/ports/repositories/circle-repository";
+import { seededShuffle } from "@/lib/seeded-shuffle";
 import type { Circle, CircleCategory, CircleMembership, CircleMemberRole, CircleMemberWithUser, CircleWithRole, CoverImageAttribution, CircleFollow, DashboardCircle } from "@/domain/models/circle";
 import type { PublicCircleMembership } from "@/domain/models/user";
 import type { Circle as PrismaCircle, CircleMembership as PrismaMembership } from "@prisma/client";
@@ -462,6 +464,65 @@ export const prismaCircleRepository: CircleRepository = {
       email: r.user.email,
       firstName: r.user.firstName,
       lastName: r.user.lastName,
+    }));
+  },
+
+  async findFeatured(): Promise<FeaturedCircle[]> {
+    const circles = await prisma.circle.findMany({
+      where: {
+        visibility: "PUBLIC",
+        coverImage: { not: null },
+        excludedFromExplorer: false,
+        isDemo: false,
+        NOT: {
+          memberships: {
+            some: {
+              role: "HOST",
+              user: { email: { endsWith: "@test.playground" } },
+            },
+          },
+        },
+      },
+      select: {
+        id: true,
+        slug: true,
+        name: true,
+        description: true,
+        category: true,
+        customCategory: true,
+        city: true,
+        coverImage: true,
+        coverImageAttribution: true,
+        _count: {
+          select: {
+            memberships: true,
+            moments: {
+              where: {
+                status: "PUBLISHED",
+                startsAt: { gte: new Date() },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    // Seed = date du jour (YYYY-MM-DD) → sélection stable sur 24h
+    const today = new Date().toISOString().slice(0, 10);
+    const shuffled = seededShuffle(circles, today);
+
+    return shuffled.slice(0, 3).map((c) => ({
+      id: c.id,
+      slug: c.slug,
+      name: c.name,
+      description: c.description,
+      category: c.category ?? null,
+      customCategory: c.customCategory ?? null,
+      city: c.city ?? null,
+      coverImage: c.coverImage!, // non-null garanti par le WHERE
+      coverImageAttribution: c.coverImageAttribution as CoverImageAttribution | null,
+      memberCount: c._count.memberships,
+      upcomingMomentCount: c._count.moments,
     }));
   },
 

--- a/src/infrastructure/repositories/prisma-circle-repository.ts
+++ b/src/infrastructure/repositories/prisma-circle-repository.ts
@@ -322,6 +322,33 @@ export const prismaCircleRepository: CircleRepository = {
       where: {
         visibility: "PUBLIC",
         ...(filters.category && { category: filters.category }),
+        // Exclure les circles admin-exclus
+        excludedFromExplorer: false,
+        // Exclure les circles dont le host a un email @test.playground
+        NOT: {
+          memberships: {
+            some: {
+              role: "HOST",
+              user: { email: { endsWith: "@test.playground" } },
+            },
+          },
+        },
+        // Seuil d'affichage : ≥1 membre réel (PLAYER) OU ≥1 event publié à venir
+        OR: [
+          {
+            memberships: {
+              some: { role: "PLAYER" },
+            },
+          },
+          {
+            moments: {
+              some: {
+                status: "PUBLISHED",
+                startsAt: { gte: now },
+              },
+            },
+          },
+        ],
       },
       include: {
         // Comptes SQL précis — aucun enregistrement Moment chargé en mémoire pour le count
@@ -341,9 +368,10 @@ export const prismaCircleRepository: CircleRepository = {
           select: { title: true, startsAt: true },
         },
       },
-      orderBy: filters.sortBy === "popular"
-        ? { memberships: { _count: "desc" } }
-        : { createdAt: "desc" },
+      orderBy:
+        filters.sortBy === "date"
+          ? { createdAt: "desc" }
+          : [{ explorerScore: "desc" }, { createdAt: "desc" }],
       take: filters.limit ?? 20,
       skip: filters.offset ?? 0,
     });
@@ -364,6 +392,8 @@ export const prismaCircleRepository: CircleRepository = {
       // upcomingMomentCount issu du _count SQL, pas de moments.length
       upcomingMomentCount: c._count.moments,
       nextMoment: c.moments[0] ?? null,
+      isDemo: c.isDemo,
+      explorerScore: c.explorerScore,
     }));
   },
 

--- a/src/infrastructure/repositories/prisma-circle-repository.ts
+++ b/src/infrastructure/repositories/prisma-circle-repository.ts
@@ -1,4 +1,5 @@
 import { prisma, Prisma } from "@/infrastructure/db/prisma";
+import { excludeTestHostFilter } from "@/infrastructure/db/explorer-filters";
 import type {
   CircleRepository,
   CreateCircleInput,
@@ -326,15 +327,8 @@ export const prismaCircleRepository: CircleRepository = {
         ...(filters.category && { category: filters.category }),
         // Exclure les circles admin-exclus
         excludedFromExplorer: false,
-        // Exclure les circles dont le host a un email @test.playground
-        NOT: {
-          memberships: {
-            some: {
-              role: "HOST",
-              user: { email: { endsWith: "@test.playground" } },
-            },
-          },
-        },
+        // Exclure les circles dont le host est un compte de test
+        NOT: excludeTestHostFilter(),
         // Seuil d'affichage : ≥1 membre réel (PLAYER) OU ≥1 event publié à venir
         OR: [
           {
@@ -468,21 +462,30 @@ export const prismaCircleRepository: CircleRepository = {
   },
 
   async findFeatured(): Promise<FeaturedCircle[]> {
+    const featuredWhere = {
+      visibility: "PUBLIC" as const,
+      coverImage: { not: null as null },
+      excludedFromExplorer: false,
+      isDemo: false,
+      NOT: excludeTestHostFilter(),
+    };
+
+    // Charger uniquement les IDs pour le shuffle (évite de lire toutes les colonnes)
+    const rows = await prisma.circle.findMany({
+      where: featuredWhere,
+      select: { id: true },
+    });
+
+    if (rows.length === 0) return [];
+
+    // Seed = date du jour (YYYY-MM-DD) → sélection stable sur 24h
+    const today = new Date().toISOString().slice(0, 10);
+    const selectedIds = seededShuffle(rows, today).slice(0, 3).map((r) => r.id);
+
+    // Charger uniquement les 3 circles sélectionnés avec toutes leurs colonnes
+    const now = new Date();
     const circles = await prisma.circle.findMany({
-      where: {
-        visibility: "PUBLIC",
-        coverImage: { not: null },
-        excludedFromExplorer: false,
-        isDemo: false,
-        NOT: {
-          memberships: {
-            some: {
-              role: "HOST",
-              user: { email: { endsWith: "@test.playground" } },
-            },
-          },
-        },
-      },
+      where: { id: { in: selectedIds } },
       select: {
         id: true,
         slug: true,
@@ -497,33 +500,33 @@ export const prismaCircleRepository: CircleRepository = {
           select: {
             memberships: true,
             moments: {
-              where: {
-                status: "PUBLISHED",
-                startsAt: { gte: new Date() },
-              },
+              where: { status: "PUBLISHED", startsAt: { gte: now } },
             },
           },
         },
       },
     });
 
-    // Seed = date du jour (YYYY-MM-DD) → sélection stable sur 24h
-    const today = new Date().toISOString().slice(0, 10);
-    const shuffled = seededShuffle(circles, today);
+    // Conserver l'ordre du shuffle (WHERE id IN ne garantit pas l'ordre)
+    const byId = new Map(circles.map((c) => [c.id, c]));
 
-    return shuffled.slice(0, 3).map((c) => ({
-      id: c.id,
-      slug: c.slug,
-      name: c.name,
-      description: c.description,
-      category: c.category ?? null,
-      customCategory: c.customCategory ?? null,
-      city: c.city ?? null,
-      coverImage: c.coverImage!, // non-null garanti par le WHERE
-      coverImageAttribution: c.coverImageAttribution as CoverImageAttribution | null,
-      memberCount: c._count.memberships,
-      upcomingMomentCount: c._count.moments,
-    }));
+    return selectedIds.flatMap((id) => {
+      const c = byId.get(id);
+      if (!c) return [];
+      return [{
+        id: c.id,
+        slug: c.slug,
+        name: c.name,
+        description: c.description,
+        category: c.category ?? null,
+        customCategory: c.customCategory ?? null,
+        city: c.city ?? null,
+        coverImage: c.coverImage!, // non-null garanti par le WHERE
+        coverImageAttribution: c.coverImageAttribution as CoverImageAttribution | null,
+        memberCount: c._count.memberships,
+        upcomingMomentCount: c._count.moments,
+      }];
+    });
   },
 
   async getPublicCirclesForUser(userId: string): Promise<PublicCircleMembership[]> {

--- a/src/infrastructure/repositories/prisma-moment-repository.ts
+++ b/src/infrastructure/repositories/prisma-moment-repository.ts
@@ -135,22 +135,34 @@ export const prismaMomentRepository: MomentRepository = {
 
   async findPublicUpcoming(filters: PublicMomentFilters): Promise<PublicMoment[]> {
     const now = new Date();
+    const orderBy =
+      filters.sortBy === "date"
+        ? { startsAt: "asc" as const }
+        : [{ explorerScore: "desc" as const }, { startsAt: "asc" as const }];
+
     const moments = await prisma.moment.findMany({
       where: {
         status: "PUBLISHED",
         startsAt: { gte: now },
         circle: {
           visibility: "PUBLIC",
+          excludedFromExplorer: false,
+          NOT: {
+            memberships: {
+              some: {
+                role: "HOST",
+                user: { email: { endsWith: "@test.playground" } },
+              },
+            },
+          },
           ...(filters.category && { category: filters.category }),
         },
       },
       include: {
-        circle: { select: { slug: true, name: true, category: true, city: true } },
+        circle: { select: { slug: true, name: true, category: true, city: true, isDemo: true } },
         _count: { select: { registrations: { where: { status: "REGISTERED" } } } },
       },
-      orderBy: filters.sortBy === "popular"
-        ? { registrations: { _count: "desc" } }
-        : { startsAt: "asc" },
+      orderBy,
       take: filters.limit ?? 20,
       skip: filters.offset ?? 0,
     });
@@ -167,11 +179,13 @@ export const prismaMomentRepository: MomentRepository = {
       locationName: m.locationName,
       registrationCount: m._count.registrations,
       capacity: m.capacity,
+      explorerScore: m.explorerScore,
       circle: {
         slug: m.circle.slug,
         name: m.circle.name,
         category: m.circle.category ?? null,
         city: m.circle.city ?? null,
+        isDemo: m.circle.isDemo,
       },
     }));
   },

--- a/src/infrastructure/repositories/prisma-moment-repository.ts
+++ b/src/infrastructure/repositories/prisma-moment-repository.ts
@@ -1,4 +1,5 @@
 import { prisma, Prisma } from "@/infrastructure/db/prisma";
+import { excludeTestHostFilter } from "@/infrastructure/db/explorer-filters";
 import type {
   MomentRepository,
   CreateMomentInput,
@@ -147,14 +148,7 @@ export const prismaMomentRepository: MomentRepository = {
         circle: {
           visibility: "PUBLIC",
           excludedFromExplorer: false,
-          NOT: {
-            memberships: {
-              some: {
-                role: "HOST",
-                user: { email: { endsWith: "@test.playground" } },
-              },
-            },
-          },
+          NOT: excludeTestHostFilter(),
           ...(filters.category && { category: filters.category }),
         },
       },

--- a/src/infrastructure/services/__tests__/explorer-score.service.test.ts
+++ b/src/infrastructure/services/__tests__/explorer-score.service.test.ts
@@ -59,7 +59,7 @@ describe("calculateCircleScore", () => {
         coverImage: "https://example.com/cover.jpg",
         hasUpcomingEvent: true,
         description: "Une communauté dédiée aux passionnés de tech parisiens.",
-        category: "tech",
+        category: "TECH",
         // createdAt = twoDaysAgo → ageInDays >= 1 ✓
         // raw = 18 + 15 + 10 + 7 + 5 = 55 → round(55/205*100) = 27
       });
@@ -74,7 +74,7 @@ describe("calculateCircleScore", () => {
         coverImage: "https://example.com/cover.jpg",
         hasPastEventWithRegistrant: true,
         hasUpcomingEvent: true,
-        category: "tech",
+        category: "TECH",
         // pas de description longue
         description: "Court.",
         memberCount: 3,
@@ -94,7 +94,7 @@ describe("calculateCircleScore", () => {
         hasPastEventWithRegistrant: true,
         hasUpcomingEvent: true,
         description: "Une communauté très active avec de nombreux événements.",
-        category: "sport",
+        category: "SPORT_WELLNESS",
         memberCount: 10,
         pastEventCount: 5,
         // raw = 20 + 18 + 15 + 10 + 7 + 5 + 80 + 50 = 205
@@ -141,7 +141,7 @@ describe("calculateCircleScore", () => {
         hasPastEventWithRegistrant: true,
         hasUpcomingEvent: true,
         description: "Une communauté démo bien remplie pour les tests.",
-        category: "design",
+        category: "DESIGN",
         memberCount: 8,
         pastEventCount: 4,
       });

--- a/src/infrastructure/services/__tests__/explorer-score.service.test.ts
+++ b/src/infrastructure/services/__tests__/explorer-score.service.test.ts
@@ -1,0 +1,390 @@
+import { describe, it, expect } from "vitest";
+import {
+  calculateCircleScore,
+  calculateMomentScore,
+  type CircleScoreInput,
+  type MomentScoreInput,
+} from "../explorer-score.service";
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+/** Date antérieure à 2 jours — satisfait la condition ageInDays >= 1. */
+const twoDaysAgo = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000);
+
+/** Date d'il y a 30 minutes — ne satisfait PAS ageInDays >= 1. */
+const thirtyMinutesAgo = new Date(Date.now() - 30 * 60 * 1000);
+
+/** Input Circle de base : tous les signaux binaires à false/null, quantitatifs à 0. */
+function baseCircleInput(
+  overrides: Partial<CircleScoreInput> = {}
+): CircleScoreInput {
+  return {
+    description: "",
+    coverImage: null,
+    category: null,
+    createdAt: twoDaysAgo,
+    isDemo: false,
+    overrideScore: null,
+    memberCount: 0,
+    pastEventCount: 0,
+    hasPastEventWithRegistrant: false,
+    hasUpcomingEvent: false,
+    ...overrides,
+  };
+}
+
+/** Input Moment de base : tous les signaux à leur valeur minimale. */
+function baseMomentInput(
+  overrides: Partial<MomentScoreInput> = {}
+): MomentScoreInput {
+  return {
+    description: "",
+    coverImage: null,
+    locationName: null,
+    registrantCount: 0,
+    circleScore: 0,
+    circleIsDemo: false,
+    ...overrides,
+  };
+}
+
+// ─── calculateCircleScore ────────────────────────────────────────────────────
+
+describe("calculateCircleScore", () => {
+  // ── Cas concrets de la spec ──────────────────────────────────────────────
+
+  describe("given a well-crafted new community (0 members, 1 upcoming event)", () => {
+    it("should return score 27", () => {
+      const input = baseCircleInput({
+        coverImage: "https://example.com/cover.jpg",
+        hasUpcomingEvent: true,
+        description: "Une communauté dédiée aux passionnés de tech parisiens.",
+        category: "tech",
+        // createdAt = twoDaysAgo → ageInDays >= 1 ✓
+        // raw = 18 + 15 + 10 + 7 + 5 = 55 → round(55/205*100) = 27
+      });
+
+      expect(calculateCircleScore(input)).toBe(27);
+    });
+  });
+
+  describe("given a community with 3 members, cover, 1 past event, 1 upcoming", () => {
+    it("should return score 48", () => {
+      const input = baseCircleInput({
+        coverImage: "https://example.com/cover.jpg",
+        hasPastEventWithRegistrant: true,
+        hasUpcomingEvent: true,
+        category: "tech",
+        // pas de description longue
+        description: "Court.",
+        memberCount: 3,
+        pastEventCount: 1,
+        // raw = 20 + 18 + 15 + 7 + 5 + (3*8=24) + (1*10=10) = 99
+        // round(99/205*100) = round(48.29) = 48
+      });
+
+      expect(calculateCircleScore(input)).toBe(48);
+    });
+  });
+
+  describe("given an established community with 10 members, 5 past events, all signals checked", () => {
+    it("should return score 100", () => {
+      const input = baseCircleInput({
+        coverImage: "https://example.com/cover.jpg",
+        hasPastEventWithRegistrant: true,
+        hasUpcomingEvent: true,
+        description: "Une communauté très active avec de nombreux événements.",
+        category: "sport",
+        memberCount: 10,
+        pastEventCount: 5,
+        // raw = 20 + 18 + 15 + 10 + 7 + 5 + 80 + 50 = 205
+        // round(205/205*100) = 100
+      });
+
+      expect(calculateCircleScore(input)).toBe(100);
+    });
+  });
+
+  // ── Override score ───────────────────────────────────────────────────────
+
+  describe("given overrideScore is set", () => {
+    it("should return overrideScore regardless of other inputs", () => {
+      const input = baseCircleInput({
+        overrideScore: 90,
+        // tous les autres signaux à 0 / null
+      });
+
+      expect(calculateCircleScore(input)).toBe(90);
+    });
+
+    it("should return overrideScore 0 when explicitly set to 0", () => {
+      const input = baseCircleInput({
+        overrideScore: 0,
+        coverImage: "https://example.com/cover.jpg",
+        memberCount: 10,
+      });
+
+      expect(calculateCircleScore(input)).toBe(0);
+    });
+  });
+
+  // ── Communautés démo ─────────────────────────────────────────────────────
+
+  describe("given a demo community (isDemo = true)", () => {
+    it("should cap score at 30 even when raw score would yield ~90/100", () => {
+      // Score brut élevé : tout coché, 8 membres, 4 events passés
+      // raw = 20+18+15+10+7+5+(8*8=64)+(4*10=40) = 179
+      // round(179/205*100) = round(87.3) = 87 → capé à 30
+      const input = baseCircleInput({
+        isDemo: true,
+        coverImage: "https://example.com/cover.jpg",
+        hasPastEventWithRegistrant: true,
+        hasUpcomingEvent: true,
+        description: "Une communauté démo bien remplie pour les tests.",
+        category: "design",
+        memberCount: 8,
+        pastEventCount: 4,
+      });
+
+      expect(calculateCircleScore(input)).toBe(30);
+    });
+
+    it("should not cap if the calculated score is already below 30", () => {
+      // raw = 5 (ageInDays only) → round(5/205*100) = round(2.4) = 2
+      const input = baseCircleInput({
+        isDemo: true,
+        hasUpcomingEvent: false,
+        memberCount: 0,
+        pastEventCount: 0,
+      });
+
+      expect(calculateCircleScore(input)).toBe(2);
+    });
+  });
+
+  // ── Signaux binaires ─────────────────────────────────────────────────────
+
+  describe("given binary signals", () => {
+    it("should add 20 pts for hasPastEventWithRegistrant", () => {
+      const without = calculateCircleScore(
+        baseCircleInput({ createdAt: thirtyMinutesAgo })
+      );
+      const with_ = calculateCircleScore(
+        baseCircleInput({
+          hasPastEventWithRegistrant: true,
+          createdAt: thirtyMinutesAgo,
+        })
+      );
+      // Δ en score brut = 20 → Δ normalisé ≈ round(20/205*100) = 10
+      expect(with_ - without).toBe(10);
+    });
+
+    it("should add 18 pts for cover image", () => {
+      const without = calculateCircleScore(
+        baseCircleInput({ createdAt: thirtyMinutesAgo })
+      );
+      const with_ = calculateCircleScore(
+        baseCircleInput({
+          coverImage: "https://example.com/cover.jpg",
+          createdAt: thirtyMinutesAgo,
+        })
+      );
+      // Δ brut = 18 → round(18/205*100) = 9
+      expect(with_ - without).toBe(9);
+    });
+
+    it("should not award ageInDays bonus for a community created less than 1 day ago", () => {
+      const input = baseCircleInput({
+        createdAt: thirtyMinutesAgo,
+        hasUpcomingEvent: true, // pour qu'elle soit éligible Explorer
+      });
+      // raw sans âge = 15; round(15/205*100) = 7
+      expect(calculateCircleScore(input)).toBe(7);
+    });
+
+    it("should award ageInDays bonus for a community created more than 1 day ago", () => {
+      const input = baseCircleInput({
+        createdAt: twoDaysAgo,
+        hasUpcomingEvent: true,
+      });
+      // raw = 15 + 5 = 20; round(20/205*100) = 10
+      expect(calculateCircleScore(input)).toBe(10);
+    });
+  });
+
+  // ── Caps quantitatifs ────────────────────────────────────────────────────
+
+  describe("given quantitative signals caps", () => {
+    it("should cap member score at 80 pts (≥ 10 members)", () => {
+      const at10 = calculateCircleScore(
+        baseCircleInput({ memberCount: 10, createdAt: thirtyMinutesAgo })
+      );
+      const at20 = calculateCircleScore(
+        baseCircleInput({ memberCount: 20, createdAt: thirtyMinutesAgo })
+      );
+      // Les deux doivent avoir le même score (cap atteint)
+      expect(at10).toBe(at20);
+    });
+
+    it("should cap past events score at 50 pts (≥ 5 past events)", () => {
+      const at5 = calculateCircleScore(
+        baseCircleInput({ pastEventCount: 5, createdAt: thirtyMinutesAgo })
+      );
+      const at10 = calculateCircleScore(
+        baseCircleInput({ pastEventCount: 10, createdAt: thirtyMinutesAgo })
+      );
+      expect(at5).toBe(at10);
+    });
+
+    it("should scale member score linearly before the cap", () => {
+      const at0 = calculateCircleScore(
+        baseCircleInput({ memberCount: 0, createdAt: thirtyMinutesAgo })
+      );
+      const at5 = calculateCircleScore(
+        baseCircleInput({ memberCount: 5, createdAt: thirtyMinutesAgo })
+      );
+      // Δ brut = 5*8 = 40 → round(40/205*100) = 20
+      expect(at5 - at0).toBe(20);
+    });
+  });
+});
+
+// ─── calculateMomentScore ────────────────────────────────────────────────────
+
+describe("calculateMomentScore", () => {
+  // ── Cas concret spec ────────────────────────────────────────────────────
+
+  describe("given an event with 10 registrants, cover, description, location, circle score 80", () => {
+    it("should return score 90", () => {
+      const input = baseMomentInput({
+        registrantCount: 10,
+        coverImage: "https://example.com/cover.jpg",
+        description: "Un atelier intensif sur React 19 et les nouvelles API.",
+        locationName: "Paris 11e",
+        circleScore: 80,
+        // moment_raw = min(10*7, 70) + 15 + 10 + 5 = 70 + 15 + 10 + 5 = 100
+        // score = round(80*0.5 + 100*0.5) = round(40 + 50) = 90
+      });
+
+      expect(calculateMomentScore(input)).toBe(90);
+    });
+  });
+
+  // ── Communauté démo ──────────────────────────────────────────────────────
+
+  describe("given an event in a demo circle (circleIsDemo = true)", () => {
+    it("should cap the moment score at 30", () => {
+      const input = baseMomentInput({
+        registrantCount: 10,
+        coverImage: "https://example.com/cover.jpg",
+        description: "Un super événement de démonstration bien rempli.",
+        locationName: "Paris",
+        circleScore: 80,
+        circleIsDemo: true,
+        // score non capé = 90 → capé à 30
+      });
+
+      expect(calculateMomentScore(input)).toBe(30);
+    });
+
+    it("should not cap if the score is already below 30", () => {
+      const input = baseMomentInput({
+        registrantCount: 0,
+        circleScore: 10,
+        circleIsDemo: true,
+        // moment_raw = 0; score = round(10*0.5 + 0*0.5) = 5
+      });
+
+      expect(calculateMomentScore(input)).toBe(5);
+    });
+  });
+
+  // ── Caps quantitatifs ────────────────────────────────────────────────────
+
+  describe("given registrant count cap", () => {
+    it("should cap registrant contribution at 70 pts (≥ 10 registrants)", () => {
+      const at10 = calculateMomentScore(
+        baseMomentInput({ registrantCount: 10, circleScore: 0 })
+      );
+      const at20 = calculateMomentInput({ registrantCount: 20, circleScore: 0 });
+      // Les deux doivent avoir le même score sur le signal inscrits
+      expect(at10).toBe(at20);
+    });
+
+    it("should scale registrant score linearly before the cap", () => {
+      const at0 = calculateMomentScore(
+        baseMomentInput({ registrantCount: 0, circleScore: 0 })
+      );
+      const at5 = calculateMomentScore(
+        baseMomentInput({ registrantCount: 5, circleScore: 0 })
+      );
+      // moment_raw avec 5 inscrits = 5*7 = 35 → score = round(0*0.5 + 35*0.5) = round(17.5) = 18
+      expect(at5 - at0).toBe(18);
+    });
+  });
+
+  // ── Couplage Circle ──────────────────────────────────────────────────────
+
+  describe("given circle score coupling (50/50)", () => {
+    it("should give 50% weight to circle score", () => {
+      const lowCircle = calculateMomentScore(
+        baseMomentInput({ circleScore: 0, registrantCount: 0 })
+      );
+      const highCircle = calculateMomentScore(
+        baseMomentInput({ circleScore: 100, registrantCount: 0 })
+      );
+      // score_low = round(0*0.5 + 0) = 0
+      // score_high = round(100*0.5 + 0) = 50
+      expect(highCircle - lowCircle).toBe(50);
+    });
+  });
+
+  // ── Signaux binaires ─────────────────────────────────────────────────────
+
+  describe("given binary moment signals", () => {
+    it("should add cover signal contribution", () => {
+      const without = calculateMomentScore(
+        baseMomentInput({ circleScore: 0 })
+      );
+      const with_ = calculateMomentScore(
+        baseMomentInput({
+          circleScore: 0,
+          coverImage: "https://example.com/cover.jpg",
+        })
+      );
+      // moment_raw Δ = 15 → score Δ = round(15*0.5) = round(7.5) = 8
+      expect(with_ - without).toBe(8);
+    });
+
+    it("should add location signal contribution", () => {
+      const without = calculateMomentScore(
+        baseMomentInput({ circleScore: 0 })
+      );
+      const with_ = calculateMomentScore(
+        baseMomentInput({ circleScore: 0, locationName: "Paris" })
+      );
+      // moment_raw Δ = 5 → score Δ = round(5*0.5) = round(2.5) = 3
+      expect(with_ - without).toBe(3);
+    });
+
+    it("should add description signal contribution", () => {
+      const shortDesc = calculateMomentScore(
+        baseMomentInput({ circleScore: 0, description: "Court." })
+      );
+      const longDesc = calculateMomentScore(
+        baseMomentInput({
+          circleScore: 0,
+          description: "Une description suffisamment longue pour passer le seuil.",
+        })
+      );
+      // moment_raw Δ = 10 → score Δ = round(10*0.5) = 5
+      expect(longDesc - shortDesc).toBe(5);
+    });
+  });
+});
+
+// ─── Helper pour les tests de cap (évite la répétition) ─────────────────────
+
+function calculateMomentInput(overrides: Partial<MomentScoreInput>): number {
+  return calculateMomentScore(baseMomentInput(overrides));
+}

--- a/src/infrastructure/services/explorer-score.service.ts
+++ b/src/infrastructure/services/explorer-score.service.ts
@@ -7,10 +7,21 @@
  * Ref : spec/feature-explorer-rating.md
  */
 
+import type { CircleCategory } from "@/domain/models/circle";
+
+// Constantes du scoring Circle — reflètent la formule de la spec
+const CIRCLE_RAW_MAX = 205; // somme max des points bruts (20+18+15+10+7+5+80+50)
+const DEMO_SCORE_CAP = 30; // plafond de score pour les Communautés de démo
+const DESCRIPTION_MIN_LENGTH = 30; // longueur minimale de description pour +10 pts
+const MEMBER_SCORE_MAX = 80; // plafond scoring membres (memberCount × 8)
+const PAST_EVENT_SCORE_MAX = 50; // plafond scoring événements passés (pastEventCount × 10)
+const REGISTRANT_SCORE_MAX = 70; // plafond scoring inscrits (registrantCount × 7)
+const ONE_DAY_MS = 1000 * 60 * 60 * 24;
+
 export type CircleScoreInput = {
   description: string;
   coverImage: string | null;
-  category: string | null;
+  category: CircleCategory | null;
   createdAt: Date;
   isDemo: boolean;
   overrideScore: number | null;
@@ -29,8 +40,6 @@ export type MomentScoreInput = {
   circleIsDemo: boolean;
 };
 
-const CIRCLE_RAW_MAX = 205;
-
 /**
  * Calcule le score Explorer d'une Communauté (0–100).
  *
@@ -42,22 +51,21 @@ export function calculateCircleScore(input: CircleScoreInput): number {
     return input.overrideScore;
   }
 
-  const ageInDays =
-    (Date.now() - input.createdAt.getTime()) / (1000 * 60 * 60 * 24);
+  const ageInDays = (Date.now() - input.createdAt.getTime()) / ONE_DAY_MS;
 
   const rawScore =
     (input.hasPastEventWithRegistrant ? 20 : 0) +
     (input.coverImage !== null ? 18 : 0) +
     (input.hasUpcomingEvent ? 15 : 0) +
-    (input.description.trim().length >= 30 ? 10 : 0) +
+    (input.description.trim().length >= DESCRIPTION_MIN_LENGTH ? 10 : 0) +
     (input.category !== null ? 7 : 0) +
     (ageInDays >= 1 ? 5 : 0) +
-    Math.min(input.memberCount * 8, 80) +
-    Math.min(input.pastEventCount * 10, 50);
+    Math.min(input.memberCount * 8, MEMBER_SCORE_MAX) +
+    Math.min(input.pastEventCount * 10, PAST_EVENT_SCORE_MAX);
 
   const score = Math.round((rawScore / CIRCLE_RAW_MAX) * 100);
 
-  return input.isDemo ? Math.min(score, 30) : score;
+  return input.isDemo ? Math.min(score, DEMO_SCORE_CAP) : score;
 }
 
 /**
@@ -68,12 +76,12 @@ export function calculateCircleScore(input: CircleScoreInput): number {
  */
 export function calculateMomentScore(input: MomentScoreInput): number {
   const momentRaw =
-    Math.min(input.registrantCount * 7, 70) +
+    Math.min(input.registrantCount * 7, REGISTRANT_SCORE_MAX) +
     (input.coverImage !== null ? 15 : 0) +
-    (input.description.trim().length >= 30 ? 10 : 0) +
+    (input.description.trim().length >= DESCRIPTION_MIN_LENGTH ? 10 : 0) +
     (input.locationName !== null ? 5 : 0);
 
   const score = Math.round(input.circleScore * 0.5 + momentRaw * 0.5);
 
-  return input.circleIsDemo ? Math.min(score, 30) : score;
+  return input.circleIsDemo ? Math.min(score, DEMO_SCORE_CAP) : score;
 }

--- a/src/infrastructure/services/explorer-score.service.ts
+++ b/src/infrastructure/services/explorer-score.service.ts
@@ -1,0 +1,79 @@
+/**
+ * Service de calcul du score Explorer.
+ *
+ * Score interne non exposé aux utilisateurs — sert uniquement au tri sur la page Explorer.
+ * Recalculé chaque nuit via un batch (Vercel Cron) et persisté en DB.
+ *
+ * Ref : spec/feature-explorer-rating.md
+ */
+
+export type CircleScoreInput = {
+  description: string;
+  coverImage: string | null;
+  category: string | null;
+  createdAt: Date;
+  isDemo: boolean;
+  overrideScore: number | null;
+  memberCount: number; // membres hors host (role PLAYER uniquement)
+  pastEventCount: number; // nombre d'événements passés (status PAST)
+  hasPastEventWithRegistrant: boolean; // au moins 1 event passé avec ≥ 1 inscrit
+  hasUpcomingEvent: boolean; // au moins 1 event PUBLISHED + startsAt > now
+};
+
+export type MomentScoreInput = {
+  description: string;
+  coverImage: string | null;
+  locationName: string | null;
+  registrantCount: number; // inscriptions avec status REGISTERED
+  circleScore: number; // score déjà calculé du Circle parent (0–100)
+  circleIsDemo: boolean;
+};
+
+const CIRCLE_RAW_MAX = 205;
+
+/**
+ * Calcule le score Explorer d'une Communauté (0–100).
+ *
+ * Si `overrideScore` est non-null, il est retourné directement sans calcul.
+ * Si `isDemo`, le score est plafonné à 30.
+ */
+export function calculateCircleScore(input: CircleScoreInput): number {
+  if (input.overrideScore !== null) {
+    return input.overrideScore;
+  }
+
+  const ageInDays =
+    (Date.now() - input.createdAt.getTime()) / (1000 * 60 * 60 * 24);
+
+  const rawScore =
+    (input.hasPastEventWithRegistrant ? 20 : 0) +
+    (input.coverImage !== null ? 18 : 0) +
+    (input.hasUpcomingEvent ? 15 : 0) +
+    (input.description.trim().length >= 30 ? 10 : 0) +
+    (input.category !== null ? 7 : 0) +
+    (ageInDays >= 1 ? 5 : 0) +
+    Math.min(input.memberCount * 8, 80) +
+    Math.min(input.pastEventCount * 10, 50);
+
+  const score = Math.round((rawScore / CIRCLE_RAW_MAX) * 100);
+
+  return input.isDemo ? Math.min(score, 30) : score;
+}
+
+/**
+ * Calcule le score Explorer d'un événement (0–100).
+ *
+ * Score = 50 % score Communauté parente + 50 % signaux propres à l'événement.
+ * Si le Circle est une démo (`circleIsDemo`), le score est plafonné à 30.
+ */
+export function calculateMomentScore(input: MomentScoreInput): number {
+  const momentRaw =
+    Math.min(input.registrantCount * 7, 70) +
+    (input.coverImage !== null ? 15 : 0) +
+    (input.description.trim().length >= 30 ? 10 : 0) +
+    (input.locationName !== null ? 5 : 0);
+
+  const score = Math.round(input.circleScore * 0.5 + momentRaw * 0.5);
+
+  return input.circleIsDemo ? Math.min(score, 30) : score;
+}

--- a/src/lib/__tests__/seeded-shuffle.test.ts
+++ b/src/lib/__tests__/seeded-shuffle.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { seededShuffle } from "@/lib/seeded-shuffle";
+
+describe("seededShuffle", () => {
+  it("should return same order for same seed", () => {
+    const arr = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    const seed = "2026-03-13";
+
+    const first = seededShuffle(arr, seed);
+    const second = seededShuffle(arr, seed);
+
+    expect(first).toEqual(second);
+  });
+
+  it("should return different order for different seeds", () => {
+    const arr = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+
+    const resultA = seededShuffle(arr, "2026-03-13");
+    const resultB = seededShuffle(arr, "2026-03-14");
+
+    // Très improbable que deux seeds différents donnent exactement le même ordre
+    expect(resultA).not.toEqual(resultB);
+  });
+
+  it("should not modify the original array", () => {
+    const arr = [1, 2, 3, 4, 5];
+    const original = [...arr];
+
+    seededShuffle(arr, "2026-03-13");
+
+    expect(arr).toEqual(original);
+  });
+
+  it("should handle empty array", () => {
+    const result = seededShuffle([], "2026-03-13");
+    expect(result).toEqual([]);
+  });
+
+  it("should handle single element array", () => {
+    const result = seededShuffle(["only"], "2026-03-13");
+    expect(result).toEqual(["only"]);
+  });
+
+  it("should contain all original elements after shuffle", () => {
+    const arr = ["a", "b", "c", "d", "e"];
+    const result = seededShuffle(arr, "2026-03-13");
+
+    expect(result).toHaveLength(arr.length);
+    expect(result.sort()).toEqual([...arr].sort());
+  });
+});

--- a/src/lib/seeded-shuffle.ts
+++ b/src/lib/seeded-shuffle.ts
@@ -1,0 +1,29 @@
+/**
+ * Mélange un tableau de façon déterministe selon un seed string.
+ * Utilise Fisher-Yates avec un LCG (Linear Congruential Generator) initialisé
+ * depuis un hash simple du seed. Même seed → même ordre, garanti.
+ */
+export function seededShuffle<T>(arr: T[], seed: string): T[] {
+  const result = [...arr];
+
+  // Hash simple du seed (polynomial rolling hash)
+  let hash = 0;
+  for (let i = 0; i < seed.length; i++) {
+    hash = (hash * 31 + seed.charCodeAt(i)) & 0xffffffff;
+  }
+
+  // LCG — paramètres de Numerical Recipes
+  let state = hash;
+  const rand = () => {
+    state = (state * 1664525 + 1013904223) & 0xffffffff;
+    return (state >>> 0) / 0x100000000;
+  };
+
+  // Fisher-Yates shuffle
+  for (let i = result.length - 1; i > 0; i--) {
+    const j = Math.floor(rand() * (i + 1));
+    [result[i], result[j]] = [result[j], result[i]];
+  }
+
+  return result;
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,9 @@
 {
-  "ignoreCommand": "exit 1"
+  "ignoreCommand": "exit 1",
+  "crons": [
+    {
+      "path": "/api/cron/recalculate-scores",
+      "schedule": "0 3 * * *"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

- Ajoute un score de pertinence interne (invisible aux utilisateurs) pour trier les Communautés et événements sur la page Explorer
- Batch quotidien (Vercel Cron, 3h) qui recalcule et persiste les scores en DB
- Section "À la une" avec sélection déterministe par date (Fisher-Yates + LCG seedé)

## Changements

**Schema Prisma (`Circle`)** — 5 nouveaux champs :
- `isDemo` — marque les Communautés de démo (plafond score à 30)
- `excludedFromExplorer` — exclusion manuelle admin
- `overrideScore` — score forcé admin (court-circuite le calcul)
- `explorerScore` — score calculé persisté (0–100)
- `scoreUpdatedAt` — timestamp du dernier recalcul

**Schema Prisma (`Moment`)** — 1 nouveau champ : `explorerScore`

**Service de calcul** (`infrastructure/services/explorer-score.service.ts`) :
- `calculateCircleScore` : 8 critères pondérés (photo, description, catégorie, ancienneté, membres, événements passés, inscrit passé, événement à venir)
- `calculateMomentScore` : 50% score Circle parent + 50% signaux propres

**Cron batch** (`app/api/cron/recalculate-scores`) :
- POST protégé par `Authorization: Bearer CRON_SECRET`
- Recalcule circles puis moments en 2 transactions Prisma atomiques
- Planifié chaque nuit à 3h dans `vercel.json`

**Repositories** :
- `findPublic` (circles) : filtre `excludedFromExplorer` + exclusion `@test.playground`, tri `explorerScore DESC`
- `findPublicUpcoming` (moments) : mêmes filtres, tri `explorerScore DESC` ou `startsAt ASC` selon `sortBy`
- `findFeatured` (circles) : IDs-first → seededShuffle par date → 3 complets (optimisé N+1)

**Utilitaires** :
- `src/infrastructure/db/explorer-filters.ts` — filtre d'exclusion `@test.playground` centralisé
- `src/lib/seeded-shuffle.ts` — Fisher-Yates + LCG pour sélection déterministe "À la une"
- `scripts/backfill-explorer-is-demo.ts` — backfill `isDemo = true` pour les circles @demo.playground existants

## Test plan

- [ ] Vérifier que la page Explorer charge sans erreur
- [ ] Vérifier que les Communautés sont triées par `explorerScore DESC`
- [ ] Vérifier que les événements sont triés par score (popular) ou date selon le sélecteur
- [ ] Tester le cron `POST /api/cron/recalculate-scores` avec le header `Authorization: Bearer CRON_SECRET`
- [ ] Vérifier que les circles `@test.playground` et `@demo.playground` sont exclus (ou plafonnés à 30)
- [ ] Vérifier que `pnpm db:push:prod` a bien été appliqué (tous les champs présents en prod)

🤖 Generated with [Claude Code](https://claude.com/claude-code)