### PR TITLE
chore(i18n): dashboard subtitle + Welcome vouvoiement

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -263,7 +263,7 @@
     "hostTools": "Host tools",
     "greeting": "Hello, {name}",
     "greetingAnonymous": "Hello",
-    "greetingSubtitle": "Your communities and upcoming Events, all in one place.",
+    "greetingSubtitle": "Here's what's happening in your communities.",
     "memberCount": "{count} members",
     "filterAll": "All",
     "filterHostOnly": "Organizer"

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -172,12 +172,12 @@
     },
     "modeChoice": {
       "greetingPrefix": "Bienvenue,",
-      "greetingSuffix": "Que veux-tu faire ?",
-      "greetingAnonymous": "Bienvenue — que veux-tu faire ?",
-      "subtitle": "Par où veux-tu commencer ?",
+      "greetingSuffix": "Que voulez-vous faire ?",
+      "greetingAnonymous": "Bienvenue — que voulez-vous faire ?",
+      "subtitle": "Par où voulez-vous commencer ?",
       "participant": {
         "title": "Je participe",
-        "description": "Explorer et rejoindre des événements qui m'inspirent"
+        "description": "Explorer et rejoindre des événements qui vous inspirent"
       },
       "organizer": {
         "title": "J'organise",
@@ -263,7 +263,7 @@
     "hostTools": "Outils organisateur",
     "greeting": "Bonjour, {name}",
     "greetingAnonymous": "Bonjour",
-    "greetingSubtitle": "Vos communautés et vos prochains événements, au même endroit.",
+    "greetingSubtitle": "Voici ce qui se passe dans vos communautés.",
     "memberCount": "{count} membres",
     "filterAll": "Tous",
     "filterHostOnly": "Organisateur"


### PR DESCRIPTION
## Summary
- Dashboard greeting subtitle : « Voici ce qui se passe dans vos communautés. » (remplace « Vos communautés et vos prochains événements, au même endroit. »)
- Welcome modeChoice : migration des 4 dernières chaînes en tutoiement vers vouvoiement, pour rester cohérent avec le reste de l'app qui utilise majoritairement le vouvoiement (~230 occurrences vs 13)
- EN mis à jour pour le sous-titre (la distinction tu/vous n'existe pas en anglais)

## Test plan
- [ ] Vérifier visuellement le nouveau sous-titre sur `/dashboard` (FR + EN)
- [ ] Vérifier la page `/dashboard/welcome` en FR : plus aucune trace de « tu / toi / ton / ta »
- [ ] Le parcours "modeChoice" (première visite) s'affiche correctement

🤖 Generated with [Claude Code](https://claude.com/claude-code)