### PR TITLE
docs(help): mention direct publish from create form

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1573,7 +1573,7 @@
         "adv1": "<strong>Capacity</strong> — maximum number of attendees (automatically activates the waitlist)",
         "adv2": "<strong>Price</strong> — if the event is paid, payment is handled via Stripe (attendees pay directly, The Playground takes no commission)",
         "adv3": "<strong>Cover image</strong>",
-        "callout": "The event is created as a <strong>draft</strong>: it is not yet visible in Explore or open for registration. When it's ready, click <strong>Publish</strong> to make it public and notify community members."
+        "callout": "The event is created as a <strong>draft</strong>: it is not yet visible in Explore or open for registration. When it's ready, click <strong>Publish</strong> to make it public and notify community members. On desktop, you can also click <strong>Publish</strong> directly in the creation form to create and publish in a single step."
       },
       "manageRegistrations": {
         "title": "Manage registrations",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1573,7 +1573,7 @@
         "adv1": "<strong>Capacité</strong> — nombre maximum de participants (active la liste d'attente automatiquement)",
         "adv2": "<strong>Prix</strong> — si l'événement est payant, le paiement se fait via Stripe (les participants paient directement, The Playground ne prend aucune commission)",
         "adv3": "<strong>Image de couverture</strong>",
-        "callout": "L'événement est créé en <strong>brouillon</strong> : il n'est pas encore visible dans Explorer ni ouvert aux inscriptions. Quand il est prêt, cliquez sur <strong>Publier</strong> pour le rendre public et notifier les membres de la communauté."
+        "callout": "L'événement est créé en <strong>brouillon</strong> : il n'est pas encore visible dans Découvrir ni ouvert aux inscriptions. Quand il est prêt, cliquez sur <strong>Publier</strong> pour le rendre public et notifier les membres de la communauté. Sur ordinateur, vous pouvez aussi cliquer directement sur <strong>Publier</strong> depuis le formulaire de création pour créer et publier en une seule étape."
       },
       "manageRegistrations": {
         "title": "Gérer les inscriptions",


### PR DESCRIPTION
## Summary

Mise à jour de la page Aide avant la release 2.7.0 : ajout de la mention de la publication directe depuis le formulaire de création d'événement (PR #362).

- FR : "Sur ordinateur, vous pouvez aussi cliquer directement sur **Publier** depuis le formulaire de création pour créer et publier en une seule étape."
- EN : "On desktop, you can also click **Publish** directly in the creation form to create and publish in a single step."
- Fix accessoire FR : "Explorer" → "Découvrir" (terminologie user-facing correcte)

Détecté par l'agent `docs-coherence-guardian` lors de la procédure de release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)