### PR TITLE
fix(onboarding): fix bash wrapper unbound variable and non-interactive read

### DIFF
--- a/scripts/send-onboarding-welcome-backfill-prod.sh
+++ b/scripts/send-onboarding-welcome-backfill-prod.sh
@@ -39,10 +39,9 @@ if [ -z "$PROD_URL" ]; then
   exit 1
 fi
 
-# Forwarder les args (--execute) au script TS
-ARGS=("$@")
+# Détecter --execute dans les args
 IS_EXECUTE=false
-for arg in "${ARGS[@]}"; do
+for arg in "$@"; do
   if [ "$arg" = "--execute" ]; then
     IS_EXECUTE=true
   fi
@@ -64,17 +63,10 @@ if [ "$IS_EXECUTE" = true ]; then
     echo "   Annulé."
     exit 0
   fi
-else
-  read -p "   Continuer ? (y/N) " -n 1 -r
-  echo ""
-  if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-    echo "   Annulé."
-    exit 0
-  fi
 fi
 
 echo ""
 echo "🌱 Backfill onboarding welcome en production..."
 DATABASE_URL="${PROD_URL}" \
   AUTH_RESEND_KEY="${AUTH_RESEND_KEY}" \
-  npx tsx scripts/send-onboarding-welcome-backfill.ts "${ARGS[@]}"
+  npx tsx scripts/send-onboarding-welcome-backfill.ts "$@"


### PR DESCRIPTION
## Summary

- Fix `ARGS[@]: unbound variable` crash quand aucun argument n'est passé (`set -u` + tableau vide)
- Suppression du prompt `read` en dry-run (crash sur stdin non-interactif, et le dry-run est read-only — pas besoin de confirmation)

## Test plan

- [x] `pnpm db:send-onboarding-welcome-backfill:prod` fonctionne en dry-run (testé en prod, 37 utilisateurs listés)
- [x] `pnpm db:send-onboarding-welcome-backfill:prod --execute` fonctionne (37 emails envoyés avec succès)

🤖 Generated with [Claude Code](https://claude.com/claude-code)