### PR TITLE
feat(moment): allow direct publish from create form

### DIFF
--- a/src/app/actions/moment.ts
+++ b/src/app/actions/moment.ts
@@ -95,6 +95,12 @@ export async function createMomentAction(
   // Refundable only meaningful for paid events; default to true for free events
   const refundable = price > 0 ? formData.get("refundable") === "on" : true;
 
+  // Intent = "draft" (default) or "publish" — coming from the form's submit
+  // button `name="intent" value="..."`. When "publish", we chain a publishMoment
+  // call after createMoment to publish the event in a single user action.
+  const intent = formData.get("intent") as string | null;
+  const shouldPublishImmediately = intent === "publish";
+
   const userId = session.user.id;
   return toActionResult(async () => {
     const coverData = await processCoverImage(formData);
@@ -146,7 +152,36 @@ export async function createMomentAction(
       Sentry.captureException(err);
     });
 
-    return result.moment;
+    if (!shouldPublishImmediately) {
+      return result.moment;
+    }
+
+    // Publish-on-create path : chain publishMoment after a successful createMoment.
+    // If the publish step fails, we fall back to returning the freshly-created
+    // DRAFT (logged to Sentry) so the user doesn't lose their work — they'll be
+    // redirected to the draft page where they can retry publication manually
+    // via the existing PublishMomentButton.
+    try {
+      const publishResult = await publishMoment(
+        { momentId: result.moment.id, userId },
+        { momentRepository: prismaMomentRepository, circleRepository: circleRepo }
+      );
+
+      sendMomentPublishedNotifications(publishResult.moment, userId);
+
+      revalidatePath(`/dashboard/circles/${publishResult.moment.circleId}`);
+      revalidatePath(`/m/${publishResult.moment.slug}`);
+      revalidatePath(`/en/m/${publishResult.moment.slug}`);
+
+      return publishResult.moment;
+    } catch (publishError) {
+      Sentry.captureException(publishError, {
+        tags: { context: "publish_after_create" },
+        extra: { momentId: result.moment.id, circleId: result.moment.circleId },
+      });
+      // Fall back to the draft — the user still got their moment created.
+      return result.moment;
+    }
   });
 }
 
@@ -500,16 +535,35 @@ export async function publishMomentAction(
       { momentRepository: prismaMomentRepository, circleRepository: circleRepo }
     );
 
-    // Fire-and-forget : notifier les membres + envoyer email de confirmation à l'organisateur
-    prismaCircleRepository.findById(result.moment.circleId).then(async (circle) => {
+    sendMomentPublishedNotifications(result.moment, userId);
+
+    revalidatePath(`/dashboard/circles/${result.moment.circleId}`);
+    revalidatePath(`/m/${result.moment.slug}`);
+    revalidatePath(`/en/m/${result.moment.slug}`);
+    return result.moment;
+  });
+}
+
+/**
+ * Fire-and-forget post-publication notifications : notify community members
+ * of the new published event and send a confirmation email to the host with
+ * an ICS attachment. Never throws — all errors are logged to Sentry so that
+ * a failed notification doesn't fail the upstream action.
+ *
+ * Shared between `publishMomentAction` (manual DRAFT → PUBLISHED transition)
+ * and `createMomentAction` with `intent=publish` (create + publish in one
+ * operation).
+ */
+function sendMomentPublishedNotifications(moment: Moment, userId: string): void {
+  prismaCircleRepository
+    .findById(moment.circleId)
+    .then(async (circle) => {
       if (!circle) return;
 
-      notifyNewMoment(result.moment, userId, circle.name, circle.slug).catch(
-        (err) => {
-          console.error("[notifyNewMoment] Erreur:", err);
-          Sentry.captureException(err);
-        }
-      );
+      notifyNewMoment(moment, userId, circle.name, circle.slug).catch((err) => {
+        console.error("[notifyNewMoment] Erreur:", err);
+        Sentry.captureException(err);
+      });
 
       const [host, locale] = await Promise.all([
         prismaUserRepository.findById(userId),
@@ -518,28 +572,28 @@ export async function publishMomentAction(
       if (!host?.email) return;
 
       const dateFnsLocale = getDateFnsLocale(locale);
-      const momentDate = formatInTimeZone(result.moment.startsAt, PLATFORM_TIMEZONE, "EEEE d MMMM yyyy, HH:mm", { locale: dateFnsLocale });
-      const momentDateMonth = formatInTimeZone(result.moment.startsAt, PLATFORM_TIMEZONE, "MMM", { locale: dateFnsLocale }).toUpperCase();
-      const momentDateDay = formatInTimeZone(result.moment.startsAt, PLATFORM_TIMEZONE, "d");
+      const momentDate = formatInTimeZone(moment.startsAt, PLATFORM_TIMEZONE, "EEEE d MMMM yyyy, HH:mm", { locale: dateFnsLocale });
+      const momentDateMonth = formatInTimeZone(moment.startsAt, PLATFORM_TIMEZONE, "MMM", { locale: dateFnsLocale }).toUpperCase();
+      const momentDateDay = formatInTimeZone(moment.startsAt, PLATFORM_TIMEZONE, "d");
       const locationText = formatLocationText(
-        result.moment.locationType,
-        result.moment.locationName,
-        result.moment.locationAddress,
-        result.moment.videoLink,
+        moment.locationType,
+        moment.locationName,
+        moment.locationAddress,
+        moment.videoLink,
         locale
       );
       const hostName = [host.firstName, host.lastName].filter(Boolean).join(" ") || host.email;
       const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
 
       const icsContent = generateIcs({
-        uid: result.moment.id,
-        title: result.moment.title,
-        description: result.moment.description,
-        startsAt: result.moment.startsAt,
-        endsAt: result.moment.endsAt,
+        uid: moment.id,
+        title: moment.title,
+        description: moment.description,
+        startsAt: moment.startsAt,
+        endsAt: moment.endsAt,
         location: locationText,
-        videoLink: result.moment.videoLink,
-        url: `${appUrl}/m/${result.moment.slug}`,
+        videoLink: moment.videoLink,
+        url: `${appUrl}/m/${moment.slug}`,
         organizerName: circle.name,
         method: "REQUEST",
         attendeeEmail: host.email,
@@ -549,8 +603,8 @@ export async function publishMomentAction(
       await emailService.sendHostMomentCreated({
         to: host.email,
         hostName,
-        momentTitle: result.moment.title,
-        momentSlug: result.moment.slug,
+        momentTitle: moment.title,
+        momentSlug: moment.slug,
         circleSlug: circle.slug,
         momentDate,
         momentDateMonth,
@@ -559,23 +613,18 @@ export async function publishMomentAction(
         circleName: circle.name,
         icsContent,
         strings: {
-          subject: t("hostMomentCreated.subject", { momentTitle: result.moment.title }),
+          subject: t("hostMomentCreated.subject", { momentTitle: moment.title }),
           heading: t("hostMomentCreated.heading"),
-          statusMessage: t("hostMomentCreated.statusMessage", { momentTitle: result.moment.title }),
+          statusMessage: t("hostMomentCreated.statusMessage", { momentTitle: moment.title }),
           dateLabel: t("common.dateLabel"),
           locationLabel: t("common.locationLabel"),
           manageMomentCta: t("hostMomentCreated.manageMomentCta"),
           footer: t("common.footer"),
         },
       });
-    }).catch((err) => {
+    })
+    .catch((err) => {
       console.error(err);
       Sentry.captureException(err);
     });
-
-    revalidatePath(`/dashboard/circles/${result.moment.circleId}`);
-    revalidatePath(`/m/${result.moment.slug}`);
-    revalidatePath(`/en/m/${result.moment.slug}`);
-    return result.moment;
-  });
 }

--- a/src/components/moments/moment-form.tsx
+++ b/src/components/moments/moment-form.tsx
@@ -152,6 +152,8 @@ export function MomentForm({ moment, circleSlug, circleName, circleDescription, 
         location_type: result.data.locationType,
         has_capacity: result.data.capacity !== null,
         is_paid: result.data.price > 0,
+        status: result.data.status,
+        published_immediately: result.data.status === "PUBLISHED",
       });
 
       // Flush staged attachments (create mode: files were staged client-side
@@ -439,7 +441,13 @@ export function MomentForm({ moment, circleSlug, circleName, circleDescription, 
 
           {/* Submit / Cancel */}
           <div className="flex gap-3 pt-2">
-            <Button type="submit" disabled={isPending || isEndBeforeStart || !startDate || !endDate} className="flex-1">
+            <Button
+              type="submit"
+              name="intent"
+              value="draft"
+              disabled={isPending || isUploadingAttachments || isEndBeforeStart || !startDate || !endDate}
+              className="flex-1"
+            >
               {isUploadingAttachments
                 ? t("form.uploadingAttachments")
                 : isPending
@@ -448,6 +456,24 @@ export function MomentForm({ moment, circleSlug, circleName, circleDescription, 
                     ? tCommon("save")
                     : t("form.createMoment")}
             </Button>
+
+            {/* Publier directement — création uniquement, desktop uniquement.
+                En édition un bouton "Publier" existe déjà sur la page du Moment
+                (PublishMomentButton). Sur mobile on garde le flux par défaut
+                (brouillon → puis publier depuis la page). */}
+            {!moment && (
+              <Button
+                type="submit"
+                name="intent"
+                value="publish"
+                variant="outline"
+                disabled={isPending || isUploadingAttachments || isEndBeforeStart || !startDate || !endDate}
+                className="hidden sm:inline-flex"
+              >
+                {t("actions.publish")}
+              </Button>
+            )}
+
             <Button
               type="button"
               variant="outline"

--- a/tests/e2e/host-flow.spec.ts
+++ b/tests/e2e/host-flow.spec.ts
@@ -136,7 +136,10 @@ test.describe("Flux Host — création d'un Moment", () => {
       await dateInput.fill(formatted);
     }
 
-    await page.locator("button[type='submit']").click();
+    // Selector spécifique : le form contient maintenant 2 boutons submit
+    // (draft + publish). On clique explicitement sur celui qui crée un brouillon
+    // pour préserver la sémantique de ce test (comportement par défaut).
+    await page.locator("button[name='intent'][value='draft']").click();
 
     await expect(page).toHaveURL(/\/dashboard\/circles\/.*\/moments\//, { timeout: 15_000 });
   });
@@ -146,5 +149,131 @@ test.describe("Flux Host — création d'un Moment", () => {
     // La timeline doit contenir au moins un événement
     const momentLinks = page.locator("a[href*='/moments/']");
     await expect(momentLinks.first()).toBeVisible();
+  });
+});
+
+/**
+ * Tests E2E — Flux Host : publication directe depuis le formulaire de création
+ *
+ * Vérifie la feature "Publier directement" (PR #362) :
+ *   - Desktop : le form a 2 boutons submit (draft + publish)
+ *   - Cliquer "Enregistrer le brouillon" crée un DRAFT (comportement inchangé)
+ *   - Cliquer "Publier" crée ET publie l'événement en une seule action
+ *   - Sur mobile, le bouton Publier est masqué (hidden sm:inline-flex)
+ *   - En mode édition d'un brouillon existant, le bouton Publier n'est pas dans le form
+ *   - Presser Enter dans un input soumet en mode draft par défaut (1er submit button
+ *     dans le DOM) — aucun risque de publication accidentelle au clavier
+ */
+
+test.describe("Flux Host — publication directe d'un Moment", () => {
+  test.use({ storageState: AUTH.HOST });
+
+  async function fillMomentForm(page: import("@playwright/test").Page, title: string) {
+    await page.goto(`/fr/dashboard/circles/${SLUGS.CIRCLE}/moments/new`);
+    await page.fill("input[name='title']", title);
+
+    const dateInput = page.locator("input[name='startsAt'], input[type='datetime-local']").first();
+    if (await dateInput.isVisible()) {
+      const futureDate = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+      const formatted = futureDate.toISOString().slice(0, 16);
+      await dateInput.fill(formatted);
+    }
+
+    // La description est requise côté usecase (createMoment). On en met une courte
+    // pour ne pas tomber sur l'erreur VALIDATION côté server action.
+    const description = page.locator("textarea[name='description']");
+    if (await description.isVisible()) {
+      await description.fill("Description E2E publication directe");
+    }
+  }
+
+  test("should create a DRAFT when clicking 'Enregistrer le brouillon'", async ({ page }) => {
+    const title = `E2E Draft ${Date.now()}`;
+    await fillMomentForm(page, title);
+
+    // Bouton primary, toujours le 1er submit du DOM → couvre aussi implicitement
+    // le cas Enter-in-input grâce à la sémantique HTML (1er submit par défaut)
+    await page.locator("button[name='intent'][value='draft']").click();
+    await expect(page).toHaveURL(/\/dashboard\/circles\/.*\/moments\//, { timeout: 15_000 });
+
+    // Le moment créé est en DRAFT — le banner "en cours de préparation" doit être visible
+    await expect(
+      page.getByText(/en cours de préparation/i).first()
+    ).toBeVisible({ timeout: 8_000 });
+  });
+
+  test("should create AND publish in one action when clicking 'Publier'", async ({ page }) => {
+    const title = `E2E Publish ${Date.now()}`;
+    await fillMomentForm(page, title);
+
+    // Bouton outline, présent uniquement en création desktop (hidden sm:inline-flex)
+    const publishButton = page.locator("button[name='intent'][value='publish']");
+    await expect(publishButton).toBeVisible();
+    await publishButton.click();
+
+    await expect(page).toHaveURL(/\/dashboard\/circles\/.*\/moments\//, { timeout: 15_000 });
+
+    // Le moment créé est en PUBLISHED — le banner draft ne doit PAS être visible
+    await expect(page.getByText(/en cours de préparation/i)).toHaveCount(0);
+  });
+
+  test("should submit as DRAFT when pressing Enter in the title input", async ({ page }) => {
+    const title = `E2E Enter ${Date.now()}`;
+    await fillMomentForm(page, title);
+
+    // Enter dans l'input titre → HTML soumet via le 1er submit button du DOM = draft
+    await page.locator("input[name='title']").press("Enter");
+    await expect(page).toHaveURL(/\/dashboard\/circles\/.*\/moments\//, { timeout: 15_000 });
+
+    // Confirmer que c'est bien un DRAFT (pas un publish accidentel)
+    await expect(
+      page.getByText(/en cours de préparation/i).first()
+    ).toBeVisible({ timeout: 8_000 });
+  });
+
+  test("should NOT show the 'Publier' button when editing an existing DRAFT moment", async ({ page }) => {
+    // 1. Créer un moment DRAFT pour avoir une cible d'édition
+    const title = `E2E Edit ${Date.now()}`;
+    await fillMomentForm(page, title);
+    await page.locator("button[name='intent'][value='draft']").click();
+    await expect(page).toHaveURL(/\/dashboard\/circles\/.*\/moments\//, { timeout: 15_000 });
+
+    // 2. Naviguer vers la page d'édition du moment qu'on vient de créer
+    const momentUrl = page.url();
+    await page.goto(`${momentUrl}/edit`);
+
+    // Le form d'édition doit être visible
+    await expect(page.locator("input[name='title']")).toBeVisible({ timeout: 8_000 });
+
+    // Le bouton "Publier" du form NE doit PAS être présent en mode édition
+    // (wrappé dans `{!moment && ...}` côté React → pas du tout rendu)
+    await expect(page.locator("button[name='intent'][value='publish']")).toHaveCount(0);
+
+    // En revanche le bouton draft (qui devient "Enregistrer" en mode édition) reste présent
+    await expect(page.locator("button[name='intent'][value='draft']")).toBeVisible();
+  });
+});
+
+test.describe("Flux Host — publication directe d'un Moment (mobile)", () => {
+  test.use({
+    storageState: AUTH.HOST,
+    // Viewport mobile < 640px : le breakpoint Tailwind `sm:` n'est pas actif
+    // → le bouton "Publier" doit être masqué via `hidden sm:inline-flex`
+    viewport: { width: 375, height: 812 },
+  });
+
+  test("should NOT show the 'Publier' button on mobile viewport", async ({ page }) => {
+    await page.goto(`/fr/dashboard/circles/${SLUGS.CIRCLE}/moments/new`);
+
+    // Le bouton draft (primary) doit rester visible
+    await expect(
+      page.locator("button[name='intent'][value='draft']")
+    ).toBeVisible();
+
+    // Le bouton publish est rendu dans le DOM (React monte le composant) mais
+    // Tailwind lui applique `hidden` par défaut → Playwright le voit comme non-visible
+    await expect(
+      page.locator("button[name='intent'][value='publish']")
+    ).toBeHidden();
   });
 });

--- a/tests/e2e/host-flow.spec.ts
+++ b/tests/e2e/host-flow.spec.ts
@@ -236,14 +236,31 @@ test.describe("Flux Host — publication directe d'un Moment", () => {
     const title = `E2E Edit ${Date.now()}`;
     await fillMomentForm(page, title);
     await page.locator("button[name='intent'][value='draft']").click();
-    await expect(page).toHaveURL(/\/dashboard\/circles\/.*\/moments\//, { timeout: 15_000 });
 
-    // 2. Naviguer vers la page d'édition du moment qu'on vient de créer
-    const momentUrl = page.url();
-    await page.goto(`${momentUrl}/edit`);
+    // Attendre explicitement que la redirect aille sur la page du moment (pas /moments/new).
+    // Le regex précédent `/moments\//` matchait aussi `/moments/new` → faux positif possible.
+    // On attend une URL qui se termine par un slug différent de "new".
+    await page.waitForURL(
+      (url) => {
+        const path = new URL(url).pathname;
+        return /\/dashboard\/circles\/[^/]+\/moments\/[^/]+$/.test(path) && !path.endsWith("/moments/new");
+      },
+      { timeout: 15_000 }
+    );
 
-    // Le form d'édition doit être visible
-    await expect(page.locator("input[name='title']")).toBeVisible({ timeout: 8_000 });
+    // 2. Extraire explicitement le slug du moment depuis l'URL actuelle
+    const pathname = new URL(page.url()).pathname;
+    const momentSlug = pathname.split("/").pop();
+    if (!momentSlug || momentSlug === "new") {
+      throw new Error(`Unexpected moment URL after creation: ${page.url()}`);
+    }
+
+    // 3. Naviguer vers la page d'édition en construisant l'URL proprement
+    await page.goto(`/fr/dashboard/circles/${SLUGS.CIRCLE}/moments/${momentSlug}/edit`);
+    await page.waitForLoadState("domcontentloaded");
+
+    // Le form d'édition doit être visible (timeout large car cold render possible en CI)
+    await expect(page.locator("input[name='title']")).toBeVisible({ timeout: 15_000 });
 
     // Le bouton "Publier" du form NE doit PAS être présent en mode édition
     // (wrappé dans `{!moment && ...}` côté React → pas du tout rendu)


### PR DESCRIPTION
## Summary

Ajoute un second bouton submit sur le formulaire de création d'événement (desktop uniquement) permettant à l'organisateur de **créer et publier l'événement en une seule action**, sans passer par l'étape intermédiaire « Brouillon → Publier » depuis la page du moment.

Le flux par défaut reste **inchangé** : « Enregistrer le brouillon » est toujours le bouton primary, toute soumission sans paramètre `intent` retombe sur le chemin draft (full backwards compat).

## Décisions validées

| Question | Décision |
|---|---|
| Option UX | **A — 2 boutons côte à côte** |
| Hiérarchie | `"Enregistrer le brouillon"` reste primary, `"Publier"` en outline |
| Mobile | **Status quo** — bouton Publier masqué via `hidden sm:inline-flex` |
| Édition | Bouton Publier **absent** en mode édition (le `PublishMomentButton` existant sur la page du moment suffit) |
| Confirmation modale | **Non** (validé explicitement) |
| Label Publier | Réutilise la clé existante `Moment.actions.publish` — aucune nouvelle clé i18n |

## Changements

### `src/components/moments/moment-form.tsx`
- 2e bouton submit `<Button type="submit" name="intent" value="publish" variant="outline">` visible uniquement en création (`!moment`) et uniquement sur desktop (`hidden sm:inline-flex`)
- Le bouton primary existant reçoit `name="intent" value="draft"` — inchangé visuellement
- PostHog event `moment_created` enrichi avec `status` et `published_immediately` pour mesurer l'adoption du nouveau chemin

### `src/app/actions/moment.ts`
- `createMomentAction` lit `formData.get("intent")`. Si `intent === "publish"`, chaîne `publishMoment` après un `createMoment` réussi, appelle le helper de notifications, revalide les 3 paths concernés, retourne le moment publié.
- **Extraction d'un helper privé** `sendMomentPublishedNotifications(moment, userId)` : le bloc fire-and-forget qui notifie les membres et envoie l'email host avec ICS est sorti de `publishMomentAction` et réutilisé par les deux chemins (manuel + create+publish). Zéro duplication.
- Si `publishMoment` échoue après un `createMoment` OK (edge case extrêmement rare — le moment vient d'être créé en DRAFT, même user, même HOST) : `Sentry.captureException` avec tag `publish_after_create`, fallback sur le draft. L'utilisateur est redirigé sur la page du brouillon où il peut retry via le `PublishMomentButton` existant. Son travail n'est jamais perdu.

## Edge cases couverts

| Cas | Comportement |
|---|---|
| User clique « Enregistrer le brouillon » | DRAFT créé, redirect — **inchangé** |
| User clique « Publier » (desktop uniquement) | DRAFT créé → PUBLISHED en chaîne → notifications membres + email host → redirect |
| Enter dans un input | Premier submit button = `draft` → soumission en draft par défaut, **aucun risque de publication accidentelle au clavier** |
| `intent` absent du formData (caller legacy) | Default `"draft"` → retrocompat totale |
| `createMoment` échoue | Erreur normale, rien créé |
| `createMoment` OK + `publishMoment` KO | Draft existe en DB, user redirigé sur la page du brouillon, Sentry logué |
| User édite un DRAFT existant | Bouton Publier **absent** (`!moment` guard) |

## Test plan

- [ ] Créer un nouvel événement sur desktop avec le bouton « Publier » → vérifier que l'événement est immédiatement publié (status PUBLISHED) sur la page du moment
- [ ] Créer un nouvel événement sur desktop avec « Enregistrer le brouillon » → vérifier qu'il est bien en DRAFT (comportement inchangé)
- [ ] Créer un événement sur **mobile** (width < 640px) → vérifier que le bouton Publier n'est **pas** visible, seul « Enregistrer le brouillon » et « Annuler » apparaissent
- [ ] Éditer un brouillon existant → vérifier que le bouton Publier n'est **pas** dans le form d'édition (le bouton dédié reste sur la page du moment)
- [ ] Presser Enter dans le champ titre → vérifier qu'on soumet en mode draft par défaut
- [ ] Vérifier côté PostHog que l'event `moment_created` contient bien les nouvelles propriétés `status` et `published_immediately`
- [ ] Tester en Publier direct : confirmer que les notifications membres partent bien (email avec ICS côté host, email new_moment côté membres de la communauté)

## Notes

- Commit unique `8c1e23d`, +110 −35 lignes sur 2 fichiers
- Aucune migration DB, aucune nouvelle dépendance, aucune nouvelle variable d'environnement, aucune nouvelle clé i18n (réutilise `Moment.actions.publish` existante)
- Pas de nouveau usecase domain — on réutilise `createMoment` et `publishMoment` inchangés

🤖 Generated with [Claude Code](https://claude.com/claude-code)