### PR TITLE
docs(help): add attachments section to Help page

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1453,6 +1453,7 @@
       "leave": "Leave a community",
       "createCommunity": "Create your community",
       "createEvent": "Create an event",
+      "attachments": "Attach documents",
       "manageRegistrations": "Manage registrations",
       "contact": "Contact your members",
       "editCancel": "Edit or cancel",
@@ -1574,6 +1575,14 @@
         "adv2": "<strong>Price</strong> — if the event is paid, payment is handled via Stripe (attendees pay directly, The Playground takes no commission)",
         "adv3": "<strong>Cover image</strong>",
         "callout": "The event is created as a <strong>draft</strong>: it is not yet visible in Explore or open for registration. When it's ready, click <strong>Publish</strong> to make it public and notify community members. On desktop, you can also click <strong>Publish</strong> directly in the creation form to create and publish in a single step."
+      },
+      "attachments": {
+        "title": "Attach documents",
+        "intro": "You can attach up to <strong>3 files</strong> (PDF, JPEG, PNG or WebP, 10 MB max each) to any event — great for sharing a presentation deck, meeting notes, venue directions or any relevant document.",
+        "item1": "From the event page, click <strong>Add document</strong> or drag your files into the drop zone",
+        "item2": "Documents can be added when creating the event (before publishing) or at any time from the event page",
+        "item3": "Attendees can see the documents directly on the event page and download them in one click",
+        "callout": "On mobile, tapping a document opens it directly in a new tab. You can delete a document at any time from the event page."
       },
       "manageRegistrations": {
         "title": "Manage registrations",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1453,6 +1453,7 @@
       "leave": "Quitter une communauté",
       "createCommunity": "Créer sa communauté",
       "createEvent": "Créer un événement",
+      "attachments": "Ajouter des documents",
       "manageRegistrations": "Gérer les inscriptions",
       "contact": "Contacter vos participants",
       "editCancel": "Modifier ou annuler",
@@ -1574,6 +1575,14 @@
         "adv2": "<strong>Prix</strong> — si l'événement est payant, le paiement se fait via Stripe (les participants paient directement, The Playground ne prend aucune commission)",
         "adv3": "<strong>Image de couverture</strong>",
         "callout": "L'événement est créé en <strong>brouillon</strong> : il n'est pas encore visible dans Découvrir ni ouvert aux inscriptions. Quand il est prêt, cliquez sur <strong>Publier</strong> pour le rendre public et notifier les membres de la communauté. Sur ordinateur, vous pouvez aussi cliquer directement sur <strong>Publier</strong> depuis le formulaire de création pour créer et publier en une seule étape."
+      },
+      "attachments": {
+        "title": "Ajouter des documents",
+        "intro": "Vous pouvez joindre jusqu'à <strong>3 fichiers</strong> (PDF, JPEG, PNG ou WebP, 10 Mo max chacun) à chaque événement — pratique pour partager un support de présentation, un compte-rendu, un plan d'accès ou tout document utile aux participants.",
+        "item1": "Depuis la page de votre événement, cliquez sur <strong>Ajouter un document</strong> ou glissez vos fichiers dans la zone prévue",
+        "item2": "Les documents peuvent être ajoutés dès la création de l'événement (avant publication) ou à tout moment depuis la page de l'événement",
+        "item3": "Les participants voient les documents directement sur la page de l'événement et peuvent les télécharger en un clic",
+        "callout": "Sur mobile, un tap sur un document ouvre directement le fichier dans un nouvel onglet. Vous pouvez supprimer un document à tout moment depuis la page de l'événement."
       },
       "manageRegistrations": {
         "title": "Gérer les inscriptions",

--- a/src/app/[locale]/(routes)/(static)/help/page.tsx
+++ b/src/app/[locale]/(routes)/(static)/help/page.tsx
@@ -100,6 +100,7 @@ export default async function HelpPage() {
       children: [
         { id: "createCommunity", label: t("sidebar.createCommunity") },
         { id: "createEvent", label: t("sidebar.createEvent") },
+        { id: "attachments", label: t("sidebar.attachments") },
         { id: "manageRegistrations", label: t("sidebar.manageRegistrations") },
         { id: "contactParticipants", label: t("sidebar.contact") },
         { id: "editCancel", label: t("sidebar.editCancel") },
@@ -425,6 +426,25 @@ export default async function HelpPage() {
                 ))}
               </ul>
               <Callout>{t.rich("organizer.createEvent.callout", rich)}</Callout>
+            </div>
+
+            <hr className="border-border" />
+
+            {/* Ajouter des documents */}
+            <div className="space-y-4">
+              <SectionH3 id="attachments">{t("organizer.attachments.title")}</SectionH3>
+              <p className="text-sm leading-relaxed text-muted-foreground">
+                {t.rich("organizer.attachments.intro", rich)}
+              </p>
+              <ul className="space-y-2">
+                {(["item1", "item2", "item3"] as const).map((item) => (
+                  <li key={item} className="flex items-start gap-2 text-sm text-muted-foreground">
+                    <span className="mt-1.5 size-1.5 shrink-0 rounded-full bg-primary" />
+                    {t.rich(`organizer.attachments.${item}`, rich)}
+                  </li>
+                ))}
+              </ul>
+              <Callout>{t.rich("organizer.attachments.callout", rich)}</Callout>
             </div>
 
             <hr className="border-border" />


### PR DESCRIPTION
## Summary

La section « Documents joints » manquait de la page Aide — feature livrée en v2.7.0 (PR #358) mais non documentée dans la page Aide à ce moment-là. Dernier rattrapage avant l'application de la nouvelle règle (page Aide obligatoire dans chaque PR de feature user-facing).

## Changements

- **Sidebar** : nouvelle entrée « Ajouter des documents » / « Attach documents » (après « Créer un événement »)
- **Contenu organizer** : nouvelle section avec intro, 3 items (comment ajouter, quand, vue participant), callout (mobile + suppression)
- **help/page.tsx** : nouveau bloc JSX `<SectionH3 id="attachments">` avec 3 items + callout

## Test plan

- [ ] Vérifier `/help` en FR → la section "Ajouter des documents" apparaît dans le sidebar et dans le contenu, juste après "Créer un événement"
- [ ] Vérifier `/en/help` → même section en anglais
- [ ] Cliquer sur l'entrée sidebar → scroll vers la section

🤖 Generated with [Claude Code](https://claude.com/claude-code)