### PR TITLE
fix(moment-attachments): tap direct en mobile + bouton Ouvrir sur desktop

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -535,6 +535,7 @@
       "hostedBy": "Hosted by",
       "attachments": {
         "sectionTitle": "Documents",
+        "viewerOpen": "Open in a new tab",
         "viewerDownload": "Download",
         "viewerClose": "Close"
       },

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -535,6 +535,7 @@
       "hostedBy": "Organisé par",
       "attachments": {
         "sectionTitle": "Documents",
+        "viewerOpen": "Ouvrir dans un nouvel onglet",
         "viewerDownload": "Télécharger",
         "viewerClose": "Fermer"
       },

--- a/src/components/moments/attachment-viewer-dialog.tsx
+++ b/src/components/moments/attachment-viewer-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Download, X } from "lucide-react";
+import { Download, ExternalLink, X } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { Dialog as DialogPrimitive } from "radix-ui";
 import type { MomentAttachment } from "@/domain/models/moment-attachment";
@@ -66,6 +66,23 @@ export function AttachmentViewerDialog({
               {attachment?.filename}
             </DialogPrimitive.Description>
             <div className="flex shrink-0 gap-1.5">
+              {/* Open in new tab — critical on mobile where the inline
+                  preview (iframe for PDF, <img> for image) does not
+                  support pinch-to-zoom because touch events are
+                  intercepted by the modal. Opening in a new tab uses
+                  the browser's native full-screen reader which has
+                  proper zoom controls on both desktop and mobile. */}
+              {attachment && (
+                <a
+                  href={attachment.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="border-border hover:bg-muted hover:border-primary flex size-9 items-center justify-center rounded-lg border transition-colors"
+                  aria-label={t("viewerOpen")}
+                >
+                  <ExternalLink className="size-4" />
+                </a>
+              )}
               <a
                 href={downloadHref}
                 className="border-border hover:bg-muted hover:border-primary flex size-9 items-center justify-center rounded-lg border transition-colors"

--- a/src/components/moments/moment-attachments-list.tsx
+++ b/src/components/moments/moment-attachments-list.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { ChevronRight, FileText, ImageIcon } from "lucide-react";
 import { useTranslations } from "next-intl";
 import type { MomentAttachment } from "@/domain/models/moment-attachment";
@@ -17,8 +17,34 @@ type MomentAttachmentsListProps = {
 };
 
 /**
+ * Detects touch-first devices (phones, tablets) at click time.
+ * `(pointer: coarse)` is the standard media query for coarse pointers
+ * like fingers (vs. `fine` for mouse/trackpad).
+ *
+ * Runs only in the browser — always returns false during SSR/first
+ * render, avoiding hydration mismatch. This is fine because the only
+ * place we call it is inside a click handler, which by definition runs
+ * on the client.
+ */
+function isCoarsePointer(): boolean {
+  if (typeof window === "undefined") return false;
+  return window.matchMedia("(pointer: coarse)").matches;
+}
+
+/**
  * Public-facing list of attachments on the Moment page.
- * Unified card treatment for PDFs and images. Click opens the viewer modal.
+ *
+ * Click behavior differs by device:
+ * - **Touch device (mobile, tablet)**: opens the file directly in a new
+ *   browser tab. The native full-screen reader (iOS Quick Look, Android
+ *   PDF viewer, image viewer) has proper pinch-to-zoom and orientation
+ *   handling. In PWA standalone mode, the file opens in the system
+ *   browser — the user leaves the PWA temporarily, then returns via
+ *   task switching. Acceptable trade-off vs. embedding pdf.js + a zoom
+ *   library (~400 KB).
+ * - **Desktop (fine pointer)**: opens the in-page viewer modal with
+ *   inline preview (iframe for PDFs, <img> for images). Users can still
+ *   open in a new tab from the modal if they want zoom or printing.
  */
 export function MomentAttachmentsList({
   attachments,
@@ -28,6 +54,14 @@ export function MomentAttachmentsList({
   const [openAttachment, setOpenAttachment] = useState<MomentAttachment | null>(
     null
   );
+
+  const handleCardClick = useCallback((attachment: MomentAttachment) => {
+    if (isCoarsePointer()) {
+      window.open(attachment.url, "_blank", "noopener,noreferrer");
+      return;
+    }
+    setOpenAttachment(attachment);
+  }, []);
 
   if (attachments.length === 0) return null;
 
@@ -46,7 +80,7 @@ export function MomentAttachmentsList({
               <li key={attachment.id} role="listitem">
                 <button
                   type="button"
-                  onClick={() => setOpenAttachment(attachment)}
+                  onClick={() => handleCardClick(attachment)}
                   className="border-border bg-card hover:bg-muted hover:border-primary/20 flex min-h-14 w-full items-center gap-3.5 rounded-lg border px-4 py-3 text-left transition-colors"
                 >
                   <div className="bg-primary/10 text-primary flex size-8 shrink-0 items-center justify-center rounded-lg">


### PR DESCRIPTION
## Problem

Les utilisateurs mobiles ne pouvaient pas zoomer sur les documents (menus, catalogues, plans). La modale de consultation affichait un iframe PDF ou une balise `<img>`, mais le pinch-to-zoom était intercepté par le boundary de la modale/iframe — rendant la lecture difficile sur téléphone.

En plus, il fallait **2 taps** pour accéder au contenu lisible : tap sur la carte → modale → tap sur un bouton → ouverture externe.

## Fix

Deux changements complémentaires :

### 1. Desktop — bouton "Ouvrir dans un nouvel onglet" dans la modale
Ajout d'une action `ExternalLink` dans le header de `AttachmentViewerDialog`, à côté de Télécharger et Fermer. Utile pour :
- Ouvrir le PDF en plein onglet pour le lire tranquillement
- Imprimer via les contrôles navigateur
- Zoomer avec les raccourcis clavier du navigateur

### 2. Touch device — tap direct sur la carte, pas de modale
Détection via `window.matchMedia('(pointer: coarse)')` **au moment du click** (pas à l'hydratation → zéro problème SSR). Sur touch device, le tap sur la carte ouvre directement le fichier dans un nouvel onglet — le lecteur natif iOS/Android prend le relais avec :
- Pinch-to-zoom
- Rotation / orientation
- Recherche dans le PDF (iOS)
- Partage / impression / AirDrop

**1 seule action** au lieu de 2 sur mobile.

### Desktop inchangé
Click carte → modale (preview inline) → choix entre Ouvrir / Télécharger / Fermer.

## Mode PWA

En PWA standalone, `window.open(url, '_blank')` ouvre dans le navigateur système (Safari sur iOS, Chrome sur Android). L'utilisateur quitte temporairement la PWA, lit le document avec les contrôles natifs, puis revient via le multitâche. C'est le comportement standard des PWA pour les liens externes.

**Trade-off assumé** : pas de lecteur in-app custom en V1. L'alternative serait d'embarquer pdf.js (~400 KB) + une lib de zoom image, pour un bénéfice marginal vs l'UX native.

## Tests

- **Typecheck** : vert
- **Tests unitaires** : inchangés (26 tests domain toujours verts)
- **E2E Playwright** : les tests tournent sur Desktop Chrome (`pointer: fine`) → continuent de tester le flow modale. Le flow mobile n'est pas couvert par un test Playwright dédié pour l'instant — `matchMedia` nécessiterait une config device emulation qui complique le spec. À ajouter en V1.1 si besoin.

## Test plan manuel

- [ ] **Desktop** : click sur une carte → modale s'ouvre → click "Ouvrir" → fichier s'ouvre dans nouvel onglet
- [ ] **Desktop** : click sur une carte → modale → click "Télécharger" → fichier se télécharge
- [ ] **Desktop** : click sur une carte → modale → Escape ferme
- [ ] **Mobile (Chrome ou Safari)** : tap sur une carte PDF → s'ouvre directement dans un nouvel onglet → pinch-to-zoom fonctionne
- [ ] **Mobile** : tap sur une carte image → ouverture directe → pinch-to-zoom sur l'image
- [ ] **Mobile PWA (si installée)** : tap sur une carte → Safari/Chrome s'ouvre avec le doc, puis retour à la PWA via le switcher d'apps

🤖 Generated with [Claude Code](https://claude.com/claude-code)