### PR TITLE
chore(scripts): add git worktree helpers (new + cleanup)

### DIFF
--- a/scripts/worktree-cleanup.sh
+++ b/scripts/worktree-cleanup.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# worktree-cleanup.sh — Retire tous les worktrees sans modifications non committées.
+#
+# Usage :
+#   ./scripts/worktree-cleanup.sh
+#
+# Ce que le script fait :
+#   1. Liste tous les worktrees sauf le repo principal
+#   2. Pour chacun, vérifie s'il y a des changements staged ou unstaged
+#   3. Si clean → `git worktree remove`
+#   4. Si dirty → skip et affiche un warning
+#   5. À la fin, liste les worktrees restants
+#
+# Note : les fichiers untracked ne bloquent PAS la suppression (les worktrees
+# contiennent typiquement `.next/`, `node_modules/`, etc. qui sont untracked).
+# Si on veut être strict, `git worktree remove --force` peut être ajouté
+# manuellement pour les cas où on sait ce qu'on fait.
+
+set -euo pipefail
+
+main_root="$(git rev-parse --show-toplevel)"
+
+# Si on est appelé depuis un worktree secondaire, remonter au repo principal
+if git -C "$main_root" worktree list --porcelain | awk '/^worktree / { print $2 }' | head -1 | grep -q -v "^$main_root$"; then
+  main_root="$(git -C "$main_root" worktree list --porcelain | awk '/^worktree / { print $2; exit }')"
+fi
+
+removed=0
+skipped=0
+
+git -C "$main_root" worktree list --porcelain | awk '/^worktree / { print $2 }' | while read -r wt_path; do
+  # Skip le worktree principal
+  if [ "$wt_path" = "$main_root" ]; then
+    continue
+  fi
+
+  # Skip si le worktree n'existe plus sur disque (listé par git mais manquant)
+  if [ ! -d "$wt_path" ]; then
+    echo "⊘ Missing on disk: $wt_path (run 'git worktree prune')"
+    continue
+  fi
+
+  # Check changements staged ou unstaged
+  if ! git -C "$wt_path" diff --quiet 2>/dev/null || ! git -C "$wt_path" diff --cached --quiet 2>/dev/null; then
+    echo "⊘ Skipped (dirty): $wt_path"
+    continue
+  fi
+
+  echo "✓ Removing   : $wt_path"
+  git -C "$main_root" worktree remove "$wt_path"
+done
+
+echo ""
+echo "Worktrees restants :"
+git -C "$main_root" worktree list

--- a/scripts/worktree-new.sh
+++ b/scripts/worktree-new.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# worktree-new.sh — Crée un nouveau git worktree prêt à l'emploi.
+#
+# Usage :
+#   ./scripts/worktree-new.sh <branch-name>
+#
+# Exemple :
+#   ./scripts/worktree-new.sh feat/my-feature
+#
+# Ce que le script fait :
+#   1. Fetche origin/main
+#   2. Crée un worktree à côté du repo principal, avec une nouvelle branche
+#      partant d'origin/main
+#   3. Installe les dépendances (--prefer-offline, rapide grâce au store pnpm partagé)
+#   4. Copie .env.local depuis le repo principal si présent
+#   5. Affiche un message de fin avec la commande pour lancer le dev server
+#      sur un port alternatif (3001) pour ne pas entrer en conflit avec le
+#      dev server du repo principal
+
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 <branch-name>" >&2
+  echo "Example: $0 feat/my-feature" >&2
+  exit 1
+fi
+
+branch="$1"
+
+# Détecter la racine du repo principal (le script peut être appelé depuis n'importe où)
+main_root="$(git rev-parse --show-toplevel)"
+main_name="$(basename "$main_root")"
+parent_dir="$(dirname "$main_root")"
+
+# Slug pour le nom du répertoire : remplacer / par -
+slug="${branch//\//-}"
+worktree_dir="$parent_dir/$main_name-$slug"
+
+if [ -e "$worktree_dir" ]; then
+  echo "Error: $worktree_dir already exists" >&2
+  exit 1
+fi
+
+echo "→ Fetch origin/main"
+git -C "$main_root" fetch origin main --quiet
+
+echo "→ Create worktree at $worktree_dir"
+git -C "$main_root" worktree add -b "$branch" "$worktree_dir" origin/main
+
+echo "→ Install dependencies (pnpm install --prefer-offline)"
+cd "$worktree_dir"
+pnpm install --prefer-offline --silent
+
+if [ -f "$main_root/.env.local" ]; then
+  echo "→ Copy .env.local"
+  cp "$main_root/.env.local" .env.local
+fi
+
+echo ""
+echo "✓ Worktree prêt"
+echo "    Path    : $worktree_dir"
+echo "    Branche : $branch"
+echo ""
+echo "  Suite :"
+echo "    cd \"$worktree_dir\""
+echo "    PORT=3001 pnpm dev    # port alternatif pour ne pas entrer en conflit avec le repo principal"


### PR DESCRIPTION
## Summary

Ajoute deux petits scripts shell pour systématiser l'usage de `git worktree` sur le projet. Ils servent à la fois à l'utilisateur (création rapide d'un worktree de test / review) et aux sessions Claude Code (qui vont désormais **systématiquement** passer par un worktree dédié pour chaque nouvelle branche d'implémentation).

## Contexte — pourquoi ces scripts

Incident du 2026-04-11 : une session Claude a créé une branche `feat/moment-publish-on-create` directement dans le repo principal (`git checkout -b`) alors que l'utilisateur avait du WIP non committé sur une autre feature (`feat/onboarding-welcome-email`). Conséquences :

1. Le typecheck a cassé sur des fichiers totalement non-liés (`mock-user-repository.ts` attendait un champ ajouté par l'autre feature)
2. Il a fallu un stash sélectif (`--keep-index`), un checkout croisé, un commit partiel, puis un retour avec `git checkout --` pour nettoyer — ~20 minutes de démêlage git pur
3. Les deux sessions ne pouvaient pas tester leur code proprement sans perturber l'autre

Racine : l'hypothèse implicite que le working tree du repo principal « appartient » à Claude pendant qu'il travaille. Faux — l'utilisateur a toujours son propre WIP, et plusieurs sessions Claude peuvent tourner en parallèle.

**Solution structurelle** : `git worktree` pour chaque nouvelle branche, systématiquement. Un worktree = un checkout séparé, son propre working tree, son propre `node_modules`, sa propre `.env.local`, son propre `.next`. Isolation totale.

Ces deux scripts existent pour rendre la création et le nettoyage de worktrees **triviaux** (une commande), afin qu'il n'y ait plus aucune friction à utiliser worktree par défaut.

## Changements

### `scripts/worktree-new.sh <branch-name>`

Création en une commande :

1. `git fetch origin main`
2. `git worktree add -b <branch-name> ../the-playground-<slug> origin/main`
3. `pnpm install --prefer-offline` (~7 s grâce au store pnpm partagé entre worktrees)
4. Copie `.env.local` depuis le repo principal si présent
5. Affiche un message de fin avec la commande pour lancer le dev server sur `PORT=3001` (pour ne pas entrer en conflit avec le dev server du repo principal sur `:3000`)

Usage :

```bash
./scripts/worktree-new.sh feat/my-feature
# → ../the-playground-feat-my-feature/ prêt, deps installées, .env.local copié
cd "../the-playground-feat-my-feature"
PORT=3001 pnpm dev
```

### `scripts/worktree-cleanup.sh`

Nettoyage automatique des worktrees clean :

1. Itère sur tous les worktrees sauf le principal
2. Pour chacun : vérifie `git diff --quiet` + `git diff --cached --quiet`
3. Si clean → `git worktree remove`
4. Si dirty → skip + warning explicite
5. Affiche à la fin la liste des worktrees restants

Safe par défaut : les worktrees avec des modifs non committées sont **préservés** (pas de `--force`). Les untracked files ne bloquent pas la suppression (sinon `.next/` et `node_modules/` empêcheraient toujours le cleanup).

Usage :

```bash
./scripts/worktree-cleanup.sh
# ✓ Removing   : ../the-playground-feat-foo
# ⊘ Skipped (dirty): ../the-playground-feat-bar
#
# Worktrees restants :
# /Users/dragos/AI Projects/the-playground               <sha>  [main]
# /Users/dragos/AI Projects/the-playground-feat-bar      <sha>  [feat/bar]
```

## Test plan

- [x] `bash -n` passe sur les 2 scripts (syntaxe OK)
- [x] Les 2 scripts sont en `chmod +x`
- [ ] Tester `./scripts/worktree-new.sh chore/test-throwaway` depuis le repo principal → vérifier que le worktree est créé avec deps installées + `.env.local` copié
- [ ] `cd` dans le nouveau worktree et lancer `PORT=3001 pnpm dev` → vérifier qu'aucun conflit avec le dev server principal
- [ ] Revenir au repo principal et lancer `./scripts/worktree-cleanup.sh` → vérifier que le worktree de test est bien retiré (après `cd` out)
- [ ] Tester le cas « dirty » : créer un fichier, ne pas committer, relancer `worktree-cleanup.sh` → vérifier que le worktree est skippé avec un warning visible

## Notes

- Commit unique `856415e`, +121 lignes sur 2 nouveaux fichiers
- Aucune dépendance npm ajoutée — scripts bash pur
- Fait suite directement à une discussion avec l'utilisateur sur la systématisation des worktrees pour les sessions Claude Code en parallèle
- Une **règle absolue** a été ajoutée à la mémoire Claude du projet (`MEMORY.md`) pointant vers un fichier détaillé : toute nouvelle branche passera désormais par un worktree, exception unique pour les hotfix triviaux explicitement demandés « direct ici »
- Cette PR elle-même a été créée depuis un worktree dédié (`../the-playground-worktree-helpers`) — ironie assumée, et application immédiate de la nouvelle règle

🤖 Generated with [Claude Code](https://claude.com/claude-code)