### PR TITLE
fix(changelog): harden humanize prompt against duplicates and terminology

### DIFF
--- a/scripts/humanize-changelog.ts
+++ b/scripts/humanize-changelog.ts
@@ -76,6 +76,27 @@ Orienté bénéfices utilisateur, vocabulaire naturel, pas de jargon technique.
 - Français uniquement
 - Omettre les entrées purement techniques (refactor, ci, chore, tests, infra) invisibles pour l'utilisateur
 
+## Terminologie obligatoire (FR)
+
+Le code source utilise des termes anglais techniques. Dans le changelog (texte user-facing en français), tu DOIS TOUJOURS utiliser les traductions suivantes :
+- Moment → **événement** (jamais "moment", "Moment", ni "escale")
+- Circle → **Communauté** (jamais "cercle", "circle", ni "Circle")
+- Host → **Organisateur** (jamais "host", "fondateur", ni "créateur")
+- Player → **Participant** (jamais "player")
+- Dashboard → **Mon espace** (jamais "dashboard")
+- Explorer → **Découvrir** (jamais "explorer", "Explorer")
+
+## Règle anti-doublon
+
+Si plusieurs entrées Release Please décrivent la même fonctionnalité sous des angles différents (par exemple "feat(moment): add attachments" et "feat(moment-attachments): allow organizers to attach files to events"), les FUSIONNER en une seule entrée cohérente. Ne jamais lister la même feature deux fois avec des formulations différentes, même si les commits source sont distincts.
+
+## Précision factuelle
+
+Ne pas extrapoler ni inventer des détails absents du texte source. Rester fidèle au périmètre exact de chaque commit :
+- Si le commit dit "send welcome email after onboarding" sans restriction, ne PAS traduire en "email pour les organisateurs" — écrire "email pour chaque nouvel utilisateur".
+- En cas de doute sur le périmètre (qui est concerné, dans quelles conditions), utiliser une formulation inclusive plutôt que restrictive.
+- Ne pas ajouter de qualificatifs non présents dans le texte source (ex: "fondateur", "premium", "avancé").
+
 ## Exemples de notre style (3 dernières versions) :
 
 ${examples}


### PR DESCRIPTION
## Summary

Le prompt envoyé à Claude dans le workflow Humanize Changelog manquait de 3 garde-fous qui ont causé des erreurs dans le changelog 2.7.0 (corrigées manuellement dans PR #369).

## Les 3 erreurs que ce fix prévient

### 1. Doublons (même feature listée 2 fois)
**Avant** : 2 commits décrivant la même feature "attachments" → 2 entrées séparées dans le changelog ("Pièces jointes sur les moments" + "Pièces jointes sur les événements")
**Fix** : ajout d'une règle anti-doublon explicite : « si plusieurs entrées Release Please décrivent la même fonctionnalité, les fusionner en une seule entrée »

### 2. Terminologie incohérente
**Avant** : le LLM gardait parfois "moment" (terme code) au lieu de "événement" (terme FR user-facing), et utilisait "Explorer" au lieu de "Découvrir"
**Fix** : ajout d'une table de terminologie obligatoire avec les 6 mappings (Moment→événement, Circle→Communauté, Host→Organisateur, Player→Participant, Dashboard→Mon espace, Explorer→Découvrir) et des contraintes "jamais utiliser X"

### 3. Extrapolation factuelle
**Avant** : le LLM a traduit "welcome email after onboarding" en "email de bienvenue pour les fondateurs/organisateurs" alors que tous les utilisateurs sont concernés
**Fix** : ajout d'une règle de précision factuelle : rester fidèle au périmètre du commit, formulation inclusive en cas de doute, ne pas ajouter de qualificatifs absents du source

## Changement

1 fichier modifié (`scripts/humanize-changelog.ts`), +21 lignes dans le prompt string. Aucun changement de logique, juste 3 nouvelles sections dans le prompt envoyé au LLM.

## Test plan

Le prompt amélioré sera testé naturellement à la prochaine release (workflow Humanize Changelog se déclenche sur la PR Release Please). Pour vérifier avant :

```bash
ANTHROPIC_API_KEY=... pnpm tsx scripts/humanize-changelog.ts
```

sur une branche Release Please avec un CHANGELOG en format brut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)