### PR TITLE
chore(moment-attachments): simplify after code review

### DIFF
--- a/src/app/actions/moment-attachments.ts
+++ b/src/app/actions/moment-attachments.ts
@@ -10,6 +10,7 @@ import {
   prismaCircleRepository,
 } from "@/infrastructure/repositories";
 import { vercelBlobStorageService } from "@/infrastructure/services/storage/vercel-blob-storage-service";
+import { prismaRateLimiter } from "@/infrastructure/services/rate-limiter/prisma-rate-limiter";
 import { addMomentAttachment } from "@/domain/usecases/add-moment-attachment";
 import { removeMomentAttachment } from "@/domain/usecases/remove-moment-attachment";
 import {
@@ -20,16 +21,8 @@ import type { MomentAttachment } from "@/domain/models/moment-attachment";
 import type { ActionResult } from "./types";
 import { DomainError } from "@/domain/errors/domain-error";
 
-/**
- * Uploads a new attachment to a Moment.
- * Called from the moment form options section (drag-and-drop or file picker).
- *
- * Security:
- * - Auth required
- * - Magic number check via file-type (prevents mime spoofing)
- * - Ownership check in the usecase (HOST only)
- * - Size check both in the action (early) and the usecase (defense in depth)
- */
+const UPLOAD_RATE_LIMIT = { max: 10, windowMs: 60 * 1000 };
+
 export async function uploadMomentAttachmentAction(
   momentId: string,
   formData: FormData
@@ -39,12 +32,24 @@ export async function uploadMomentAttachmentAction(
     return { success: false, error: "Non authentifié", code: "UNAUTHORIZED" };
   }
 
+  const rate = await prismaRateLimiter.checkLimit(
+    `attachment-upload:${session.user.id}`,
+    UPLOAD_RATE_LIMIT.max,
+    UPLOAD_RATE_LIMIT.windowMs
+  );
+  if (!rate.allowed) {
+    return {
+      success: false,
+      error: "Trop de tentatives, réessayez dans quelques instants",
+      code: "RATE_LIMITED",
+    };
+  }
+
   const file = formData.get("file") as File | null;
   if (!file || file.size === 0) {
     return { success: false, error: "Fichier manquant", code: "MISSING_FILE" };
   }
 
-  // Early size check (avoid loading a huge file into memory if we know it's too big)
   if (file.size > MAX_ATTACHMENT_SIZE_BYTES) {
     return {
       success: false,
@@ -65,7 +70,7 @@ export async function uploadMomentAttachmentAction(
     };
   }
 
-  // Magic number check: trust the actual bytes, not the declared contentType
+  // Trust the actual bytes, not the client-declared contentType.
   const detected = await fileTypeFromBuffer(buffer);
   const detectedMime = detected?.mime;
   if (!detectedMime || !ALLOWED_ATTACHMENT_CONTENT_TYPES.has(detectedMime)) {
@@ -96,7 +101,6 @@ export async function uploadMomentAttachmentAction(
       }
     );
 
-    // Revalidate the public moment page so the new attachment appears
     revalidatePath(`/m/[slug]`, "page");
 
     return { success: true, data: attachment };
@@ -113,9 +117,6 @@ export async function uploadMomentAttachmentAction(
   }
 }
 
-/**
- * Deletes an attachment. HOST-only (enforced in the usecase).
- */
 export async function deleteMomentAttachmentAction(
   attachmentId: string
 ): Promise<ActionResult<null>> {
@@ -150,4 +151,3 @@ export async function deleteMomentAttachmentAction(
     };
   }
 }
-

--- a/src/app/api/moments/[slug]/attachments/[attachmentId]/download/route.ts
+++ b/src/app/api/moments/[slug]/attachments/[attachmentId]/download/route.ts
@@ -8,18 +8,9 @@ import {
 } from "@/infrastructure/repositories";
 
 /**
- * GET /api/moments/[slug]/attachments/[attachmentId]/download
- *
- * Proxies an attachment blob and forces a download via Content-Disposition.
- *
- * Visibility rules (same as the public moment page):
- * - Moment must exist and not be CANCELLED
- * - If the Circle is PUBLIC: anyone can download
- * - If the Circle is PRIVATE: only ACTIVE members of the Circle can download
- *
- * Why this is a route API (and not a server action):
- * We need to return a binary stream with a Content-Disposition header.
- * Server actions can't set response headers or stream binary content.
+ * Why a route and not a server action: we stream the blob with a
+ * Content-Disposition header to force a real download, which isn't
+ * possible from a server action.
  */
 export async function GET(
   _request: Request,
@@ -28,19 +19,18 @@ export async function GET(
   const { slug, attachmentId } = await params;
 
   try {
-    // 1. Resolve the moment by slug
-    const moment = await prismaMomentRepository.findBySlug(slug);
+    const [moment, attachment] = await Promise.all([
+      prismaMomentRepository.findBySlug(slug),
+      prismaMomentAttachmentRepository.findById(attachmentId),
+    ]);
+
     if (!moment || moment.status === "CANCELLED") {
       return new NextResponse("Not found", { status: 404 });
     }
-
-    // 2. Resolve the attachment and check it belongs to this moment
-    const attachment = await prismaMomentAttachmentRepository.findById(attachmentId);
     if (!attachment || attachment.momentId !== moment.id) {
       return new NextResponse("Not found", { status: 404 });
     }
 
-    // 3. Visibility check — same rules as the public moment page
     const circle = await prismaCircleRepository.findById(moment.circleId);
     if (!circle) {
       return new NextResponse("Not found", { status: 404 });
@@ -60,7 +50,6 @@ export async function GET(
       }
     }
 
-    // 4. Fetch the blob from Vercel Blob
     const blobResponse = await fetch(attachment.url);
     if (!blobResponse.ok || !blobResponse.body) {
       Sentry.captureMessage(
@@ -69,8 +58,7 @@ export async function GET(
       return new NextResponse("Not found", { status: 404 });
     }
 
-    // 5. Stream the response with a Content-Disposition header that forces download.
-    //    RFC 5987 filename* parameter supports non-ASCII characters.
+    // RFC 5987: filename* supports non-ASCII, filename is the ASCII fallback
     const asciiFilename = attachment.filename.replace(/[^\x20-\x7e]/g, "_");
     const encodedFilename = encodeURIComponent(attachment.filename);
     const contentDisposition = `attachment; filename="${asciiFilename}"; filename*=UTF-8''${encodedFilename}`;
@@ -80,7 +68,6 @@ export async function GET(
         "Content-Type": attachment.contentType,
         "Content-Disposition": contentDisposition,
         "Content-Length": String(attachment.sizeBytes),
-        // Prevent intermediary caches from serving stale content to wrong users.
         "Cache-Control": "private, no-store",
       },
     });

--- a/src/components/moments/attachment-format.ts
+++ b/src/components/moments/attachment-format.ts
@@ -1,3 +1,11 @@
+export function isImageAttachment(contentType: string): boolean {
+  return contentType.startsWith("image/");
+}
+
+export function isPdfAttachment(contentType: string): boolean {
+  return contentType === "application/pdf";
+}
+
 /**
  * Format bytes as "X KB" or "X,Y MB" (French decimal separator).
  */

--- a/src/components/moments/attachment-viewer-dialog.tsx
+++ b/src/components/moments/attachment-viewer-dialog.tsx
@@ -5,7 +5,12 @@ import { useTranslations } from "next-intl";
 import { Dialog as DialogPrimitive } from "radix-ui";
 import type { MomentAttachment } from "@/domain/models/moment-attachment";
 import { cn } from "@/lib/utils";
-import { formatAttachmentSize, formatAttachmentType } from "./attachment-format";
+import {
+  formatAttachmentSize,
+  formatAttachmentType,
+  isImageAttachment,
+  isPdfAttachment,
+} from "./attachment-format";
 
 type AttachmentViewerDialogProps = {
   attachment: MomentAttachment | null;
@@ -26,8 +31,8 @@ export function AttachmentViewerDialog({
   const t = useTranslations("Moment.public.attachments");
 
   const isOpen = attachment !== null;
-  const isImage = attachment?.contentType.startsWith("image/") ?? false;
-  const isPdf = attachment?.contentType === "application/pdf";
+  const isImage = attachment ? isImageAttachment(attachment.contentType) : false;
+  const isPdf = attachment ? isPdfAttachment(attachment.contentType) : false;
 
   const downloadHref = attachment
     ? `/api/moments/${momentSlug}/attachments/${attachment.id}/download`

--- a/src/components/moments/moment-attachments-editor.tsx
+++ b/src/components/moments/moment-attachments-editor.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ReactNode } from "react";
 import {
   forwardRef,
   useCallback,
@@ -7,17 +8,24 @@ import {
   useRef,
   useState,
 } from "react";
-import { FileText, ImageIcon, Upload, X, AlertCircle } from "lucide-react";
+import {
+  AlertCircle,
+  FileText,
+  ImageIcon,
+  Upload,
+  X,
+  type LucideIcon,
+} from "lucide-react";
 import { useTranslations } from "next-intl";
 import type { MomentAttachment } from "@/domain/models/moment-attachment";
 import {
-  MAX_ATTACHMENTS_PER_MOMENT,
-  MAX_ATTACHMENT_SIZE_BYTES,
   ALLOWED_ATTACHMENT_CONTENT_TYPES,
+  MAX_ATTACHMENT_SIZE_BYTES,
+  MAX_ATTACHMENTS_PER_MOMENT,
 } from "@/domain/models/moment-attachment";
 import {
-  uploadMomentAttachmentAction,
   deleteMomentAttachmentAction,
+  uploadMomentAttachmentAction,
 } from "@/app/actions/moment-attachments";
 import {
   AlertDialog,
@@ -29,16 +37,12 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import { formatAttachmentSize } from "./attachment-format";
+import {
+  formatAttachmentSize,
+  isImageAttachment,
+} from "./attachment-format";
 
-/** Local file held in the staging list (create mode — moment doesn't exist yet). */
-type StagedFile = {
-  tempId: string;
-  file: File;
-  error?: string;
-};
-
-/** Upload in progress (live mode — moment exists, upload fired). */
+type StagedFile = { tempId: string; file: File; error?: string };
 type UploadingFile = {
   tempId: string;
   filename: string;
@@ -48,17 +52,13 @@ type UploadingFile = {
 };
 
 type MomentAttachmentsEditorProps = {
-  /** Moment ID if editing an existing moment (live mode). Null during creation (staged mode). */
+  /** Null during creation (staged mode), set when editing an existing moment (live mode). */
   momentId: string | null;
   initialAttachments?: MomentAttachment[];
 };
 
 export type MomentAttachmentsEditorHandle = {
-  /**
-   * In staged mode: uploads all staged files to the newly-created moment.
-   * Resolves once all uploads complete (success or error).
-   * Returns the number of files that failed to upload.
-   */
+  /** Upload every staged file to the newly-created moment. Resolves with the error count. */
   flushStaged(momentId: string): Promise<{ failedCount: number }>;
   hasStagedFiles(): boolean;
 };
@@ -66,15 +66,18 @@ export type MomentAttachmentsEditorHandle = {
 const MAX_MB = MAX_ATTACHMENT_SIZE_BYTES / 1024 / 1024;
 const ACCEPT = Array.from(ALLOWED_ATTACHMENT_CONTENT_TYPES).join(",");
 
+function newTempId(): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  return `${Date.now()}-${Math.random()}`;
+}
+
 /**
- * Attachments editor displayed in the Moment form.
- *
- * Two modes:
- * - **Staged mode** (create): moment doesn't exist yet. Files are held in
- *   browser memory as File objects, no upload happens. After the moment is
- *   created, the parent calls `flushStaged(momentId)` via ref to upload them.
- * - **Live mode** (edit): moment exists. Each dropped/picked file is uploaded
- *   immediately via server action.
+ * Two modes, picked by `momentId`:
+ * - **Staged** (create): files stay in browser memory until the parent
+ *   calls `flushStaged(newMomentId)` via ref after the moment is created.
+ * - **Live** (edit): each dropped file is uploaded immediately.
  */
 export const MomentAttachmentsEditor = forwardRef<
   MomentAttachmentsEditorHandle,
@@ -113,7 +116,6 @@ export const MomentAttachmentsEditor = forwardRef<
     [t]
   );
 
-  // ── File intake (both modes) ─────────────────────────────
   const handleFiles = useCallback(
     async (files: FileList | File[]) => {
       setGlobalError(null);
@@ -131,23 +133,17 @@ export const MomentAttachmentsEditor = forwardRef<
       }
 
       for (const file of toProcess) {
-        const tempId = `${file.name}-${Date.now()}-${Math.random()}`;
+        const tempId = newTempId();
         const clientError = clientValidate(file);
 
-        // Staged mode: just add to the local list (no upload yet)
         if (!isLiveMode) {
           setStaged((prev) => [
             ...prev,
-            {
-              tempId,
-              file,
-              error: clientError ?? undefined,
-            },
+            { tempId, file, error: clientError ?? undefined },
           ]);
           continue;
         }
 
-        // Live mode: upload immediately
         if (clientError) {
           setUploading((prev) => [
             ...prev,
@@ -191,7 +187,6 @@ export const MomentAttachmentsEditor = forwardRef<
     [clientValidate, isLiveMode, momentId, t, totalCount]
   );
 
-  // ── Imperative handle: flushStaged (called by parent after create) ───
   useImperativeHandle(
     ref,
     () => ({
@@ -199,10 +194,8 @@ export const MomentAttachmentsEditor = forwardRef<
         const filesToUpload = staged.filter((s) => !s.error);
         if (filesToUpload.length === 0) return { failedCount: 0 };
 
-        // Move every staged file to the "uploading" state at once so the user
-        // immediately sees one card per file with the pulse progress bar.
-        // This provides real-time feedback during the flush, instead of a
-        // silent wait while uploads happen in the background.
+        // Move staged files to the uploading state immediately so the user
+        // sees progress cards instead of a silent wait during the flush.
         const uploadingEntries: UploadingFile[] = filesToUpload.map((s) => ({
           tempId: s.tempId,
           filename: s.file.name,
@@ -214,9 +207,6 @@ export const MomentAttachmentsEditor = forwardRef<
 
         let failedCount = 0;
 
-        // Upload all files in parallel — faster than a sequential for-await loop.
-        // Each upload updates its own card as soon as it resolves (success =>
-        // card moves to attachments, failure => card shows error state).
         await Promise.all(
           filesToUpload.map(async (stagedFile) => {
             const formData = new FormData();
@@ -252,7 +242,6 @@ export const MomentAttachmentsEditor = forwardRef<
     [staged]
   );
 
-  // ── Drag & drop handlers ─────────────────────────────────
   const onDrop = useCallback(
     (e: React.DragEvent) => {
       e.preventDefault();
@@ -288,7 +277,6 @@ export const MomentAttachmentsEditor = forwardRef<
     [handleFiles]
   );
 
-  // ── Delete / remove handlers ─────────────────────────────
   const onConfirmDelete = useCallback(async () => {
     if (!pendingDelete) return;
     const id = pendingDelete.id;
@@ -311,6 +299,7 @@ export const MomentAttachmentsEditor = forwardRef<
 
   const isEmpty =
     attachments.length === 0 && staged.length === 0 && uploading.length === 0;
+  const removeAriaLabel = t("deleteConfirmAction");
 
   return (
     <div className="space-y-3">
@@ -323,7 +312,6 @@ export const MomentAttachmentsEditor = forwardRef<
         </span>
       </div>
 
-      {/* Dropzone — only when empty */}
       {isEmpty && (
         <button
           type="button"
@@ -349,7 +337,6 @@ export const MomentAttachmentsEditor = forwardRef<
         </button>
       )}
 
-      {/* Cards list */}
       {!isEmpty && (
         <div
           onDrop={onDrop}
@@ -357,130 +344,71 @@ export const MomentAttachmentsEditor = forwardRef<
           onDragLeave={onDragLeave}
           className={`space-y-2 ${isDragging ? "ring-primary rounded-lg ring-2" : ""}`}
         >
-          {/* Persistent attachments (live mode) */}
-          {attachments.map((a) => {
-            const isImage = a.contentType.startsWith("image/");
-            const Icon = isImage ? ImageIcon : FileText;
-            return (
-              <div
-                key={a.id}
-                className="border-border bg-muted flex min-h-14 items-center gap-3 rounded-lg border px-4 py-3"
-              >
-                <div className="text-muted-foreground flex size-8 shrink-0 items-center justify-center">
-                  <Icon className="size-4" />
-                </div>
-                <div className="min-w-0 flex-1">
-                  <p className="text-foreground truncate text-sm font-medium">
-                    {a.filename}
-                  </p>
-                  <p className="text-muted-foreground mt-0.5 text-xs">
-                    {formatAttachmentSize(a.sizeBytes)}
-                  </p>
-                </div>
-                <button
-                  type="button"
-                  onClick={() => setPendingDelete(a)}
-                  className="hover:bg-destructive/10 hover:text-destructive text-muted-foreground flex size-7 shrink-0 items-center justify-center rounded transition-colors"
-                  aria-label={t("deleteConfirmAction")}
-                >
-                  <X className="size-4" />
-                </button>
-              </div>
-            );
-          })}
+          {attachments.map((a) => (
+            <AttachmentCard
+              key={a.id}
+              icon={isImageAttachment(a.contentType) ? ImageIcon : FileText}
+              filename={a.filename}
+              subtitle={formatAttachmentSize(a.sizeBytes)}
+              onRemove={() => setPendingDelete(a)}
+              removeAriaLabel={removeAriaLabel}
+            />
+          ))}
 
-          {/* Staged files (create mode — not yet uploaded) */}
-          {staged.map((s) => {
-            const isImage = s.file.type.startsWith("image/");
-            const Icon = s.error ? AlertCircle : isImage ? ImageIcon : FileText;
-            return (
-              <div
-                key={s.tempId}
-                className={`flex min-h-14 items-center gap-3 rounded-lg border px-4 py-3 ${
-                  s.error
-                    ? "border-destructive/30 bg-destructive/5"
-                    : "border-border bg-muted"
-                }`}
-              >
-                <div
-                  className={`flex size-8 shrink-0 items-center justify-center ${
-                    s.error ? "text-destructive" : "text-muted-foreground"
-                  }`}
-                >
-                  <Icon className="size-4" />
-                </div>
-                <div className="min-w-0 flex-1">
-                  <p className="text-foreground truncate text-sm font-medium">
-                    {s.file.name}
-                  </p>
-                  {s.error ? (
-                    <p className="text-destructive mt-0.5 text-xs">{s.error}</p>
-                  ) : (
-                    <p className="text-muted-foreground mt-0.5 text-xs">
-                      {formatAttachmentSize(s.file.size)}
-                    </p>
-                  )}
-                </div>
-                <button
-                  type="button"
-                  onClick={() => onRemoveStaged(s.tempId)}
-                  className="hover:bg-destructive/10 hover:text-destructive text-muted-foreground flex size-7 shrink-0 items-center justify-center rounded transition-colors"
-                  aria-label={t("deleteConfirmAction")}
-                >
-                  <X className="size-4" />
-                </button>
-              </div>
-            );
-          })}
+          {staged.map((s) => (
+            <AttachmentCard
+              key={s.tempId}
+              icon={
+                s.error
+                  ? AlertCircle
+                  : isImageAttachment(s.file.type)
+                    ? ImageIcon
+                    : FileText
+              }
+              filename={s.file.name}
+              subtitle={
+                s.error ? (
+                  <span className="text-destructive">{s.error}</span>
+                ) : (
+                  formatAttachmentSize(s.file.size)
+                )
+              }
+              hasError={!!s.error}
+              onRemove={() => onRemoveStaged(s.tempId)}
+              removeAriaLabel={removeAriaLabel}
+            />
+          ))}
 
-          {/* In-progress uploads (live mode) */}
-          {uploading.map((u) => {
-            const isImage = u.contentType.startsWith("image/");
-            const Icon = u.error ? AlertCircle : isImage ? ImageIcon : FileText;
-            return (
-              <div
-                key={u.tempId}
-                className={`flex min-h-14 items-center gap-3 rounded-lg border px-4 py-3 ${
-                  u.error
-                    ? "border-destructive/30 bg-destructive/5"
-                    : "border-border bg-muted"
-                }`}
-              >
-                <div
-                  className={`flex size-8 shrink-0 items-center justify-center ${
-                    u.error ? "text-destructive" : "text-muted-foreground"
-                  }`}
-                >
-                  <Icon className="size-4" />
-                </div>
-                <div className="min-w-0 flex-1">
-                  <p className="text-foreground truncate text-sm font-medium">
-                    {u.filename}
-                  </p>
-                  {u.error ? (
-                    <p className="text-destructive mt-0.5 text-xs">{u.error}</p>
-                  ) : (
-                    <>
-                      <div className="bg-border mt-1.5 h-1 overflow-hidden rounded-full">
-                        <div className="bg-primary h-full w-1/2 animate-pulse" />
-                      </div>
-                      <p className="text-muted-foreground mt-1 text-xs">
-                        {t("uploading")} · {formatAttachmentSize(u.sizeBytes)}
-                      </p>
-                    </>
-                  )}
-                </div>
-                <button
-                  type="button"
-                  onClick={() => onCancelUpload(u.tempId)}
-                  className="hover:bg-destructive/10 hover:text-destructive text-muted-foreground flex size-7 shrink-0 items-center justify-center rounded transition-colors"
-                  aria-label={t("deleteConfirmAction")}
-                >
-                  <X className="size-4" />
-                </button>
-              </div>
-            );
-          })}
+          {uploading.map((u) => (
+            <AttachmentCard
+              key={u.tempId}
+              icon={
+                u.error
+                  ? AlertCircle
+                  : isImageAttachment(u.contentType)
+                    ? ImageIcon
+                    : FileText
+              }
+              filename={u.filename}
+              subtitle={
+                u.error ? (
+                  <span className="text-destructive">{u.error}</span>
+                ) : (
+                  <>
+                    <span className="bg-border mt-1.5 block h-1 overflow-hidden rounded-full">
+                      <span className="bg-primary block h-full w-1/2 animate-pulse" />
+                    </span>
+                    <span className="mt-1 block">
+                      {t("uploading")} · {formatAttachmentSize(u.sizeBytes)}
+                    </span>
+                  </>
+                )
+              }
+              hasError={!!u.error}
+              onRemove={() => onCancelUpload(u.tempId)}
+              removeAriaLabel={removeAriaLabel}
+            />
+          ))}
 
           {canAddMore && (
             <button
@@ -533,3 +461,51 @@ export const MomentAttachmentsEditor = forwardRef<
     </div>
   );
 });
+
+type AttachmentCardProps = {
+  icon: LucideIcon;
+  filename: string;
+  subtitle: ReactNode;
+  hasError?: boolean;
+  onRemove: () => void;
+  removeAriaLabel: string;
+};
+
+function AttachmentCard({
+  icon: Icon,
+  filename,
+  subtitle,
+  hasError = false,
+  onRemove,
+  removeAriaLabel,
+}: AttachmentCardProps) {
+  return (
+    <div
+      className={`flex min-h-14 items-center gap-3 rounded-lg border px-4 py-3 ${
+        hasError
+          ? "border-destructive/30 bg-destructive/5"
+          : "border-border bg-muted"
+      }`}
+    >
+      <div
+        className={`flex size-8 shrink-0 items-center justify-center ${
+          hasError ? "text-destructive" : "text-muted-foreground"
+        }`}
+      >
+        <Icon className="size-4" />
+      </div>
+      <div className="min-w-0 flex-1">
+        <p className="text-foreground truncate text-sm font-medium">{filename}</p>
+        <p className="text-muted-foreground mt-0.5 text-xs">{subtitle}</p>
+      </div>
+      <button
+        type="button"
+        onClick={onRemove}
+        className="hover:bg-destructive/10 hover:text-destructive text-muted-foreground flex size-7 shrink-0 items-center justify-center rounded transition-colors"
+        aria-label={removeAriaLabel}
+      >
+        <X className="size-4" />
+      </button>
+    </div>
+  );
+}

--- a/src/components/moments/moment-attachments-list.tsx
+++ b/src/components/moments/moment-attachments-list.tsx
@@ -9,6 +9,7 @@ import {
   formatAttachmentName,
   formatAttachmentSize,
   formatAttachmentType,
+  isImageAttachment,
 } from "./attachment-format";
 
 type MomentAttachmentsListProps = {
@@ -74,8 +75,7 @@ export function MomentAttachmentsList({
 
         <ul role="list" className="flex flex-col gap-2">
           {attachments.map((attachment) => {
-            const isImage = attachment.contentType.startsWith("image/");
-            const Icon = isImage ? ImageIcon : FileText;
+            const Icon = isImageAttachment(attachment.contentType) ? ImageIcon : FileText;
             return (
               <li key={attachment.id} role="listitem">
                 <button

--- a/src/domain/usecases/add-moment-attachment.ts
+++ b/src/domain/usecases/add-moment-attachment.ts
@@ -34,17 +34,6 @@ type AddMomentAttachmentDeps = {
   storage: StorageService;
 };
 
-/**
- * Adds a new attachment (PDF or image) to an event.
- *
- * Rules:
- * - Only HOST members of the Moment's Circle can add attachments
- * - Max 3 attachments per Moment (MAX_ATTACHMENTS_PER_MOMENT)
- * - Max 10 MB per file (MAX_ATTACHMENT_SIZE_BYTES)
- * - Allowed types: PDF, JPEG, PNG, WEBP (ALLOWED_ATTACHMENT_CONTENT_TYPES)
- *
- * Storage path: `moment-attachments/${momentId}-${Date.now()}-${safeFilename}`
- */
 export async function addMomentAttachment(
   input: AddMomentAttachmentInput,
   deps: AddMomentAttachmentDeps
@@ -52,43 +41,37 @@ export async function addMomentAttachment(
   const { attachmentRepository, momentRepository, circleRepository, storage } =
     deps;
 
-  // 1. Moment exists
+  // Cheap input validation first — fail fast before any DB round-trip.
+  if (!ALLOWED_ATTACHMENT_CONTENT_TYPES.has(input.file.contentType)) {
+    throw new AttachmentTypeNotAllowedError(input.file.contentType);
+  }
+  if (input.file.sizeBytes > MAX_ATTACHMENT_SIZE_BYTES) {
+    throw new AttachmentTooLargeError(MAX_ATTACHMENT_SIZE_BYTES);
+  }
+
   const moment = await momentRepository.findById(input.momentId);
   if (!moment) {
     throw new MomentNotFoundError(input.momentId);
   }
 
-  // 2. Ownership: user must be HOST of the Circle
-  const membership = await circleRepository.findMembership(
-    moment.circleId,
-    input.userId
-  );
+  const [membership, count] = await Promise.all([
+    circleRepository.findMembership(moment.circleId, input.userId),
+    attachmentRepository.countByMoment(input.momentId),
+  ]);
+
   if (!membership || membership.role !== "HOST") {
     throw new UnauthorizedMomentActionError();
   }
-
-  // 3. Type check
-  if (!ALLOWED_ATTACHMENT_CONTENT_TYPES.has(input.file.contentType)) {
-    throw new AttachmentTypeNotAllowedError(input.file.contentType);
-  }
-
-  // 4. Size check
-  if (input.file.sizeBytes > MAX_ATTACHMENT_SIZE_BYTES) {
-    throw new AttachmentTooLargeError(MAX_ATTACHMENT_SIZE_BYTES);
-  }
-
-  // 5. Limit check
-  const count = await attachmentRepository.countByMoment(input.momentId);
   if (count >= MAX_ATTACHMENTS_PER_MOMENT) {
     throw new AttachmentLimitReachedError(MAX_ATTACHMENTS_PER_MOMENT);
   }
 
-  // 6. Upload to storage (format preserved, no conversion)
+  // Format is preserved (no WebP conversion, unlike cover images) so
+  // participants download a bit-identical copy of what the host uploaded.
   const safeFilename = sanitizeFilename(input.file.filename);
   const path = `moment-attachments/${input.momentId}-${Date.now()}-${safeFilename}`;
   const url = await storage.upload(path, input.file.buffer, input.file.contentType);
 
-  // 7. Persist — keep the ORIGINAL filename for display (not the sanitized one)
   return attachmentRepository.create({
     momentId: input.momentId,
     url,
@@ -98,15 +81,7 @@ export async function addMomentAttachment(
   });
 }
 
-/**
- * Sanitizes a filename for use in a URL path:
- * - Strips non-ASCII characters (accents, emoji)
- * - Replaces spaces and sequences of non-safe chars with "-"
- * - Trims leading/trailing "-"
- * - Fallback to "file" if the result is empty
- */
 function sanitizeFilename(filename: string): string {
-  // eslint-disable-next-line no-control-regex
   const ascii = filename.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
   const safe = ascii
     .replace(/[^a-zA-Z0-9._-]+/g, "-")

--- a/src/domain/usecases/remove-moment-attachment.ts
+++ b/src/domain/usecases/remove-moment-attachment.ts
@@ -20,12 +20,6 @@ type RemoveMomentAttachmentDeps = {
   storage: StorageService;
 };
 
-/**
- * Removes an attachment: deletes the blob first, then the DB row.
- *
- * If the blob deletion fails, the DB row is NOT deleted (consistency).
- * Only HOST members of the Moment's Circle can remove attachments.
- */
 export async function removeMomentAttachment(
   input: RemoveMomentAttachmentInput,
   deps: RemoveMomentAttachmentDeps
@@ -33,20 +27,16 @@ export async function removeMomentAttachment(
   const { attachmentRepository, momentRepository, circleRepository, storage } =
     deps;
 
-  // 1. Attachment exists
   const attachment = await attachmentRepository.findById(input.attachmentId);
   if (!attachment) {
     throw new AttachmentNotFoundError(input.attachmentId);
   }
 
-  // 2. Load parent Moment to resolve the Circle
   const moment = await momentRepository.findById(attachment.momentId);
   if (!moment) {
-    // Orphan attachment — should not happen but handle defensively
     throw new MomentNotFoundError(attachment.momentId);
   }
 
-  // 3. Ownership check
   const membership = await circleRepository.findMembership(
     moment.circleId,
     input.userId
@@ -55,9 +45,8 @@ export async function removeMomentAttachment(
     throw new UnauthorizedMomentActionError();
   }
 
-  // 4. Delete blob first (if this fails, DB row remains — consistency)
+  // Delete the blob before the DB row: if the blob delete fails, the row
+  // stays so the attachment is still recoverable — avoids orphan blobs.
   await storage.delete(attachment.url);
-
-  // 5. Delete DB row
   await attachmentRepository.delete(attachment.id);
 }


### PR DESCRIPTION
## Summary

Passe de `/simplify` sur la feature moment-attachments après merge. 3 agents de review (reuse / quality / efficiency) ont été lancés en parallèle sur le code de la feature, j'ai aggregé et appliqué les findings locaux. Les dettes plus larges (affectant 6+ usecases ou 42 sites d'actions) sont laissées pour de futurs refactors dédiés.

**Net : -60 lignes (209 +, 269 −), 26 tests unit verts, 4 tests E2E verts**.

## Changements

### Sécurité / correctness
- **RateLimiter câblé** sur `uploadMomentAttachmentAction` — 10 uploads/min/user via le port `RateLimiter` existant + `prismaRateLimiter`. La spec disait que ça devait être là, la première implémentation l'avait oublié. Code d'erreur `RATE_LIMITED`.

### Efficacité
- **`addMomentAttachment` usecase** : checks type/taille déplacés **avant** les queries DB (fail fast sur fichier invalide, évite les round-trips inutiles). Membership check et count parallélisés via `Promise.all`. 3 RTT séquentiels → 1 + une paire parallèle.
- **Download route** : `moment` et `attachment` fetchés en parallèle (indépendants, le match `momentId` est juste un post-check). −1 RTT par download sur le hot path.

### Qualité
- **`<AttachmentCard>` subcomponent extrait** dans l'éditeur. Remplace 3 blocs JSX quasi-identiques (~40 lignes chacun) pour les états persistent / staged / uploading. ~100 lignes de duplication supprimées.
- **Helpers `isImageAttachment` / `isPdfAttachment`** dans `attachment-format.ts`. Remplace 5+ sites qui répétaient `contentType.startsWith("image/")` ou `=== "application/pdf"`.
- **`crypto.randomUUID()`** pour `tempId` (avec fallback `Date.now() + Math.random()`) au lieu de générer des IDs fragiles.
- **Cut narration comments** agressivement partout. Gardé uniquement les **WHY** non-évidents :
  - Staged vs live mode dans l'éditeur
  - Blob-first-delete pour éviter les orphelins
  - Defense magic number contre MIME spoofing
  - RFC 5987 pour l'encodage filename

### Confirmé déjà optimal (pas de changement)
- `flushStaged` utilise bien `Promise.all` pour parallélisation réelle
- `deleteMomentAction` cleanup blob déjà parallélisé
- Page publique charge les attachments dans le `Promise.all` existant
- `findByMoment` retourne toutes les colonnes (chaque consumer en a besoin)

## Hors scope (pour de futurs refactors dédiés)

Les agents ont identifié trois dettes plus larges qui dépassent le scope d'un /simplify :

- **Discriminated-union state dans l'éditeur** + lift staged state au parent pour éliminer `forwardRef / useImperativeHandle`. Refactor conséquent, mérite sa propre PR.
- **`assertUserIsHostOfMoment` helper** pour déduper le triplet `findById moment → findMembership → throw unauthorized` répété dans 6+ usecases (attachments, update-moment, delete-moment, publish-moment, etc.). Pre-existing debt, pas introduit par cette feature.
- **`toActionResult` helper** pour déduper le mapping `DomainError → ActionResult` sur **42 sites d'actions** (`instanceof DomainError ? ... : Sentry.captureException`). Pre-existing debt, pas introduit par cette feature.

## Tests

- **Typecheck** : vert
- **26 tests unitaires domain** (add + remove usecases) : verts — le reorder des checks reste compatible car chaque test vise un cas précis
- **4 tests E2E Playwright** : verts (19.3s) — pas de régression UI malgré l'extraction du `<AttachmentCard>` et la simplification de l'éditeur

## Test plan

- [ ] Créer un événement avec un PDF attaché → vérifier que tout fonctionne (upload, display, viewer modal)
- [ ] Éditer un événement existant → ajouter un attachment → vérifier que ça upload immédiatement
- [ ] Tenter 11 uploads successifs dans la minute → 11ème doit échouer avec `RATE_LIMITED`
- [ ] Tenter un upload avec un .docx → erreur `ATTACHMENT_TYPE_NOT_ALLOWED` (doit être plus rapide qu'avant — fail fast avant les queries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)