### PR TITLE
fix(middleware): bypass i18n on Next.js metadata file routes

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -13,6 +13,10 @@ const slugRouteRe = new RegExp(
   `^(?:\\/(?:${localeAlt}))?\\/(?:m|circles)\\/([^/]+)(?:\\/|$)`
 );
 
+// Next.js metadata file routes (opengraph-image, twitter-image) — optional hash suffix
+// e.g. /fr/circles/[slug]/opengraph-image-gwtces
+const metadataFileRe = /\/(opengraph-image|twitter-image)(-[^/]+)?$/;
+
 function isBlockedBot(ua: string): boolean {
   const lower = ua.toLowerCase();
   return BLOCKED_BOTS.some((bot) => lower.includes(bot));
@@ -25,7 +29,16 @@ export default function middleware(request: NextRequest) {
     return new NextResponse("Forbidden", { status: 403 });
   }
 
-  // 2. Validate slugs on public routes before any processing
+  // 2. Bypass next-intl for Next.js metadata file routes. The i18n middleware
+  // strips the default locale prefix (e.g. /fr/...) via a 307 redirect, which
+  // drops the hash query string and breaks social crawlers (LinkedIn, X...)
+  // that don't follow redirects on og:image URLs. Next.js file-based routing
+  // still resolves these routes correctly without the middleware rewrite.
+  if (metadataFileRe.test(request.nextUrl.pathname)) {
+    return NextResponse.next();
+  }
+
+  // 3. Validate slugs on public routes before any processing
   const slugMatch = request.nextUrl.pathname.match(slugRouteRe);
   if (slugMatch) {
     const slug = decodeURIComponent(slugMatch[1]);
@@ -34,7 +47,7 @@ export default function middleware(request: NextRequest) {
     }
   }
 
-  // 3. Delegate to next-intl middleware
+  // 4. Delegate to next-intl middleware
   return intlMiddleware(request);
 }
 


### PR DESCRIPTION
## Summary

Social crawlers (LinkedIn, X...) were getting empty previews when sharing `/circles/[slug]` and `/m/[slug]` URLs. The `next-intl` middleware (with `localePrefix: "as-needed"`) was stripping the default `/fr/` prefix from `og:image` URLs via a **307 redirect**, which drops the hash query string and breaks crawlers that don't follow redirects on `og:image` resources.

The fix adds a chirurgical early return in the middleware for Next.js metadata file routes (`opengraph-image*`, `twitter-image*`). Next.js file-based routing resolves these routes correctly on its own — the i18n rewrite is unnecessary for them.

## Scope

- Fixes `/circles/[slug]` OG image (confirmed)
- Fixes `/m/[slug]` OG image (confirmed — most critical, viral entry point)
- Fixes `/blog/[slug]` OG image (same structure, not tested but covered by the same fix)
- Zero impact on page routes — the i18n locale strip behaviour is preserved for everything else

## Test plan

Validated locally against `pnpm dev`:

- [x] `/fr/circles/agile-bordeaux/opengraph-image-xxx?hash` → **200 PNG 1200x630** (was 307)
- [x] `/fr/m/after-work-post-agfr/opengraph-image-xxx?hash` → **200 PNG 1200x630** (was 307)
- [x] `/circles/agile-bordeaux` → 200 HTML (non-regression, page renders)
- [x] `/fr/circles/agile-bordeaux` → 307 strip locale prefix (i18n intact)
- [x] `/en/circles/agile-bordeaux` → 200 HTML (non-default locale intact)

## Post-deploy

Once merged, the LinkedIn previews already cached need to be refreshed via [LinkedIn Post Inspector](https://www.linkedin.com/post-inspector/) for each URL that was shared before the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)