### PR TITLE
fix(cron): accept GET method + surface errors to Sentry

### DIFF
--- a/src/app/api/cron/posthog-daily-report/route.ts
+++ b/src/app/api/cron/posthog-daily-report/route.ts
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/nextjs";
 import { NextRequest, NextResponse } from "next/server";
 import { Resend } from "resend";
 import { getSender } from "@/infrastructure/services/email/resend-email-service";
@@ -7,28 +8,38 @@ import { buildReportHtml } from "./build-report-html";
 import { extractReportKpis } from "./extract-report-kpis";
 
 /**
- * POST /api/cron/posthog-daily-report
+ * GET /api/cron/posthog-daily-report
  *
  * Envoie chaque matin un récap HTML du dashboard PostHog "Synthèse trafic
  * quotidienne" (trafic 24h, interactions, engagement, top pages) au
  * destinataire configuré via DAILY_REPORT_RECIPIENT.
  *
  * Déclenché quotidiennement à 08:07 UTC via Vercel Cron (vercel.json).
+ * Vercel Cron invoque les endpoints en GET — on expose aussi POST pour
+ * permettre un déclenchement manuel (scripts, curl, tests).
  * Protection : header Authorization: Bearer CRON_SECRET
  */
 
 const DASHBOARD_ID = 601861;
 const DASHBOARD_URL = `https://eu.posthog.com/project/134622/dashboard/${DASHBOARD_ID}`;
 
-export async function POST(request: NextRequest) {
+async function handler(request: NextRequest) {
   const authHeader = request.headers.get("authorization");
   if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    Sentry.captureMessage(
+      "[cron] posthog-daily-report: unauthorized request",
+      "warning"
+    );
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
   const recipient = process.env.DAILY_REPORT_RECIPIENT;
   if (!recipient) {
     console.error("[posthog-daily-report] DAILY_REPORT_RECIPIENT is not configured");
+    Sentry.captureMessage(
+      "[cron] posthog-daily-report: DAILY_REPORT_RECIPIENT is not configured",
+      "error"
+    );
     return NextResponse.json(
       { error: "Recipient not configured" },
       { status: 500 }
@@ -77,9 +88,15 @@ export async function POST(request: NextRequest) {
       `[posthog-daily-report] Erreur après ${durationMs}ms :`,
       error
     );
+    Sentry.captureException(error, {
+      tags: { cron: "posthog-daily-report" },
+      extra: { durationMs, dashboardId: DASHBOARD_ID },
+    });
     return NextResponse.json(
       { error: "Report generation failed" },
       { status: 500 }
     );
   }
 }
+
+export { handler as GET, handler as POST };

--- a/src/app/api/cron/posthog-weekly-report/route.ts
+++ b/src/app/api/cron/posthog-weekly-report/route.ts
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/nextjs";
 import { NextRequest, NextResponse } from "next/server";
 import { Resend } from "resend";
 import { getSender } from "@/infrastructure/services/email/resend-email-service";
@@ -7,7 +8,7 @@ import { buildReportHtml } from "../posthog-daily-report/build-report-html";
 import { extractReportKpis } from "../posthog-daily-report/extract-report-kpis";
 
 /**
- * POST /api/cron/posthog-weekly-report
+ * GET /api/cron/posthog-weekly-report
  *
  * Envoie chaque lundi matin un récap HTML du dashboard PostHog "Synthèse
  * trafic hebdomadaire" (trafic sur 7 jours, interactions, engagement,
@@ -18,15 +19,21 @@ import { extractReportKpis } from "../posthog-daily-report/extract-report-kpis";
  * quotidienne, peak "le lun 06/04", fenêtre "7 derniers jours", etc.).
  *
  * Déclenché chaque lundi à 08:07 UTC via Vercel Cron (vercel.json).
+ * Vercel Cron invoque les endpoints en GET — on expose aussi POST pour
+ * permettre un déclenchement manuel (scripts, curl, tests).
  * Protection : header Authorization: Bearer CRON_SECRET
  */
 
 const DASHBOARD_ID = 615141;
 const DASHBOARD_URL = `https://eu.posthog.com/project/134622/dashboard/${DASHBOARD_ID}`;
 
-export async function POST(request: NextRequest) {
+async function handler(request: NextRequest) {
   const authHeader = request.headers.get("authorization");
   if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    Sentry.captureMessage(
+      "[cron] posthog-weekly-report: unauthorized request",
+      "warning"
+    );
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
@@ -34,6 +41,10 @@ export async function POST(request: NextRequest) {
   if (!recipient) {
     console.error(
       "[posthog-weekly-report] DAILY_REPORT_RECIPIENT is not configured"
+    );
+    Sentry.captureMessage(
+      "[cron] posthog-weekly-report: DAILY_REPORT_RECIPIENT is not configured",
+      "error"
     );
     return NextResponse.json(
       { error: "Recipient not configured" },
@@ -82,9 +93,15 @@ export async function POST(request: NextRequest) {
       `[posthog-weekly-report] Erreur après ${durationMs}ms :`,
       error
     );
+    Sentry.captureException(error, {
+      tags: { cron: "posthog-weekly-report" },
+      extra: { durationMs, dashboardId: DASHBOARD_ID },
+    });
     return NextResponse.json(
       { error: "Report generation failed" },
       { status: 500 }
     );
   }
 }
+
+export { handler as GET, handler as POST };

--- a/src/app/api/cron/recalculate-scores/route.ts
+++ b/src/app/api/cron/recalculate-scores/route.ts
@@ -1,9 +1,10 @@
+import * as Sentry from "@sentry/nextjs";
 import { NextRequest, NextResponse } from "next/server";
 import { recalculateAllScores } from "@/infrastructure/services/recalculate-all-scores";
 import { prismaRateLimiter } from "@/infrastructure/services/rate-limiter/prisma-rate-limiter";
 
 /**
- * POST /api/cron/recalculate-scores
+ * GET /api/cron/recalculate-scores
  *
  * Batch quotidien de recalcul des scores Explorer pour toutes les Communautés
  * (publiques ET privées) et leurs événements publics à venir.
@@ -13,11 +14,17 @@ import { prismaRateLimiter } from "@/infrastructure/services/rate-limiter/prisma
  * Elles n'apparaissent jamais sur Explorer (filtre visibility: PUBLIC dans les requêtes Explorer).
  *
  * Déclenché chaque nuit à 3h via Vercel Cron (vercel.json).
+ * Vercel Cron invoque les endpoints en GET — on expose aussi POST pour
+ * permettre un déclenchement manuel (scripts, curl, tests).
  * Protection : header Authorization: Bearer CRON_SECRET
  */
-export async function POST(request: NextRequest) {
+async function handler(request: NextRequest) {
   const authHeader = request.headers.get("authorization");
   if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    Sentry.captureMessage(
+      "[cron] recalculate-scores: unauthorized request",
+      "warning"
+    );
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
@@ -36,6 +43,11 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ success: true, ...result, rateLimitsPurged: purged });
   } catch (error) {
     console.error("[recalculate-scores] Erreur :", error);
+    Sentry.captureException(error, {
+      tags: { cron: "recalculate-scores" },
+    });
     return NextResponse.json({ error: "Score recalculation failed" }, { status: 500 });
   }
 }
+
+export { handler as GET, handler as POST };

--- a/src/app/api/cron/send-reminders/route.ts
+++ b/src/app/api/cron/send-reminders/route.ts
@@ -1,26 +1,33 @@
+import * as Sentry from "@sentry/nextjs";
 import { NextRequest, NextResponse } from "next/server";
 import { prismaMomentRepository } from "@/infrastructure/repositories";
 import { createResendEmailService } from "@/infrastructure/services";
 import { buildMomentIcs, buildReminderEmailData } from "./build-reminder-email-data";
 
 /**
- * POST /api/cron/send-reminders
+ * GET /api/cron/send-reminders
  *
  * Envoie les rappels email 24h avant chaque événement PUBLISHED.
  * Fenêtre : événements démarrant entre now+22h et now+26h.
  * Idempotence : reminder24hSentAt sur le Moment — un seul envoi garanti.
  *
  * Déclenché toutes les heures via Vercel Cron (vercel.json).
+ * Vercel Cron invoque les endpoints en GET — on expose aussi POST pour
+ * permettre un déclenchement manuel (scripts, curl, tests).
  * Protection : header Authorization: Bearer CRON_SECRET
  */
 
 const emailService = createResendEmailService();
 const APP_URL = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
 
-export async function POST(request: NextRequest) {
+async function handler(request: NextRequest) {
   // 1. Auth check
   const authHeader = request.headers.get("authorization");
   if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    Sentry.captureMessage(
+      "[cron] send-reminders: unauthorized request",
+      "warning"
+    );
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
@@ -62,9 +69,15 @@ export async function POST(request: NextRequest) {
   } catch (error) {
     const durationMs = Date.now() - startedAt;
     console.error(`[send-reminders] Erreur après ${durationMs}ms :`, error);
+    Sentry.captureException(error, {
+      tags: { cron: "send-reminders" },
+      extra: { durationMs },
+    });
     return NextResponse.json(
       { error: "Reminder sending failed" },
       { status: 500 }
     );
   }
 }
+
+export { handler as GET, handler as POST };


### PR DESCRIPTION
## Summary

**Bug critique et ancien** : aucun des 4 crons Vercel ne tournait réellement en production. Tous exportaient `POST` alors que **Vercel Cron Jobs envoient des requêtes GET**. Résultat : chaque invocation cron retournait un `405 Method Not Allowed` au niveau du routeur Next.js, sans jamais atteindre le code métier.

Le bug était invisible car :
- Rien en aval (Resend, Slack, Sentry) n'était jamais appelé
- Aucune exception n'était levée — Next.js refuse la requête avant la fonction handler
- Aucun log applicatif n'apparaissait dans les logs Vercel

Il a fallu une synthèse PostHog quotidienne manquante pour s'en rendre compte.

## Crons affectés

| Cron | Schedule | Impact fonctionnel |
|---|---|---|
| `posthog-daily-report` | `7 8 * * *` (daily) | Rapport trafic quotidien jamais envoyé (ajouté 2026-04-10) |
| `posthog-weekly-report` | `7 8 * * 1` (weekly) | Rapport trafic hebdo jamais envoyé (ajouté 2026-04-10) |
| `send-reminders` | `0 * * * *` (hourly) | **Rappels 24h avant événement jamais envoyés** (bug présent depuis plusieurs semaines) |
| `recalculate-scores` | `0 3 * * *` (daily) | Score Explorer jamais recalculé en batch nocturne (bug présent depuis plusieurs semaines) |

Pour `send-reminders` et `recalculate-scores`, le bug existait probablement depuis leur création — personne ne l'avait remarqué car les rappels automatiques ne sont pas attendus à une heure précise par un humain, et le score Explorer est aussi recalculé à la volée sur chaque création/update de communauté (le batch nocturne n'est donc pas critique pour la cohérence).

## Fix

### A — Accepter GET et POST sur les 4 routes

Chaque route est refactorisée selon le pattern :

```ts
async function handler(request: NextRequest) {
  // ... logique existante inchangée ...
}

export { handler as GET, handler as POST };
```

- `GET` couvre **Vercel Cron** (qui invoque en GET)
- `POST` couvre toute invocation manuelle existante (curl, scripts, tests)

Zéro changement fonctionnel, zéro risque de casser un caller existant.

### B — Remonter les erreurs à Sentry

Avant ce fix, toutes les routes cron logguaient uniquement via `console.error` — un plantage silencieux en prod. Même si le bug GET/POST avait été corrigé il y a 6 mois, la moindre erreur runtime (clé manquante, API PostHog qui change de format, Resend qui bounce…) serait restée invisible jusqu'à ce qu'un humain la remarque.

Ajouts :

- `Sentry.captureException(error, { tags: { cron: '<name>' }, extra: {...} })` dans chaque catch block
- `Sentry.captureMessage` sur les early returns (auth échouée, variable d'env manquante) avec niveaux `warning` ou `error`

## Test plan

### Après merge et déploiement prod

- [ ] Vérifier qu'aucun typecheck / test unit ne casse sur la PR (CI GitHub)
- [ ] Déclencher `posthog-daily-report` via **Run now** dans le dashboard Vercel Crons → recevoir l'email de synthèse dans les 30s
- [ ] Vérifier dans les logs Vercel qu'on voit bien la ligne `[posthog-daily-report] Report sent to X in Yms` (absente aujourd'hui)
- [ ] Déclencher `posthog-weekly-report` via **Run now** → recevoir l'email hebdo (dimanche 12 avril OK pour un test manuel même si le cron auto tourne le lundi)
- [ ] Vérifier que `send-reminders` tourne bien à la prochaine heure pleine (dans les logs Vercel : `[send-reminders] N événement(s) traité(s), M email(s) envoyé(s)`)
- [ ] Vérifier que `recalculate-scores` tourne bien à 3h du matin demain (logs Vercel)

### Vérification Sentry (bonus)

- [ ] Déclencher volontairement une erreur (par ex. en enlevant temporairement `POSTHOG_PERSONAL_API_KEY`) et vérifier qu'un event Sentry apparaît avec le tag `cron: posthog-daily-report`
- [ ] Remettre la clé immédiatement après le test

## Notes

- PR créée depuis un **worktree isolé** (`../the-playground-cron-fix`) pour ne pas interférer avec le repo principal en cours de travail.
- Diff total : 4 fichiers, +67 −8 lignes.
- Aucune migration DB, aucune nouvelle dépendance, aucune nouvelle variable d'environnement.
- Pas de changement de `vercel.json` — le schedule reste identique.

🤖 Generated with [Claude Code](https://claude.com/claude-code)