### PR TITLE
chore(legal): enrichir le tableau des sous-traitants avec les données transmises

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1202,22 +1202,23 @@
       },
       "subprocessors": {
         "title": "Sub-processors and data recipients",
-        "intro": "Your personal data may be shared with the following sub-processors, solely for the purposes described above:",
+        "intro": "The following sub-processors are involved in operating the platform. Depending on their role, they may receive personal data, technical data, or content you have entered:",
         "headers": {
           "name": "Sub-processor",
           "purpose": "Purpose",
+          "data": "Data transmitted",
           "hq": "Headquarters",
           "hosting": "Data hosting",
           "safeguards": "Safeguards"
         },
-        "vercel": { "purpose": "Application hosting", "hq": "United States", "hosting": "European Union (Frankfurt)", "safeguards": "Vercel DPA, data hosted in EU" },
-        "neon": { "purpose": "Database hosting", "hq": "United States", "hosting": "European Union (Frankfurt)", "safeguards": "Neon DPA, data hosted in EU" },
-        "posthog": { "purpose": "Service usage analytics", "hq": "United States", "hosting": "European Union (eu.posthog.com)", "safeguards": "PostHog DPA, data hosted in EU" },
-        "sentry": { "purpose": "Technical error monitoring", "hq": "United States", "hosting": "European Union (Germany, de.sentry.io)", "safeguards": "Sentry DPA, data hosted in EU" },
-        "resend": { "purpose": "Transactional and notification emails", "hq": "United States", "hosting": "United States", "safeguards": "Resend DPA, EU standard contractual clauses" },
-        "stripe": { "purpose": "Payment processing (paid Events)", "hq": "United States", "hosting": "United States / European Union (global infrastructure)", "safeguards": "PCI-DSS certified, Stripe DPA, EU standard contractual clauses" },
-        "anthropic": { "purpose": "AI features (description generation)", "hq": "United States", "hosting": "United States", "safeguards": "Anthropic DPA, EU standard contractual clauses" },
-        "slack": { "purpose": "Internal administration notifications (new users, new communities)", "hq": "United States", "hosting": "United States", "safeguards": "Slack/Salesforce DPA, EU standard contractual clauses" },
+        "vercel": { "purpose": "Application hosting", "data": "IP address, session cookies, HTTP requests (transit)", "hq": "United States", "hosting": "European Union (Frankfurt)", "safeguards": "Vercel DPA, data hosted in EU" },
+        "neon": { "purpose": "Database hosting", "data": "All account data: email, name, profile picture, registrations, comments", "hq": "United States", "hosting": "European Union (Frankfurt)", "safeguards": "Neon DPA, data hosted in EU" },
+        "posthog": { "purpose": "Service usage analytics", "data": "User identifier, email, name, pages visited", "hq": "United States", "hosting": "European Union (eu.posthog.com)", "safeguards": "PostHog DPA, data hosted in EU" },
+        "sentry": { "purpose": "Technical error monitoring", "data": "Technical error traces (no personal data explicitly transmitted)", "hq": "United States", "hosting": "European Union (Germany, de.sentry.io)", "safeguards": "Sentry DPA, data hosted in EU" },
+        "resend": { "purpose": "Transactional and notification emails", "data": "Recipient email address, name (in some emails)", "hq": "United States", "hosting": "United States", "safeguards": "Resend DPA, EU standard contractual clauses" },
+        "stripe": { "purpose": "Payment processing (paid Events)", "data": "Email address, user identifier", "hq": "United States", "hosting": "United States / European Union (global infrastructure)", "safeguards": "PCI-DSS certified, Stripe DPA, EU standard contractual clauses" },
+        "anthropic": { "purpose": "AI features (description generation)", "data": "User-entered content (event titles and descriptions) — no personal data", "hq": "United States", "hosting": "United States", "safeguards": "Anthropic DPA, EU standard contractual clauses" },
+        "slack": { "purpose": "Internal administration notifications (new users, new communities)", "data": "User name and email (admin notifications only)", "hq": "United States", "hosting": "United States", "safeguards": "Slack/Salesforce DPA, EU standard contractual clauses" },
         "noSale": "Your data is never sold or shared with third parties for commercial or advertising purposes."
       },
       "transfers": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1202,22 +1202,23 @@
       },
       "subprocessors": {
         "title": "Sous-traitants et destinataires des données",
-        "intro": "Vos données personnelles peuvent être transmises aux sous-traitants suivants, uniquement pour les finalités décrites ci-dessus :",
+        "intro": "Les sous-traitants suivants interviennent dans le fonctionnement de la plateforme. Selon leur rôle, ils peuvent recevoir des données personnelles, des données techniques ou du contenu que vous avez saisi :",
         "headers": {
           "name": "Sous-traitant",
           "purpose": "Finalité",
+          "data": "Données transmises",
           "hq": "Siège",
           "hosting": "Hébergement des données",
           "safeguards": "Garanties"
         },
-        "vercel": { "purpose": "Hébergement de l'application", "hq": "États-Unis", "hosting": "Union européenne (Frankfurt)", "safeguards": "DPA Vercel, données hébergées en UE" },
-        "neon": { "purpose": "Hébergement de la base de données", "hq": "États-Unis", "hosting": "Union européenne (Frankfurt)", "safeguards": "DPA Neon, données hébergées en UE" },
-        "posthog": { "purpose": "Analyse d'utilisation du service", "hq": "États-Unis", "hosting": "Union européenne (eu.posthog.com)", "safeguards": "DPA PostHog, données hébergées en UE" },
-        "sentry": { "purpose": "Surveillance des erreurs techniques", "hq": "États-Unis", "hosting": "Union européenne (Allemagne, de.sentry.io)", "safeguards": "DPA Sentry, données hébergées en UE" },
-        "resend": { "purpose": "Envoi d'emails transactionnels et de notifications", "hq": "États-Unis", "hosting": "États-Unis", "safeguards": "DPA Resend, clauses contractuelles types UE" },
-        "stripe": { "purpose": "Traitement des paiements (événements payants)", "hq": "États-Unis", "hosting": "États-Unis / Union européenne (infrastructure globale)", "safeguards": "Certifié PCI-DSS, DPA Stripe, clauses contractuelles types UE" },
-        "anthropic": { "purpose": "Fonctionnalités d'intelligence artificielle (génération de descriptions)", "hq": "États-Unis", "hosting": "États-Unis", "safeguards": "DPA Anthropic, clauses contractuelles types UE" },
-        "slack": { "purpose": "Notifications internes d'administration (nouveaux utilisateurs, nouvelles communautés)", "hq": "États-Unis", "hosting": "États-Unis", "safeguards": "DPA Slack/Salesforce, clauses contractuelles types UE" },
+        "vercel": { "purpose": "Hébergement de l'application", "data": "Adresse IP, cookies de session, requêtes HTTP (transit)", "hq": "États-Unis", "hosting": "Union européenne (Frankfurt)", "safeguards": "DPA Vercel, données hébergées en UE" },
+        "neon": { "purpose": "Hébergement de la base de données", "data": "Toutes les données du compte : email, nom, photo de profil, inscriptions, commentaires", "hq": "États-Unis", "hosting": "Union européenne (Frankfurt)", "safeguards": "DPA Neon, données hébergées en UE" },
+        "posthog": { "purpose": "Analyse d'utilisation du service", "data": "Identifiant utilisateur, email, nom, pages visitées", "hq": "États-Unis", "hosting": "Union européenne (eu.posthog.com)", "safeguards": "DPA PostHog, données hébergées en UE" },
+        "sentry": { "purpose": "Surveillance des erreurs techniques", "data": "Traces d'erreur techniques (aucune donnée personnelle explicitement transmise)", "hq": "États-Unis", "hosting": "Union européenne (Allemagne, de.sentry.io)", "safeguards": "DPA Sentry, données hébergées en UE" },
+        "resend": { "purpose": "Envoi d'emails transactionnels et de notifications", "data": "Adresse email du destinataire, nom (dans certains emails)", "hq": "États-Unis", "hosting": "États-Unis", "safeguards": "DPA Resend, clauses contractuelles types UE" },
+        "stripe": { "purpose": "Traitement des paiements (événements payants)", "data": "Adresse email, identifiant utilisateur", "hq": "États-Unis", "hosting": "États-Unis / Union européenne (infrastructure globale)", "safeguards": "Certifié PCI-DSS, DPA Stripe, clauses contractuelles types UE" },
+        "anthropic": { "purpose": "Fonctionnalités d'intelligence artificielle (génération de descriptions)", "data": "Contenu saisi par l'utilisateur (titres et descriptions d'événements) — aucune donnée personnelle", "hq": "États-Unis", "hosting": "États-Unis", "safeguards": "DPA Anthropic, clauses contractuelles types UE" },
+        "slack": { "purpose": "Notifications internes d'administration (nouveaux utilisateurs, nouvelles communautés)", "data": "Nom et email de l'utilisateur (notifications administrateur uniquement)", "hq": "États-Unis", "hosting": "États-Unis", "safeguards": "DPA Slack/Salesforce, clauses contractuelles types UE" },
         "noSale": "Vos données ne sont jamais vendues ni partagées avec des tiers à des fins commerciales ou publicitaires."
       },
       "transfers": {

--- a/src/app/[locale]/(routes)/legal/cgu/page.tsx
+++ b/src/app/[locale]/(routes)/legal/cgu/page.tsx
@@ -23,10 +23,10 @@ export default async function TermsPage() {
 
   return (
     <>
+      <h1>{t("terms.title")}</h1>
       <p className="text-muted-foreground not-prose text-sm">
         {t("lastUpdated", { date: "22/02/2026" })}
       </p>
-      <h1>{t("terms.title")}</h1>
       <p>{t("terms.intro")}</p>
 
       <h2>{t("terms.acceptance.title")}</h2>

--- a/src/app/[locale]/(routes)/legal/confidentialite/page.tsx
+++ b/src/app/[locale]/(routes)/legal/confidentialite/page.tsx
@@ -183,6 +183,7 @@ export default async function PrivacyPage() {
           <tr>
             <th>{t("privacy.subprocessors.headers.name")}</th>
             <th>{t("privacy.subprocessors.headers.purpose")}</th>
+            <th>{t("privacy.subprocessors.headers.data")}</th>
             <th>{t("privacy.subprocessors.headers.hq")}</th>
             <th>{t("privacy.subprocessors.headers.hosting")}</th>
             <th>{t("privacy.subprocessors.headers.safeguards")}</th>
@@ -211,6 +212,7 @@ export default async function PrivacyPage() {
                 </strong>
               </td>
               <td>{t(`privacy.subprocessors.${sp}.purpose`)}</td>
+              <td>{t(`privacy.subprocessors.${sp}.data`)}</td>
               <td>{t(`privacy.subprocessors.${sp}.hq`)}</td>
               <td>{t(`privacy.subprocessors.${sp}.hosting`)}</td>
               <td>{t(`privacy.subprocessors.${sp}.safeguards`)}</td>

--- a/src/app/[locale]/(routes)/legal/confidentialite/page.tsx
+++ b/src/app/[locale]/(routes)/legal/confidentialite/page.tsx
@@ -44,10 +44,10 @@ export default async function PrivacyPage() {
 
   return (
     <>
+      <h1>{t("privacy.title")}</h1>
       <p className="text-muted-foreground not-prose text-sm">
         {t("lastUpdated", { date: "01/04/2026" })}
       </p>
-      <h1>{t("privacy.title")}</h1>
       <p>{t("privacy.intro")}</p>
 
       {/* 2. Responsable du traitement */}

--- a/src/app/[locale]/(routes)/legal/confidentialite/page.tsx
+++ b/src/app/[locale]/(routes)/legal/confidentialite/page.tsx
@@ -46,7 +46,7 @@ export default async function PrivacyPage() {
     <>
       <h1>{t("privacy.title")}</h1>
       <p className="text-muted-foreground not-prose text-sm">
-        {t("lastUpdated", { date: "01/04/2026" })}
+        {t("lastUpdated", { date: "09/04/2026" })}
       </p>
       <p>{t("privacy.intro")}</p>
 

--- a/src/app/[locale]/(routes)/legal/mentions-legales/page.tsx
+++ b/src/app/[locale]/(routes)/legal/mentions-legales/page.tsx
@@ -23,10 +23,10 @@ export default async function LegalNoticePage() {
 
   return (
     <>
+      <h1>{t("legalNotice.title")}</h1>
       <p className="text-muted-foreground not-prose text-sm">
         {t("lastUpdated", { date: "22/02/2026" })}
       </p>
-      <h1>{t("legalNotice.title")}</h1>
 
       <h2>{t("legalNotice.editor.title")}</h2>
       <p>{t("legalNotice.editor.content")}</p>


### PR DESCRIPTION
## Summary
- Ajout d'une colonne "Données transmises" au tableau des sous-traitants de la page confidentialité, détaillant les données exactes envoyées à chaque service (audité depuis le code source)
- Reformulation de l'intro pour distinguer données personnelles, données techniques et contenu utilisateur (au lieu d'un blanket "vos données personnelles")
- Déplacement de la date "Dernière mise à jour" sous le titre h1 sur les 3 pages légales (confidentialité, CGU, mentions légales)
- Mise à jour de la date de dernière modification à 09/04/2026

## Test plan
- [ ] Vérifier la page confidentialité FR : le tableau affiche bien la nouvelle colonne "Données transmises"
- [ ] Vérifier la page confidentialité EN : colonne "Data transmitted" présente
- [ ] Vérifier que la date apparaît bien sous le titre sur les 3 pages légales
- [ ] Vérifier le rendu mobile du tableau (scroll horizontal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)