### PR TITLE
fix(posthog-report): force dashboard refresh before generating report

### DIFF
--- a/src/app/api/cron/posthog-daily-report/fetch-dashboard.ts
+++ b/src/app/api/cron/posthog-daily-report/fetch-dashboard.ts
@@ -57,7 +57,14 @@ export async function fetchPosthogDashboard(
     );
   }
 
-  const url = `${POSTHOG_BASE_URL}/api/projects/${POSTHOG_PROJECT_ID}/dashboards/${dashboardId}/`;
+  // `refresh=force_blocking` : force PostHog à recalculer synchroniquement toutes
+  // les insights du dashboard avant de retourner la réponse, en ignorant le cache.
+  // Sans ce paramètre, PostHog renvoie le dernier cache — qui peut dater de la
+  // dernière consultation manuelle du dashboard, donc donner un rapport périmé
+  // (vu en prod : rapport généré à J affichant la période J-2 → J-1).
+  // Mesuré en local : ~7s pour le daily dashboard (5 tiles), ~8s pour le weekly.
+  // Couvert côté route par `export const maxDuration = 60`.
+  const url = `${POSTHOG_BASE_URL}/api/projects/${POSTHOG_PROJECT_ID}/dashboards/${dashboardId}/?refresh=force_blocking`;
   const response = await fetch(url, {
     headers: {
       Authorization: `Bearer ${apiKey}`,

--- a/src/app/api/cron/posthog-daily-report/route.ts
+++ b/src/app/api/cron/posthog-daily-report/route.ts
@@ -23,6 +23,12 @@ import { extractReportKpis } from "./extract-report-kpis";
 const DASHBOARD_ID = 601861;
 const DASHBOARD_URL = `https://eu.posthog.com/project/134622/dashboard/${DASHBOARD_ID}`;
 
+// Le fetch PostHog avec `?refresh=force_blocking` peut prendre ~7-12s depuis
+// la région Vercel `iad1` vers PostHog EU (round-trip US↔EU). Ajouté au reste
+// du pipeline (Resend + Slack), on approche les 15s. Défaut serverless à 15s,
+// on élargit à 60s pour être large.
+export const maxDuration = 60;
+
 async function handler(request: NextRequest) {
   const authHeader = request.headers.get("authorization");
   if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {

--- a/src/app/api/cron/posthog-weekly-report/route.ts
+++ b/src/app/api/cron/posthog-weekly-report/route.ts
@@ -27,6 +27,13 @@ import { extractReportKpis } from "../posthog-daily-report/extract-report-kpis";
 const DASHBOARD_ID = 615141;
 const DASHBOARD_URL = `https://eu.posthog.com/project/134622/dashboard/${DASHBOARD_ID}`;
 
+// Le fetch PostHog avec `?refresh=force_blocking` peut prendre ~7-12s depuis
+// la région Vercel `iad1` vers PostHog EU (round-trip US↔EU). Ajouté au reste
+// du pipeline (Resend + Slack), on approche les 15s. Défaut serverless à 15s,
+// on élargit à 60s pour être large. Le weekly a plus de data (7j vs 24h) donc
+// un refresh légèrement plus long que le daily.
+export const maxDuration = 60;
+
 async function handler(request: NextRequest) {
   const authHeader = request.headers.get("authorization");
   if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {


### PR DESCRIPTION
## Summary

**Bug observé aujourd'hui** : le premier rapport PostHog quotidien reçu (après le fix GET/POST de la PR #359) affichait **Période : 2026-04-09 → 2026-04-10** alors qu'il était généré le **11/04/2026 à 20h30**. La data avait donc **24-48h de retard**.

**Cause** : l'API PostHog Dashboard renvoie par défaut les insights **en cache**. Si personne n'a consulté le dashboard depuis un certain temps, PostHog renvoie la dernière version calculée — typiquement la dernière consultation manuelle. Le cron quotidien ne déclenche jamais lui-même un recalcul.

## Fix

### `fetch-dashboard.ts` — paramètre `refresh=force_blocking`

```diff
- const url = `${POSTHOG_BASE_URL}/api/projects/${POSTHOG_PROJECT_ID}/dashboards/${dashboardId}/`;
+ const url = `${POSTHOG_BASE_URL}/api/projects/${POSTHOG_PROJECT_ID}/dashboards/${dashboardId}/?refresh=force_blocking`;
```

PostHog recalcule alors **toutes les tiles synchroniquement** avant de retourner la réponse, en ignorant le cache. Résultat garanti frais à chaque exécution.

Ce helper est importé par **les deux routes** (`posthog-daily-report` et `posthog-weekly-report`), donc **un seul changement** corrige les deux rapports.

### `maxDuration = 60` sur les 2 routes PostHog

```ts
export const maxDuration = 60;
```

Le refresh forcé coûte du temps : **mesuré en local à 7s pour le daily et 8s pour le weekly**. Depuis Vercel prod (`iad1`) vers PostHog EU, il faut ajouter ~2-3s de latence réseau US↔EU. Le pipeline complet (fetch + buildHtml + Resend + Slack) peut donc frôler les **15 secondes**, soit la limite serverless par défaut.

On élargit `maxDuration` à 60s (limite gratuite sur Vercel Pro) pour rester très confortable. Le cron ne tourne qu'une fois par jour (daily) et une fois par semaine (weekly), le coût compute est négligeable.

## Pourquoi `force_blocking` et pas `blocking`

| Valeur | Comportement |
|---|---|
| `blocking` | Recalcule **uniquement si le cache est considéré périmé** par les heuristiques PostHog |
| `force_blocking` | Recalcule **toujours**, ignore totalement le cache |

Pour un rapport quotidien / hebdomadaire qu'on envoie à heure fixe, on veut **la garantie absolue** que les data sont fraîches au moment de l'envoi. `force_blocking` élimine toute ambiguïté.

## Test plan (post-merge)

- [ ] Attendre le déploiement prod du commit
- [ ] Dashboard Vercel → Crons → `posthog-daily-report` → **Run now**
- [ ] Vérifier que l'email reçu affiche une **période se terminant aujourd'hui** (ex: `2026-04-10 → 2026-04-11`) — pas la période d'hier comme avant
- [ ] Vérifier dans les logs Vercel que la durée du cron est bien entre 8 et 15 secondes (vs ~2s auparavant, mais avec data périmée)
- [ ] Même test sur `posthog-weekly-report` → période sur les 7 derniers jours, se terminant aujourd'hui

## Notes

- PR créée depuis un **worktree isolé** (`../the-playground-posthog-refresh`) pour ne pas interférer avec le repo principal en cours de travail.
- Diff total : 3 fichiers, +21 −1 lignes.
- Aucune migration DB, aucune nouvelle dépendance, aucune nouvelle variable d'environnement.
- Fait suite directement à la PR #359 (fix GET method + Sentry) — sans cette PR précédente, le bug n'aurait même pas été découvert (le cron retournait 405 avant d'atteindre le code métier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)