### PR TITLE
chore(readme): refresh to match current project state

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Lancez votre communauté. Organisez vos événements. Animez votre réseau.**
 
-→ [the-playground.fr](https://the-playground.fr)
+→ [the-playground.fr](https://the-playground.fr) · [Changelog](https://the-playground.fr/changelog) · [À propos](https://the-playground.fr/about)
 
 ---
 
@@ -32,27 +32,36 @@ Le modèle communautaire de Meetup + l'expérience de Luma + 100% gratuit. Pas d
 ## Fonctionnalités
 
 **Pour l'organisateur**
-- Créer et gérer sa communauté (Circle)
+- Créer et gérer sa communauté — privée ou publique, avec invitations par lien
 - Créer des événements avec une page autonome et partageable
+- **Billetterie intégrée** via Stripe Connect — 0% commission plateforme
+- **Inscriptions sur validation** pour filtrer les participants si besoin
 - Gérer ses participants de façon persistante (pas événement par événement)
-- Broadcast email à toute sa communauté
+- **Broadcast email** à toute sa communauté
 - Check-in, export CSV, liste d'attente automatique
-- Assistant IA (descriptions, emails, suggestions)
+- **Radar IA** — détection des événements similaires à venir (via Claude)
+- Assistant IA pour les descriptions, emails, suggestions
 
 **Pour le participant**
 - Découverte via lien partagé (mobile-first)
 - Inscription en quelques secondes — magic link, pas de compte requis
 - Devient automatiquement membre de la communauté
-- Notifications email (confirmation, rappels, changements)
+- **Profil public** avec bio, ville, liens sociaux
+- Notifications email (confirmation, rappels 24h et 1h, changements, annulations)
 - Page communauté : prochains événements, membres, historique
+- Fil de commentaires sur chaque événement
 
 **Plateforme**
-- Répertoire public de communautés ([Explorer](https://the-playground.fr/explorer))
-- Bilingue FR / EN
+- [Explorer](https://the-playground.fr/explorer) — répertoire public de communautés avec tri, filtres et section À la une
+- **Réseaux** — regrouper plusieurs communautés sous une vitrine commune (fédérations, collectifs, marques)
+- **Blog** — articles de fond sur la philosophie et les choix du produit
+- Bilingue FR / EN avec URLs propres
 - 100% gratuit — seuls les frais Stripe (~2,9% + 0,30€) sur les événements payants
 
 ## Stack
 
+| | |
+| --- | --- |
 | **Framework** | Next.js 16 (App Router, SSR) |
 | **Langage** | TypeScript strict, full-stack |
 | **Base de données** | PostgreSQL · Neon serverless (EU) |
@@ -62,9 +71,20 @@ Le modèle communautaire de Meetup + l'expérience de Luma + 100% gratuit. Pas d
 | **Email** | Resend + react-email |
 | **IA** | Anthropic SDK (Claude) |
 | **Paiements** | Stripe Connect |
+| **Analytics** | PostHog |
+| **Monitoring** | Sentry |
 | **Déploiement** | Vercel (EU) |
 
-Construit en moins d'une semaine avec [Claude Code](https://claude.ai/claude-code) (Anthropic). Architecture hexagonale, TypeScript strict, tout déployé en Europe.
+Architecture hexagonale (Ports & Adapters), TypeScript strict, tout déployé en Europe. Développé avec [Claude Code](https://claude.ai/claude-code) (Anthropic) — quelques jours pour le MVP, quelques semaines pour une plateforme complète en production.
+
+## En chiffres
+
+| | |
+| --- | --- |
+| **1 400+** | commits |
+| **300+** | pull requests |
+| **65** | cas d'usage (domain usecases) |
+| **880+** | tests (unit + integration + E2E) |
 
 ## Architecture
 
@@ -78,17 +98,28 @@ src/
   components/      → Composants React réutilisables
 ```
 
+Voir `CLAUDE.md` pour le contrat strict d'architecture et les règles de dépendance.
+
 ## Développement
 
 ```bash
 pnpm install
-pnpm dev          # Démarre le serveur de développement
-pnpm test         # Lance les tests (unit + integration)
-pnpm test:e2e     # Tests E2E Playwright
-pnpm typecheck    # Vérifie les types TypeScript
+pnpm dev              # Démarre le serveur de développement
+pnpm test             # Lance les tests (unit + integration)
+pnpm test:e2e         # Tests E2E Playwright
+pnpm typecheck        # Vérifie les types TypeScript
+pnpm db:push          # Applique le schema sur la DB dev
 ```
 
 Variables d'environnement requises : voir `.env.example`.
+
+## Versions récentes
+
+Les 3 dernières versions majeures (voir le [changelog complet](https://the-playground.fr/changelog)) :
+
+- **v2.6.0** — Réseaux de communautés, profils enrichis, site web des communautés
+- **v2.5.0** — Blog et landing page enrichis
+- **v2.0.0** — Événements payants et billetterie intégrée (Stripe Connect)
 
 ## Auteur
 
@@ -96,4 +127,4 @@ Projet de [Dragos Dreptate](https://www.linkedin.com/in/dragosdreptate/) — dir
 
 ---
 
-*Une expérience *[*Claude Code*](https://claude.ai/claude-code)* · Anthropic*
+*Une expérience [Claude Code](https://claude.ai/claude-code) · Anthropic*


### PR DESCRIPTION
## Summary

Le README avait vieilli : il ne mentionnait pas plusieurs fonctionnalités livrées depuis v1.x (Réseaux, billetterie Stripe, Radar IA, profils enrichis, inscriptions sur validation, blog…) et contenait la phrase trompeuse « construit en moins d'une semaine » alors que le projet a plusieurs mois et plus de 1400 commits.

Cette PR réaligne le README sur l'état réel du produit tel qu'il est décrit dans les pages `/about`, `/help` et `/changelog` de l'app.

## Changements

- **Fonctionnalités enrichies** : ajout des features manquantes
  - Réseaux de communautés (v2.6.0)
  - Profils membres enrichis (bio, ville, liens sociaux)
  - Site web des communautés
  - Billetterie Stripe Connect + mention « 0% commission » explicite
  - Inscriptions sur validation (approval flow)
  - Radar IA (explicite au lieu de « assistant IA » vague)
  - Rappels 24h et 1h précisés
  - Blog
  - Invitations par lien pour communautés privées
  - Explorer avec tri / filtres / section À la une
- **Stack mise à jour** : ajout de PostHog (analytics) et Sentry (monitoring)
- **Nouvelle section « En chiffres »** reprenant les stats de `/about` : 1 400+ commits, 300+ PRs, 65 cas d'usage, 880+ tests
- **Nouvelle section « Versions récentes »** avec les 3 dernières majeures et un lien vers le changelog complet
- **Phrase obsolète remplacée** : « construit en moins d'une semaine » → « quelques jours pour le MVP, quelques semaines pour une plateforme complète en production » (formulation alignée sur `/about`)
- **Liens ajoutés en tête** : `/changelog` et `/about`
- **Dev commands enrichies** : ajout de `pnpm db:push`
- **Pointeur vers `CLAUDE.md`** dans la section Architecture

## Test plan

- [ ] Relire le README rendu sur GitHub (tableaux, code blocks, liens cliquables)
- [ ] Vérifier les 3 liens externes en tête (site, changelog, about)
- [ ] Vérifier que les liens internes (CLAUDE.md, .env.example) pointent bien où il faut
- [ ] Vérifier que la liste de features reflète bien ce qui existe en prod

## Notes

Fait dans un worktree isolé pour ne pas interférer avec la branche `feat/moment-attachments` en cours sur le clone principal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)