### PR TITLE
chore(backlog): revue exhaustive et restructuration du backlog produit

### DIFF
--- a/spec/BACKLOG.md
+++ b/spec/BACKLOG.md
@@ -1,469 +1,330 @@
 # Backlog — The Playground
 
-> Ce fichier est tenu à jour avec les décisions prises au fil du développement.
-> Il fait foi pour le périmètre restant du MVP et les évolutions futures.
+> Ce fichier fait foi pour le **périmètre complet du produit** : ce qui est livré, ce qui reste à faire, et ce qui est prévu pour la suite.
+> Organisé par domaine fonctionnel. Chaque feature livrée renvoie vers sa spec et sa version de release.
+>
+> **Sources de vérité** : page Aide (`Help` dans `messages/fr.json`), page Changelog (`CHANGELOG.md`), historique Git/PRs.
+>
+> **Dernière mise à jour** : 2026-04-12 (v2.7.0)
 
 ---
 
-## Fait
+## Table des matières
 
-| Feature | Date | Commit |
-| --- | --- | --- |
-| Auth (magic link + OAuth Google/GitHub) | 2026-02-19 | — |
-| CRUD Communauté (domain, tests, UI, i18n) | 2026-02-19 | `dd41709` |
-| Design system Cyberpunk + dark/light toggle | 2026-02-19 | `2250774` |
-| CRUD événement (domain, tests, UI, i18n, page publique `/m/[slug]`) | 2026-02-20 | `7c507cb` |
-| Refactor membership : Host extends Player | 2026-02-20 | `d9139f4` |
-| Neon branching dev/prod + script `db:dev:reset` | 2026-02-20 | `036d93e` |
-| Profil utilisateur + onboarding obligatoire au premier login | 2026-02-20 | `fd024a7` |
-| Registration : `JoinMoment` (inscription + auto-join Communauté + liste d'attente) | 2026-02-20 | non commité |
-| Registration : `CancelRegistration` (annulation + promotion liste d'attente) | 2026-02-20 | non commité |
-| Registration : `GetMomentRegistrations`, `GetUserRegistration` | 2026-02-20 | non commité |
-| Page publique `/m/[slug]` : bouton inscription fonctionnel (`RegistrationButton`, `RegistrationsList`) | 2026-02-20 | non commité |
-| Dashboard Participant-first : `GetUserCirclesWithRole`, `GetUserUpcomingMoments` | 2026-02-20 | non commité |
-| Dashboard Participant-first : section "Mes prochains événements" + "Mes Communautés" avec badge rôle | 2026-02-20 | non commité |
-| Dev tooling : seed 3 utilisateurs test (host/player1/player2) + route GET d'impersonation (dev-only) | 2026-02-20 | `c862293` |
-| Sécurité dashboard : pages Communauté/événement vérifient le rôle — Participants voient la vue publique, contrôles Organisateur masqués | 2026-02-20 | `c862293` |
-| Règle métier : blocage inscription si événement déjà commencé (`MomentAlreadyStartedError`) + transition auto PUBLISHED→PAST | 2026-02-20 | `c862293` |
-| Bug fix : ré-inscription après annulation met à jour la ligne existante (pas de doublon) | 2026-02-20 | `c862293` |
-| Tests : 21 nouveaux tests couvrant le cycle de vie de l'inscription (re-register, capacité, flux croisés) | 2026-02-20 | `c862293` |
-| Monitoring : Sentry (error tracking client/server/edge) + Vercel Analytics + SpeedInsights | 2026-02-21 | `c862293` + `2dde4cc` |
-| Page événement unifiée : composant `MomentDetailView` partagé entre vue publique et vue Organisateur | 2026-02-21 | `e867ba0` |
-| Page Communauté redesignée : layout 2 colonnes aligné sur événement (cover gradient, Organisateurs, stats) | 2026-02-21 | `0deec99` |
-| Timeline événements sur page Communauté : toggle "À venir / Passés" (URL param `?tab=past`) + fil d'ariane avec dates | 2026-02-21 | `0deec99` |
-| Statut inscription dans la timeline : dot coloré (rose/amber) + badge (Inscrit / Liste d'attente) | 2026-02-21 | `b9a9993` |
-| Formulaire événement : auto-sync date de fin = date de début à la sélection | 2026-02-21 | `0deec99` |
-| Indicateurs événement passé : cover grisée + badge "Passé" overlay + banner contextuel + carte "Événement terminé" avec CTA rétention Communauté | 2026-02-21 | `488ddb8` |
-| Fil de commentaires sur événement : `CommentThread` (plat, chronologique) sur pages publique + dashboard Organisateur/Participant | 2026-02-21 | non commité |
-| Scripts données test : `db:seed-test-data` (réaliste, idempotent, FR) + `db:cleanup-test-data` (dry-run par défaut) + variantes prod | 2026-02-21 | non commité |
-| Redesign page profil : layout single-column centré, avatar header, stats inline, meta rows (email, membre depuis), formulaire simplifié | 2026-02-21 | `7142585` |
-| Fils d'ariane cohérents sur toutes les pages dashboard (6 pages ajoutées/complétées) | 2026-02-21 | `313473e` |
-| Harmonisation badges : Annulé → outline destructive, Organisateur → outline primary partout, Participant → secondary partout | 2026-02-21 | `8d7b76b` |
-| Couleur destructive = primary (une seule couleur accent rose, danger communiqué par le contexte) | 2026-02-21 | `75fd383` |
-| Bouton Modifier unifié : default (rose plein) sur pages Communauté et événement | 2026-02-21 | `295575d` |
-| Le Répertoire : `/explorer` (tabs Communautés/Événements, filtre catégorie) + page Communauté publique `/circles/[slug]` + champs `category`/`city` sur Communauté | 2026-02-21 | `c3813e7` |
-| Dashboard redesigné : pill tabs (Mes inscriptions / Mes Communautés), timeline unifiée (upcoming + past), `DashboardMomentCard` avec `CircleAvatar`, empty states CTA | 2026-02-21 | — |
-| `CircleMembersList` : section membres sur page Communauté (Organisateurs avec Crown, emails visibles Organisateur-only via `variant`) | 2026-02-21 | — |
-| Terminologie i18n : FR Moment → **Escale**, S'inscrire → **Rejoindre**, Dashboard → **Mon Playground** / EN Player → **Member**, Register → **Join**, Dashboard → **My Playground** | 2026-02-21 | — |
-| Renommage Répertoire → **La Carte** (FR) / **Explore** (EN). Route `/explorer` inchangée. | 2026-02-21 | — |
-| Homepage redesignée : hero split-screen (texte + mockup iPhone 3D tilt), section "Comment ça marche" (3 étapes), 3 piliers, CTA final, footer — i18n FR/EN complet | 2026-02-21 | — |
-| Scripts données démo : `db:seed-demo-data` (6 Communautés, 20 users `@demo.playground`, 30 événements 80%/20%, FR, idempotent) + `db:cleanup-demo-data` (dry-run par défaut) + variantes prod | 2026-02-21 | `0fa65f0` |
-| Admin plateforme : dashboard stats, listes paginées (Utilisateurs/Communautés/Événements) avec recherche, pages détail, suppression, forcer annulation événement. Middleware guard `/admin/*`, `UserRole` (USER/ADMIN), lien Admin dans UserMenu, i18n FR/EN complet | 2026-02-21 | `dbe3dda` |
-| Emails transactionnels (Resend + react-email) : confirmation inscription, confirmation liste d'attente, promotion liste d'attente, notification Organisateur nouvelle inscription. Port `EmailService` + adapter `ResendEmailService`. Templates React avec calendar badge (gradient rose→violet). Fire-and-forget depuis server actions. i18n FR/EN complet. | 2026-02-21 | — |
-| Email notification Organisateur : nouveau commentaire sur un événement (`host-new-comment` template, `sendHostNewComment` sur `EmailService`, déclenché depuis `addCommentAction`, fire-and-forget, i18n FR/EN `Email.commentNotification.*`). | 2026-02-24 | `f29287b` |
-| **Section "Prochains événements de la Communauté"** sur `/m/[slug]` (vue publique) : prop `upcomingCircleMoments` dans `MomentDetailView`, rétention depuis la porte d'entrée virale. | 2026-02-26 | `70a51f5` |
-| **Commentaires activés sur événements PAST** : formulaire toujours visible pour les utilisateurs connectés (placeholder "Remerciements, photos, retours..."). | 2026-02-26 | `bf9b036` |
-| **Notifications commentaires pour tous les inscrits** (PR #93) : `sendHostNewComment` → `sendNewComment`, notifie inscrits actifs + Organisateurs (dédupliqués par userId), exclut l'auteur, filtre par préférence `notifyNewComment`. Toggle déplacé de section Organisateur → Participant dans les préfs. MAJ traductions FR/EN/RO/NL/ES. Template `new-comment.tsx` avec URL publique `/m/[slug]`. | 2026-02-28 | `1c0d227` |
-| Couverture tests complète : 14 nouveaux fichiers (get-user-registration, get-moment-comments, get-user-past-moments, 11 usecases admin). 5 specs E2E scaffoldées (auth, join-moment, host-flow, cancel-registration, comments). *(202 tests à ce stade, avant les ajouts sécurité et suivants)* | 2026-02-21 | `3ee4865` |
-| Suppression de compte utilisateur : usecase `deleteAccount` (cascade Communauté si seul Organisateur), server action `deleteAccountAction`, section "Zone de danger" sur la page profil avec confirmation modale. i18n FR/EN `Profile.deleteAccount.*`. | 2026-02-22 | — |
-| Agents Claude Code : `test-coverage-guardian` (audit couverture + création tests manquants, run + correction en boucle) + `security-guardian` (audit RBAC/IDOR/accès admin, création tests sécurité, correction vulnérabilités). Définis dans `.claude/agents/`. | 2026-02-21 | — |
-| Sécurité : audit complet + correction vulnérabilité architecturale (defense-in-depth manquante sur 11 usecases admin). Ajout `callerRole: UserRole` + `AdminUnauthorizedError`. 59 nouveaux tests de sécurité (RBAC, IDOR cross-tenant, accès admin). *(271 tests à ce stade, avant les ajouts suivants)* | 2026-02-21 | `8b14aaf` |
-| Upload d'avatar utilisateur : port `StorageService` (hexagonal), adapter `VercelBlobStorageService` (@vercel/blob), helper `isUploadedUrl`, helper `resizeImage` (Canvas API, crop carré centré, WebP 384×384 ~50 Ko), server action `uploadAvatarAction`, composant `AvatarUpload` (hover overlay + lien texte conditionnel, preview optimiste, spinner), protection OAuth (ne pas écraser avatar uploadé), i18n FR/EN `Profile.avatar.*`, tests `blob.test.ts` + cas image dans `update-profile.test.ts`. AvatarUpload intégré aussi sur la page d'onboarding `/dashboard/profile/setup`. | 2026-02-22 | `aa84d5c` |
-| Isolation onboarding via route groups Next.js : `(app)/layout.tsx` (layout complet : SiteHeader + SiteFooter) + `(onboarding)/layout.tsx` (layout minimal : logo statique non-cliquable, LocaleToggle + ThemeToggle uniquement, pas de footer). Suppression de la prop `hideNav` du SiteHeader. Tests E2E (`onboarding.spec.ts`, 6 tests) + `playwright.config.ts` + script `test:e2e:setup-onboarding`. TDD : tests écrits en RED, puis implémentation, puis GREEN. | 2026-02-22 | `7c57b8d` |
-| Audit sécurité (security-guardian) : 20 nouveaux tests de sécurité. `avatar-upload-isolation.test.ts` (5 tests IDOR/userId isolation) + `onboarding-guard.test.ts` (15 tests anti-boucle, transitions d'état, cas limites). Aucune vulnérabilité détectée dans le code source. *(303 tests à ce stade, avant les ajouts suivants)* | 2026-02-22 | — |
-| Footer global (`SiteFooter`) + pages légales : mentions légales `/legal/mentions-legales`, confidentialité `/legal/confidentialite`, CGU `/legal/cgu`. i18n FR/EN complet (namespaces `Footer` + `Legal`). | 2026-02-22 | `da1c2e8` |
-| Magic link email : template react-email avec icône PNG embarquée en base64 (gradient + triangle play). Zéro dépendance réseau pour le rendu. | 2026-02-22 | `f27fee9` |
-| OpenGraph + SEO : images OG dynamiques (homepage, événement, Communauté), `metadataBase`, `generateMetadata`, `robots.ts`, `sitemap.ts`. | 2026-02-22 | — |
-| Mobile responsive : hamburger menu (DropdownMenu), cards compactes Explorer, footer responsive, hero centrage, tabs responsive. | 2026-02-22 | — |
-| Terminologie FR simplifiée pour accessibilité : Cercle → **Communauté**, Escale → **événement** (masculin), Mon Playground → **Mon espace**, La Carte → **Découvrir**, Rejoindre → **S'inscrire**. Code/clés JSON inchangés. EN inchangé. | 2026-02-22 | — |
-| Cover Communauté : `CoverImagePicker` (tabs Photos Unsplash + Importer), server action `processCoverImage` dans `cover-image.ts`, champs `coverImage`/`coverImageAttribution` sur Communauté (DB + domaine), API proxy Unsplash `/api/unsplash/search`, affichage sur 5 emplacements, attribution "Photo par [Nom] sur Unsplash". | 2026-02-23 | — |
-| Cover événement : mêmes champs `coverImage`/`coverImageAttribution` sur événement (DB + domaine), même composant `CoverImagePicker`, même server action `processCoverImage`, affichage sur pages publique et Organisateur. | 2026-02-23 | — |
-| **Rejoindre une Communauté directement** : usecase `joinCircleDirectly`, action `joinCircleDirectlyAction`, composant `JoinCircleButton` (remplace l'ancien `FollowButton`). Crée directement une `CircleMembership` PLAYER sans passer par un événement. Visible sur la page Communauté publique `/circles/[slug]` pour les utilisateurs connectés non-membres. | 2026-02-24 | — |
-| **Email aux membres : nouvel événement dans leur Communauté** : `notifyNewMoment` envoie automatiquement un email à tous les membres (PLAYERs) à la création d'un événement, sauf au créateur. Intégré dans `createMomentAction`. Fire-and-forget. Template `new-moment-notification.tsx`. | 2026-02-24 | `80a1390` |
-| CoverImagePicker — photos aléatoires Unsplash à l'ouverture : suppression des photos curées statiques, nouvelle route `/api/unsplash/random` (8 appels parallèles `/photos/random`, 1 par thématique, cache `s-maxage=300`), skeleton 8 cases pendant le chargement, `defaultPhotos` mis en cache entre les ouvertures. | 2026-02-23 | `dcd2c6c` |
-| CoverImagePicker — pagination recherche : remplacement du bouton "Voir plus" (qui agrandissait la modale) par une navigation prev/next qui remplace les photos sans changer la taille de la modale. | 2026-02-23 | — |
-| CoverImagePicker — fix state reset : `handleApply` et `handleRemove` appelaient `setOpen(false)` directement (bypasse `onOpenChange` en mode contrôlé Radix), laissant `pending` stale. Corrigé en appelant `handleOpenChange(false)` pour garantir le reset complet. Fix parallèle : le bouton déclencheur appelait `setOpen(true)` au lieu de `handleOpenChange(true)`, empêchant le fetch des photos aléatoires. | 2026-02-23 | `e1131ef`, `9d5cfde` |
-| **Refonte dashboard "Mon espace"** : tab Événements (`DashboardMomentCard` redesigné — cover 64 px à gauche, titre line-clamp-2, badge aligné à droite) + tab Communautés (nouveau `DashboardCircleCard` style Explorer — cover 1:1, stats membres/événements, prochain événement, bouton "Créer un événement" Organisateur-only). Nouveau type domaine `DashboardCircle` (`CircleWithRole` + `memberCount` + `upcomingMomentCount` + `nextMoment`). Nouveau usecase `getUserDashboardCircles`. Nouvelle méthode repository `findAllByUserIdWithStats` (requête unique, pas de N+1). Grille Communautés `sm:grid-cols-2`. 9 nouveaux tests unitaires (`get-user-dashboard-circles.test.ts`). | 2026-02-24 | `6a912a2` |
-| **Emails transactionnels supplémentaires** : notification de mise à jour d'événement (`momentUpdate` / `hostMomentUpdate` — envoyés aux inscrits et à l'Organisateur quand date ou lieu change) + notification d'annulation d'événement (`momentCancelled` — envoyé à tous les inscrits REGISTERED quand un événement est annulé) + notification Organisateur à la création d'événement (`hostMomentCreated` — confirmation par email au créateur). Port `EmailService` étendu avec `sendMomentUpdate`, `sendMomentCancelled`, `sendHostMomentCreated`. Fire-and-forget depuis `updateMomentAction` et `cancelMomentAction`. i18n FR/EN complet dans `messages/*.json`. | 2026-02-24 | — |
-| **Broadcast "Inviter ma Communauté"** : bouton sur la vue Organisateur d'un événement — envoie un email à tous les membres de la Communauté (cooldown 24h entre envois, protégé par `broadcastSentAt` ; bouton affiche "Envoyée" + tooltip temps restant pendant le cooldown, redevient actif après 24h). `broadcastMomentAction` (`src/app/actions/broadcast-moment.ts`), méthode `sendBroadcastMoment` sur `EmailService`, template `broadcast-moment` (react-email). Message personnalisable (`customMessage?`). i18n `Moment.broadcast.*` FR/EN complet. | 2026-02-28 | — |
-| **Préférences de notifications email** : 3 booléens sur `User` (`notifyNewRegistration`, `notifyNewComment`, `notifyNewMomentInCircle`), usecase `updateNotificationPreferences`, server action dans `profile.ts`, section "Notifications" sur `/dashboard/profile` avec toggles `Switch`, i18n FR/EN `Profile.notifications.*`. | 2026-02-24 | — |
-| **Export CSV des inscrits** : bouton "Exporter CSV" sur la vue Organisateur d'un événement (`RegistrationsList`), client-side avec BOM UTF-8, colonnes prénom/nom/email/statut/date. i18n `Moment.registrations.exportCsv` + `Moment.registrations.csvHeaders.*`. | 2026-02-24 | — |
-| **Dashboard Mode Switcher Participant / Organisateur** : enum `DashboardMode` sur `User` (DB + domaine + session Auth.js). Usecases `setDashboardMode`, `getHostUpcomingMoments`, `getHostPastMoments`. Composants `DashboardModeSwitcher` (pill switcher avec label "Vue :"), `CreateMomentButton` (CTA adaptatif 0/1/2+ Communautés), `CreateMomentDropdown` (Popover). Dashboard content filtré par mode (vue Participant / vue Organisateur). Welcome page redesignée : deux cartes cliquables "Je participe" / "J'organise". `shouldRedirectToWelcome` (`src/lib/dashboard.ts`). `SiteHeader` + `MobileNav` avec `dashboardHref` conditionnel. Homepage CTAs adaptatifs. `globalTeardown` E2E. `thomas@demo.playground` ajouté. 19 tests unitaires + spec E2E `dashboard-mode-switcher.spec.ts` (9 tests). | 2026-02-28 | — |
-| **Dashboard onglet Participant renommé** : libellé "Mes événements" → "Mes inscriptions" (FR) / "My registrations" (EN) — clé i18n `Dashboard.myMoments`. | 2026-03-02 | — |
-| **Page Aide `/help`** : page statique avec sidebar de navigation (ancres), FAQ accordion, sections Participant et Organisateur, i18n FR/EN/RO/NL/ES (namespace `Help`). Lien "Aide" ajouté dans le footer (`Footer.product.help`). | 2026-03-02 | — |
-| **Page Explorer : H1 "Communautés & événements"** (FR) / "Communities & events" (EN) — mise à jour de la clé i18n `Explorer.title`. | 2026-03-02 | — |
-| **Suppression membre d'une Communauté** : usecase `removeCircleMember`, contrôle Organisateur, annulation automatique des inscriptions à venir, i18n FR/EN. | 2026-03-01 | `706cf9b` |
-| **Invitation Communauté par lien** : usecases `generateCircleInviteToken` / `joinCircleByInvite` / `revokeCircleInviteToken`, token unique sur `Circle` (`inviteToken`), page publique `/circles/join/[token]` (rejoint la Communauté sans passer par un événement), bouton génération/révocation sur la page Communauté Organisateur, i18n FR/EN, tests unitaires + tests de sécurité (`circle-invite-security.test.ts`) + spec E2E (`circle-invite.spec.ts`). | 2026-03-04 | `ef288f7` |
-| **Catégorie personnalisée sur Communauté** : champ `customCategory` (string, max 100 chars) sur `Circle` (DB + domaine + repository). Activé uniquement quand la catégorie choisie est `OTHER`. Validé côté client dans `CircleForm` + géré dans les usecases `createCircle`/`updateCircle` via helper `resolveCustomCategoryForCreate`/`resolveCustomCategoryForUpdate` (`src/lib/circle-category-helpers.ts`). Affiché à la place du label "Autre" sur les cards et pages Communauté. | — | — |
-| **Rejoindre une Communauté directement (remplacement du Follow)** : suppression complète du modèle `CircleFollow` et des usecases `followCircle`/`unfollowCircle`. Nouveau usecase `joinCircleDirectly` + action `joinCircleDirectlyAction` + composant `JoinCircleButton`. Crée directement une `CircleMembership` PLAYER depuis la page Communauté publique. Admin stats : `totalMembers`/`recentMembers` (remplace `totalFollowers`/`recentFollowers`). | 2026-03-14 | — |
-| **Statut Brouillon (DRAFT) sur les événements** : `MomentStatus` enrichi avec `"DRAFT"`. Tout nouvel événement créé est en DRAFT par défaut. Usecase `publishMoment` (transition DRAFT → PUBLISHED, sens unique). Bouton "Publier" sur la vue Organisateur. Notifications membres + email Organisateur déplacés à la publication (plus à la création). Page publique accessible en DRAFT (bandeau "en cours de préparation", inscription bloquée). Dashboard Host : événements DRAFT dans l'onglet "à venir". Explorer : événements DRAFT exclus. Sitemap : événements DRAFT exclus. OG tags supprimés sur les pages DRAFT. | 2026-03-14 | — |
+1. [Fait (livré)](#fait-livré)
+2. [À faire — Produit](#à-faire--produit)
+3. [À faire — Infrastructure & Qualité](#à-faire--infrastructure--qualité)
+4. [Phase 2 (post-MVP)](#phase-2-post-mvp)
+5. [Bugs connus](#bugs-connus)
+6. [Améliorations futures — Stripe](#améliorations-futures--stripe)
+7. [Décisions clés](#décisions-clés)
 
 ---
 
-## MVP V1 — À faire
+## Fait (livré)
 
-> Référence UX complète : `spec/ux-parcours-jtbd.md` (8 personas, 25 JTBD, 7 parcours, matrice gaps).
+> 31 versions livrées (v0.1.0 → v2.7.0), 100+ features. Organisées par domaine fonctionnel.
+
+### Authentification & Profil
+
+| Feature | Version | Spec / PR |
+|---------|---------|-----------|
+| Auth magic link + OAuth Google/GitHub (Auth.js v5) | v0.1.0 | — |
+| Onboarding profil obligatoire au premier login | v0.2.0 | `spec/product/options-onboarding.md` |
+| Isolation onboarding (route group Next.js, layout minimal) | v0.2.0 | — |
+| Upload avatar (resize Canvas → WebP 384×384, Vercel Blob) | v0.8.0 | — |
+| Suppression de compte (cascade Communauté si seul Organisateur) | v0.8.0 | — |
+| Profils publics `/u/[identifier]` (lien unique, membres cliquables) | v1.11.0 | `spec/features/virality-public-profiles.md` |
+| Page de bienvenue `/dashboard/welcome` (choix Participant/Organisateur) | v1.6.0 | — |
+| Profils enrichis (bio, ville, liens réseaux sociaux) | v2.6.0 | — |
+| Email de bienvenue personnalisé (lettre du fondateur post-onboarding) | v2.7.0 | `spec/features/email-onboarding.md` |
+
+### Communautés (Circles)
+
+| Feature | Version | Spec / PR |
+|---------|---------|-----------|
+| CRUD Communauté (domain, tests, UI, i18n) | v0.1.0 | — |
+| Page publique `/circles/[slug]` (SEO, cold traffic, sans compte) | v0.5.0 | `spec/features/explorer-la-carte.md` |
+| Catégorie (enum 8 valeurs) + ville sur Communauté | v0.5.0 | — |
+| Catégorie personnalisée (`customCategory` si `OTHER`) | v1.0.0 | — |
+| Cover image (Unsplash via proxy + upload local, Vercel Blob) | v1.0.0 | — |
+| Liste des membres (Organisateurs avec Crown, emails Organisateur-only) | v1.1.0 | — |
+| Rejoindre une Communauté directement (`JoinCircleButton`, remplace Follow) | v1.13.0 | — |
+| Suppression de membre (`removeCircleMember`) | v1.10.0 | — |
+| Invitation par lien privé (token unique, génération/révocation) | v1.10.0 | `spec/features/bulk-invite.md` |
+| Quitter une Communauté (depuis page publique) | v1.9.0 | — |
+| Site web Communauté (URL affichée sur dashboard et page invitation) | v2.6.0 | — |
+| Réseaux de Communautés (regroupement, page partagée, badge) | v2.6.0 | `spec/features/circle-network.md` |
+
+### Événements (Moments)
+
+| Feature | Version | Spec / PR |
+|---------|---------|-----------|
+| CRUD événement + page publique `/m/[slug]` (URL partageable) | v0.1.0 | — |
+| Formulaire création minimaliste (titre, date, lieu, description) | v0.1.0 | — |
+| Autocomplétion adresse (Google Places) | v1.10.0 | — |
+| Fil de commentaires (plat, chronologique, max 2000 chars) | v0.3.0 | — |
+| Commentaires activés sur événements passés | v1.5.0 | — |
+| URLs cliquables dans descriptions et commentaires | v1.13.0 | — |
+| Événements passés accessibles (UI "Événement terminé" + CTA rétention) | v0.4.0 | — |
+| Statut Brouillon (DRAFT → PUBLISHED, sens unique) | v1.13.0 | — |
+| Publication directe depuis le formulaire de création | v2.7.0 | — |
+| Cover image événement (Unsplash contextuel lié au titre + upload) | v2.7.0 | — |
+| Pièces jointes (PDF + images, max 3 par événement) | v2.7.0 | `spec/features/moment-attachments.md` |
+| Section "Prochains événements de la Communauté" sur page événement | v1.5.0 | — |
+| Ajout au calendrier (Google Calendar, Apple Calendar, .ics) | v0.8.0 | — |
+| Dates verrouillées sur événements passés | v1.15.0 | — |
+| Mention "Proposé par [Communauté]" sur page événement | v1.15.0 | — |
+
+### Inscriptions & Liste d'attente
+
+| Feature | Version | Spec / PR |
+|---------|---------|-----------|
+| Inscription + auto-join Communauté (zéro friction) | v0.2.0 | — |
+| Annulation inscription + promotion automatique liste d'attente | v0.2.0 | — |
+| Position dans la liste d'attente visible (Xème) | v0.8.0 | — |
+| Blocage inscription si événement commencé (`MomentAlreadyStartedError`) | v0.2.0 | — |
+| Ré-inscription après annulation (update, pas de doublon) | v0.2.0 | — |
+| Inscriptions sur validation (approbation Organisateur, par événement ou Communauté) | v1.17.0 | `spec/features/approval-registration.md` |
+| File d'attente approbation dans le dashboard Organisateur | v1.17.0 | — |
+| Suppression de participant par l'Organisateur | v1.16.0 | — |
+
+### Paiements (Stripe Connect)
+
+| Feature | Version | Spec / PR |
+|---------|---------|-----------|
+| Événements payants avec prix configurable (en centimes) | v2.0.0 | `spec/features/stripe-connect.md` |
+| Stripe Connect onboarding Organisateur | v2.0.0 | — |
+| Politique de remboursement configurable par événement | v2.0.0 | — |
+| Remboursements automatiques (annulation participant, suppression, annulation événement) | v2.0.0 | — |
+| Remboursements batch à la suppression d'événement | v2.0.0 | — |
+| 0% commission plateforme (seuls frais Stripe ~2.9% + 0.30€) | v2.0.0 | — |
+| Résumé facturation sur page Organisateur | v2.0.0 | — |
+| Accès dashboard Stripe Express | v2.0.0 | — |
+
+### Emails & Notifications
+
+| Feature | Version | Spec / PR |
+|---------|---------|-----------|
+| **Architecture** : port `EmailService` (14+ méthodes) + adapter `ResendEmailService` | v0.7.0 | `spec/features/email-transactional.md` |
+| Templates React (react-email) avec calendar badge gradient | v0.7.0 | — |
+| Magic link email avec logo PNG embarqué base64 | v0.7.0 | — |
+| Confirmation inscription (+ variante liste d'attente) | v0.7.0 | — |
+| Promotion liste d'attente | v0.7.0 | — |
+| Notification Organisateur : nouvelle inscription | v0.7.0 | — |
+| Notification : nouveau commentaire (tous les inscrits + Organisateurs) | v1.5.0 | — |
+| Notification : nouveau membre rejoint la Communauté | v1.14.0 | — |
+| Notification : nouvel événement publié dans la Communauté | v1.5.0 | — |
+| Notification : mise à jour événement (date/lieu changés) | v1.3.0 | — |
+| Notification : annulation événement (tous les inscrits REGISTERED) | v1.5.0 | — |
+| Confirmation Organisateur à la création (avec .ics) | v1.5.0 | — |
+| Rappel automatique 24h avant événement (cron Vercel horaire) | v1.15.0 | — |
+| Broadcast "Inviter ma Communauté" (cooldown 24h, message personnalisable) | v1.9.0 | — |
+| Email confirmation paiement (avec reçu) | v2.0.0 | — |
+| Email notification annulation payante (pour l'Organisateur) | v2.0.0 | — |
+| Notification Organisateur : demande d'adhésion (approbation) | v2.3.1 | — |
+| Email de bienvenue personnalisé (lettre fondateur) | v2.7.0 | `spec/features/email-onboarding.md` |
+| Préférences de notifications (3 toggles opt-out sur profil) | v1.2.0 | — |
+
+### Dashboard (Mon espace)
+
+| Feature | Version | Spec / PR |
+|---------|---------|-----------|
+| Vue Participant / Organisateur (mode switcher persisté en DB + session) | v1.6.0 | — |
+| Timeline événements (à venir + passés) avec badges statut | v0.2.0 | — |
+| Onglet Communautés (cards avec stats membres/événements, prochain événement) | v1.0.0 | — |
+| Pagination événements passés (5 par défaut + "Voir plus") | v2.4.0 | — |
+| Export CSV des inscrits (prénom, nom, email, statut, date) | v1.5.0 | — |
+| CTA "Créer un événement" adaptatif (0/1/2+ Communautés) | v1.6.0 | — |
+| Badge réseau sur les Communautés du dashboard | v2.7.0 | — |
+| Compteurs inscrits/liste d'attente sur page Organisateur | v0.2.0 | — |
+| Perf : `React.cache()` pour `getUserDashboardCircles` (754ms → 192ms, -75%) | v1.5.0 | — |
+
+### Explorer (Découvrir)
+
+| Feature | Version | Spec / PR |
+|---------|---------|-----------|
+| Page `/explorer` (tabs Communautés/Événements, SSR, revalidate 300s) | v0.5.0 | `spec/features/explorer-la-carte.md` |
+| Section "À la une" (3 Communautés featured, cinématique, renouvellement quotidien) | v1.13.0 | — |
+| Filtres catégorie + tri (Recommandé / Popularité / Date) | v1.13.0 | — |
+| Format liste | v1.13.0 | — |
+| Pagination "Voir plus" (lazy loading) | v1.1.0 | — |
+| Score de classement automatique (`recalculate-scores` cron quotidien) | v1.13.0 | `spec/features/explorer-rating.md` |
+| Visibilité immédiate nouvelles Communautés + recalcul manuel (admin) | v1.16.0 | — |
+
+### Radar (planification événements)
+
+| Feature | Version | Spec / PR |
+|---------|---------|-----------|
+| Radar d'événements concurrents (Luma, Eventbrite, Meetup) | v1.8.0 | `spec/features/local-events-watcher.md` |
+| Interface : sélecteur ville, dates, mots-clés, streaming résultats | v1.8.0 | — |
+| Mots-clés personnalisés (ajout/modification/suppression) | v2.1.0 | — |
+| Limité aux événements physiques uniquement | v2.1.0 | — |
+| 25 analyses/jour par utilisateur | v2.1.0 | — |
+
+### Admin plateforme
+
+| Feature | Version | Spec / PR |
+|---------|---------|-----------|
+| Dashboard stats + listes paginées (Utilisateurs/Communautés/Événements) | v0.6.0 | `spec/features/admin-plateforme.md` |
+| Suppression + forcer annulation événement | v0.6.0 | — |
+| Courbes d'activité 30 jours enrichies | v1.12.0 | — |
+| Pages analytics détaillées (inscriptions, commentaires, avec graphiques) | v1.13.0 | — |
+| Taux d'activation (utilisateurs ayant rejoint ≥1 événement) | v1.12.0 | — |
+| Tri colonnes + responsive hamburger menu | v1.13.0 | — |
+| Gestion visibilité Explorer + recalcul scores | v1.16.0 | — |
+| Historique événements dans la fiche utilisateur | v2.3.0 | — |
+| Notifications Slack admin | v2.2.0 | — |
+
+### SEO & Contenu
+
+| Feature | Version | Spec / PR |
+|---------|---------|-----------|
+| OG images dynamiques (homepage, événement, Communauté) | v0.8.0 | `spec/infra/seo-strategy.md` |
+| `generateMetadata`, `metadataBase`, `robots.ts`, `sitemap.ts` | v0.8.0 | — |
+| Structured data enrichies (événements : description, image, prix, disponibilité) | v2.4.0 | — |
+| Canonical + hreflang sur pages publiques | v2.4.0 | — |
+| Blog bilingue FR/EN (5 articles) | v2.5.0 | `spec/features/blog-seo.md` |
+| Sections comparison/audience/FAQ structurée sur homepage | v2.5.0 | — |
+| Redirection intelligente homepage (selon contexte utilisateur) | v2.3.0 | — |
+
+### Pages institutionnelles
+
+| Feature | Version | Spec / PR |
+|---------|---------|-----------|
+| Homepage (hero, "Comment ça marche", 3 piliers, CTA, footer) | v0.5.0 | — |
+| About `/about` | v0.10.0 | — |
+| Changelog `/changelog` + réécriture automatique en langage utilisateur | v0.10.0 | — |
+| Contact `/contact` (formulaire + email direct) | v1.16.0 | — |
+| Pages légales (mentions légales, confidentialité, CGU) | v0.8.0 | — |
+| Page Aide `/help` (sidebar navigation, FAQ accordion, sections Participant/Organisateur) | v1.10.0 | `spec/product/help-page-content.md` |
+
+### Infrastructure & DevOps
+
+| Feature | Version | Spec / PR |
+|---------|---------|-----------|
+| Neon branching dev/prod + `db:dev:reset` | v0.1.0 | — |
+| Sentry error tracking (client/server/edge) | v0.2.0 | — |
+| PostHog product analytics | v0.2.0 | — |
+| Rapports PostHog quotidiens/hebdomadaires (cron email + Slack) | v2.7.0 | — |
+| CI : typecheck + tests unitaires sur chaque PR | v0.5.0 | — |
+| CI : DAST ZAP baseline hebdomadaire + full scan manuel | v1.13.0 | — |
+| CI : Release Please v17 (changelog automatique) | v1.5.0 | — |
+| PWA installable iOS (Safari) + Android (Chrome) | v1.3.0 | — |
+| Version affichée dans le footer | v1.3.0 | — |
+| Scripts seed test + démo (idempotent, variantes prod) | v0.4.0 | — |
+| Scripts export contacts Brevo, backfill notification prefs, dashboard mode | — | — |
+
+### i18n (internationalisation)
+
+| Feature | Version | Spec / PR |
+|---------|---------|-----------|
+| Français + Anglais natifs (next-intl) | v0.1.0 | — |
+| Espagnol | v1.7.0 | — |
+| Roumain | v1.7.0 | — |
+| Néerlandais | v1.7.0 | — |
+
+### Design & UX
+
+| Feature | Version | Spec / PR |
+|---------|---------|-----------|
+| Design system dark/light (Tailwind + shadcn/ui) | v0.1.0 | `spec/design/design-system.md` |
+| Responsive mobile complet (hamburger menu, cards compactes, hero centré) | v0.8.0 | — |
+| Covers carrées 1:1 partout (règle absolue) | v1.0.0 | — |
+| Avatar stacking (inscrits sur les cartes événement) | v2.3.0 | — |
+| CoverImagePicker (Unsplash contextuel + pagination + import drag-and-drop) | v1.0.0 | — |
+
+### Tests & Qualité
+
+| Feature | Version | Spec / PR |
+|---------|---------|-----------|
+| 690+ tests unitaires Vitest (37 usecases domaine + 11 admin) | — | — |
+| 99+ tests de sécurité (RBAC, IDOR cross-tenant, admin, avatar isolation, invite token) | — | — |
+| 11 specs E2E Playwright (auth, join, host-flow, cancel, comments, onboarding, waitlist, explore, dashboard-mode, broadcast, circle-invite) | — | — |
+| Infrastructure E2E : globalSetup + globalTeardown (nettoyage `@test.playground`) | — | — |
+| Audit sécurité complet | — | `spec/docs/security/AUDIT-2026-04-01.md` |
 
 ---
 
-### 🔴 Rétention & viralité — boucle critique (bloquant pour la croissance)
+## À faire — Produit
 
-> Ces éléments sont les **casseurs de loop** identifiés dans l'analyse UX.
-> Sans eux, le produit peut fonctionner mais ne peut pas croître ni fidéliser.
-> Référence : parcours A→G, gaps MVP-1 à MVP-4 + H-1 à H-8.
+> Référence UX complète : `spec/product/ux-parcours-jtbd.md` (8 personas, 25 JTBD, 7 parcours, matrice gaps).
 
-#### Emails transactionnels (Resend + react-email)
+### Haute priorité — Rétention & croissance
 
-- [x] **Email de confirmation d'inscription** (MVP-1 — parcours A) ✅
-  - Déclenché immédiatement après `JoinMoment`
-  - Contenu : titre événement, date, lieu, lien `/m/[slug]`, lien d'annulation
-  - Gère aussi le cas WAITLISTED (textes différents, même template)
+| # | Feature | Contexte | Gap |
+|---|---------|----------|-----|
+| P-01 | **Rappel 1h avant événement** | Infra 24h en place (cron, template, batch). Ajout incrémental : champ `reminder1hSentAt`, fenêtre 50min-70min. | — |
+| P-02 | **CTA "Voir dans mon espace" post-inscription** | Sur `/m/[slug]` après inscription confirmée : lien vers `/dashboard`. Faire découvrir l'espace personnel. | M-2 |
+| P-03 | **CTA "Créer le prochain événement" depuis un événement PAST** | Vue Organisateur événement passé : bouton "Programmer le prochain événement" (pré-remplir même Communauté). Capitaliser sur l'élan post-événement. | H-2 |
+| P-04 | **Guide onboarding Organisateur** | Stepper 3 étapes (Créer Communauté → Créer événement → Partager le lien). Objectif : time-to-first-event < 5 min. La welcome page oriente déjà, mais sans guide pas-à-pas. | H-7 |
 
-- [ ] **~~Email de rappel pré-événement~~** → **déprioritisé, post-MVP** (voir Phase 2)
-  - Rappel 24h avant + rappel 1h avant — nécessite une infrastructure de jobs planifiés (Vercel Cron / QStash)
-  - Complexité d'implémentation disproportionnée pour le MVP
+### Moyenne priorité
 
-- [x] **Email de promotion liste d'attente** (MVP-3 — parcours C) ✅
-  - Déclenché par `CancelRegistration` quand un inscrit se désiste et promeut un waitlisté
-  - Contenu : "Votre place est confirmée", détails de l'événement
-
-- [x] **Email de notification Organisateur : nouvelle inscription** (MVP-4 — parcours D) ✅
-  - Déclenché par chaque `JoinMoment` sur un événement dont l'utilisateur est Organisateur
-  - Contenu : nom du nouvel inscrit, total inscrits / places restantes, lien vers gestion
-  - Skip quand l'Organisateur s'inscrit lui-même
-
-- ~~**Email alerte Organisateur : nouveau follower**~~ — supprimé lors de la suppression du système Follow (remplacé par `joinCircleDirectly`).
-
-- [x] **Architecture email multi-canal** (infrastructure) ✅
-  - Port `EmailService` (14 méthodes) + adapter `ResendEmailService`
-  - Templates React (react-email) : calendar badge gradient, layout blanc/gris
-  - Fire-and-forget depuis server actions (pas de queue pour le MVP)
-  - Clé API : `AUTH_RESEND_KEY` (partagée auth + transactionnel)
-
-#### UX post-inscription — "Et maintenant ?" (parcours A)
-
-- [x] **CTA "Ajouter au calendrier" post-inscription** (gap M-1) ✅
-  - Sur la page `/m/[slug]` après inscription confirmée
-  - Liens : Google Calendar (via `buildGoogleCalendarUrl`) + fichier `.ics` (via `/api/moments/[slug]/calendar`)
-  - Composant `AddToCalendarButtons` (`src/components/moments/add-to-calendar-buttons.tsx`)
-  - Intégré dans `RegistrationButton` côté client
-
-- [ ] **Lien "Voir dans mon tableau de bord" post-inscription** (gap M-2)
-  - Sur la page `/m/[slug]` après inscription : lien visible vers `/dashboard`
-  - Objectif : faire découvrir l'espace personnel au nouveau membre
-
-- [x] **Section "Prochains événements de la Communauté" sur page événement publique** (gap M-3) ✅ — PR #68 `70a51f5`
-  - Sur `/m/[slug]` (vue publique uniquement, pas la vue Organisateur)
-  - Affiche les prochains événements PUBLISHED de la même Communauté
-  - Prop `upcomingCircleMoments` dans `MomentDetailView`
-
-#### Engagement post-événement — fenêtre d'or 24h (parcours F)
-
-- [x] **Commentaires activés sur les événements PAST** (gap H-1) ✅ — PR #93 `bf9b036`
-  - Formulaire toujours visible pour les utilisateurs connectés sur les événements passés
-  - Placeholder contextuel "Remerciements, photos, retours..."
-  - Décision prise : débloquer pour tous les connectés (pas uniquement l'Organisateur)
-
-- [ ] **CTA "Créer le prochain événement" depuis un événement PAST** (gap H-2)
-  - Sur la page événement PAST, vue Organisateur : bouton "Programmer le prochain événement"
-  - Pré-remplit le formulaire avec la même Communauté
-  - Capitalise sur l'élan post-événement
-
-#### Clarté liste d'attente (parcours C)
-
-- [x] **Position dans la liste d'attente visible** (gap H-3) ✅
-  - Sur `/m/[slug]` et dashboard : "Vous êtes X° sur la liste d'attente"
-  - Calcul à la volée via `prismaRegistrationRepository.countWaitlistPosition`
-  - Affiché dans `RegistrationButton` via prop `waitlistPosition`
-
-#### Découverte inter-événements (parcours B)
-
-- [x] **Autres événements de la Communauté sur la page événement dashboard Participant** (gap H-4) ✅
-  - `dashboard/circles/[slug]/moments/[momentSlug]/page.tsx` : `findUpcomingByCircleId(moment.circleId, moment.id, 3)` + prop `upcomingCircleMoments` passée à `MomentDetailView` (vue Participant uniquement)
-
-#### Onboarding Organisateur — time-to-first-event (parcours G)
-
-- [ ] **Guide onboarding Organisateur débutant** (gap H-7)
-  - Stepper 3 étapes — "Créez votre Communauté → Créez votre premier événement → Partagez le lien"
-  - Objectif : réduire le time-to-first-event à < 5 minutes
-  - Note : le mode choice de la welcome page (`J'organise`) oriente déjà l'Organisateur débutant, mais sans guide pas-à-pas
-
-- [x] **CTA "Devenir organisateur" pour Participants** (gap H-5) ✅
-  - Adressé par le Dashboard Mode Switcher : le pill "Organisateur" est visible pour tous les utilisateurs, même sans Communauté
-  - En mode Organisateur sans Communauté : CTA "Créer une Communauté d'abord" → `/dashboard/circles/new`
-
-#### Accueil utilisateur direct — sans lien d'entrée
-
-> Un utilisateur qui s'inscrit sans lien d'événement ni de Communauté ne sait pas où aller.
-> Le dashboard vide est silencieux — il faut l'orienter activement.
-
-- [x] **Dashboard Mode Switcher + Page de bienvenue `/dashboard/welcome`** ✅
-  - **Enum `DashboardMode`** (`PARTICIPANT` / `ORGANIZER`) sur `User` (DB + domaine + session)
-  - **Usecases** : `setDashboardMode`, `getHostUpcomingMoments`, `getHostPastMoments`
-  - **Server action** : `setDashboardModeAction` (`src/app/actions/dashboard.ts`)
-  - **Composants** : `DashboardModeSwitcher` (pill switcher client), `CreateMomentButton` (CTA adaptatif 0/1/2+ Communautés), `CreateMomentDropdown` (Popover sélection Communauté)
-  - **Dashboard content** : filtrage par mode — vue Participant (événements où inscrit) vs vue Organisateur (événements créés, variante `organizer` de `DashboardMomentCard`)
-  - **CTA adaptatif** en mode Organisateur : 0 Communauté → "Créer une Communauté d'abord", 1 Communauté → lien direct, 2+ → dropdown Popover
-  - **SiteHeader / MobileNav** : `dashboardHref` conditionnel (conserve le mode actif via URL param)
-  - **Homepage** : CTAs hero et section finale → `/dashboard/circles/new` si connecté
-  - **Welcome page redesignée** — deux cartes cliquables ("Je participe" / "J'organise") avec `setDashboardMode` immédiat et redirect vers `/dashboard`
-  - **Trigger welcome** : redirect vers `/dashboard/welcome` uniquement si `dashboardMode === null` ET aucune activité (pas de Communauté, pas d'inscription). Logique dans `shouldRedirectToWelcome` (`src/lib/dashboard.ts`)
-  - **Persistance** : `dashboardMode` en DB + en session Auth.js. Bascule via URL param `?mode=participant|organizer` + `setDashboardModeAction` en background (fire-and-forget)
-  - **Demo data** : `thomas@demo.playground` ajouté (user "blank slate" avec `dashboardMode: null` — permet de tester le flux welcome page)
-  - **Tests** : 19 tests unitaires `lib/__tests__/dashboard.test.ts` (règle `shouldRedirectToWelcome`, table de vérité exhaustive) + spec E2E `dashboard-mode-switcher.spec.ts` (9 tests — switcher, CTAs, persistence URL, redirect welcome)
-  - **Phase 2 — hors scope MVP** : email de re-engagement si N jours sans activité après le welcome
-
-#### Gestion des inscriptions Organisateur (parcours E)
-
-- [x] **Export CSV des inscrits** (gap E-3) ✅
-  - Depuis la page événement Organisateur : bouton "Exporter CSV"
-  - Colonnes : prénom, nom, email, statut (REGISTERED/WAITLISTED), date d'inscription
-  - Implémenté dans `RegistrationsList` (`src/components/moments/registrations-list.tsx`) — client-side, avec BOM UTF-8
-  - Clés i18n `Moment.registrations.exportCsv` + `Moment.registrations.csvHeaders.*`
-
-- [x] **Compteurs inscrits/liste d'attente sur page événement Organisateur** (gap H-8 + M-5) ✅ (partiel)
-  - Badges `registeredCount` + `waitlistedCount` + `capacity` en haut de `RegistrationsList`, badge par ligne
-  - Ce qui reste absent : deux sections séparées Inscrits / Liste d'attente (liste unifiée avec badges par ligne)
+| # | Feature | Contexte | Spec |
+|---|---------|----------|------|
+| P-05 | **Co-Organisateurs** | Plusieurs Organisateurs par Communauté. Nécessite un modèle de permissions. | `spec/features/co-organisateurs.md` |
+| P-06 | **Export données Organisateur étendu** | CSV membres Communauté, historique événements, inscrits cumulés. L'export CSV inscrits par événement existe déjà. | — |
+| P-07 | **Assistant IA basique** | Description événement, email invitation, suggestions Communauté. SDK Anthropic (Claude). | — |
+| P-08 | **Stats Communauté basiques** | Métriques sur la page Communauté Organisateur (tendance membres, taux de remplissage, etc.). | — |
 
 ---
 
-### Personnalisation visuelle — avatars & covers
+## À faire — Infrastructure & Qualité
 
-> Directement lié au principe "design premium par défaut" et à l'identité des communautés.
-> Les gradients générés sont de bons fallbacks, mais les Organisateurs doivent pouvoir personnaliser leur Communauté.
-
-- [x] **Avatar utilisateur** ✅ — upload photo de profil (Vercel Blob, resize Canvas WebP 384×384)
-
-- [x] **Cover Communauté** ✅ — image personnalisée de la Communauté (Vercel Blob, Unsplash via proxy + upload local)
-  - Champs `coverImage: String?` + `coverImageAttribution: Json?` sur `Circle` (DB + domaine)
-  - Composant `CoverImagePicker` : dialog tabs "Photos Unsplash" + "Importer" (drag-and-drop, resize client-side)
-    - Onglet Photos : 8 photos aléatoires Unsplash à l'ouverture (1/thématique, via `/api/unsplash/random`, chargées en parallèle, mises en cache) + recherche paginée prev/next
-    - Onglet Importer : drag-and-drop ou sélection fichier, validation client (5 Mo, JPG/PNG/WebP), resize Canvas → WebP
-  - Server action `processCoverImage` dans `src/app/actions/cover-image.ts` (partagée Communauté + événement)
-  - Affiché sur page Communauté publique, page Communauté dashboard, `CircleCard`, `PublicCircleCard`, `CircleAvatar`
-  - Attribution Unsplash : "Photo par [Nom] sur Unsplash"
-  - Fallback : gradient actuel si pas d'image
-  - Cleanup Vercel Blob de l'ancienne image lors du remplacement ou de la suppression
-
-- [x] **Cover événement** ✅ — image de couverture de l'événement (Vercel Blob, Unsplash via proxy + upload local)
-  - Champs `coverImage: String?` + `coverImageAttribution: Json?` sur `Moment` (DB + domaine)
-  - Même composant `CoverImagePicker` que pour la Communauté (même server action `processCoverImage`)
-  - Affiché en bannière sur la page publique `/m/[slug]` et la vue Organisateur
-  - Fallback : gradient actuel si pas d'image
-
-- [x] **Infrastructure upload** ✅ (prérequis commun aux covers Communauté/événement)
-  - Port `StorageService` + adapter `VercelBlobStorageService` (@vercel/blob)
-  - Contraintes : taille max 5 Mo, formats JPEG/PNG/WebP, redimensionnement Canvas côté client (WebP 384×384)
-
----
-
-### Priorité haute (bloquant pour le lancement)
-
-- [x] **Admin plateforme** ✅
-  - Pages `/admin/*` (même stack, shadcn)
-  - Dashboard stats + listes paginées + détail + suppression (Users, Circles, Moments)
-  - Forcer annulation événement
-  - Champ `role` (USER/ADMIN) sur User, middleware guard sur `/admin/*`
-
-- [x] **Préférences de notifications email** ✅ — intégrées dans la page profil (pas de page `/dashboard/settings` séparée)
-  - Section "Notifications" sur `/dashboard/profile` avec toggles `Switch` par type
-  - Préférences implémentées : `notifyNewRegistration`, `notifyNewComment`, `notifyNewMomentInCircle`
-  - Toutes activées par défaut (opt-out), champs booléens sur `User` en DB
-  - Usecase `updateNotificationPreferences` + server action dans `profile.ts`
-  - Chaque server action qui envoie un email consulte la préférence avant d'appeler `emailService`
-  - i18n FR/EN : namespace `Profile.notifications.*`
-
-- [ ] **Outils Organisateur enrichis** *(partiellement implémenté)*
-  - Co-Organisateurs (plusieurs Organisateurs par Communauté)
-  - [x] Retirer un membre d'une Communauté ✅ — usecase `removeCircleMember`, PR #123
-  - [x] Inviter par lien privé ✅ — token d'invitation unique sur la Communauté, page `/circles/join/[token]`, génération/révocation depuis la page Communauté Organisateur
-  - Stats Communauté basiques
-
-- [ ] **Paiement Stripe Connect**
-  - Événements payants : prix en centimes, reversement aux Organisateurs
-  - Stripe Connect onboarding pour les Organisateurs
-  - 0% commission plateforme, seuls frais Stripe
-
-- [x] **Fil de commentaires sur événement** ✅
-  - CRUD commentaire sur chaque événement
-  - Visible sur la page publique et la vue dashboard
-
-- [x] **Explorer** (ex-Répertoire, ex-Découvrir) ✅ — `spec/feature-explorer-la-carte.md`
-  - Page `/explorer` : vitrine publique, "répertoire de tous les possibles" (SSR, revalidate: 300)
-  - Section **"À la une"** : 3 Communautés mises en avant (sélection par `getFeaturedCircles`, renouvelées quotidiennement), composant `ExplorerFeatured`
-  - Tab **Communautés** : annuaire des Communautés publiques (card : nom, catégorie, ville, N membres, prochain événement en teaser)
-  - Tab **Événements** : agenda des événements PUBLISHED de Communautés publiques (card community-first)
-  - Filtres par **catégorie** + **tri** (`sortBy` : Recommandé / Popularité / Date — défaut Communautés : Recommandé, défaut Événements : Date)
-  - Page Communauté publique `/circles/[slug]` accessible sans compte (SEO + cold traffic)
-  - Lien "Explorer" dans le header principal (visible utilisateurs connectés)
-  - Schema : `CircleCategory` enum (8 valeurs) + `category` + `city` sur Communauté
-  - Formulaire Communauté : Select catégorie + Input ville
-  - 10 nouveaux tests unitaires BDD (`getPublicCircles`, `getPublicUpcomingMoments`)
-
-### Priorité moyenne
-
-- [x] **Email aux membres : nouvel événement dans leur Communauté** (gap M-4) ✅
-  - Automatique à la **publication** (`publishMomentAction`) — les événements en Brouillon ne déclenchent pas de notification
-  - Destinataires : membres PLAYER de la Communauté (hors créateur), filtrés par préférence `notifyNewMomentInCircle`
-  - Créateur exclu de la notification (via `findPlayersForNewMomentNotification`)
-
-- [ ] **Export données Organisateur**
-  - CSV export : membres Communauté, historique événements, inscrits cumulés
-
-- [ ] **Assistant IA basique**
-  - Description événement, email invitation, suggestions Communauté
-  - SDK Anthropic (Claude)
-
-### Infrastructure / Qualité
-
-- [x] **Perf dashboard : React.cache() pour getUserDashboardCircles** ✅ — PR #160, 2026-03-05
-  - `dashboard-content:circles` : **754ms → 192ms (-75%)**. `src/lib/dashboard-cache.ts` avec `getCachedDashboardCircles` + `getCachedHostMoments`.
-
-- [ ] **Stratégie migrations DB + rollback production** — voir `spec/db-migration-rollback-strategy.md`
-  - Baseline migrations Prisma (passer de `db:push` à `prisma migrate`)
-  - Scripts `db:migrate`, `db:migrate:prod`, `db:migrate:status`, `db:snapshot`
-  - Workflow pré-déploiement : snapshot Neon + Point-in-Time Restore comme filet
-  - Validation titre événement dans les usecases (max 200 chars, actuellement front-only)
-  - **Risque si non fait** : `db:push` peut silencieusement supprimer des données en prod (drop + recreate sur renommage de colonne)
-
-- [ ] **Corriger les vulnérabilités de dépendances** 🔴
-  - `pnpm audit` remonte 6 high + 5 moderate + 1 low (état au 2026-02-27)
-  - Analyser (`pnpm audit --audit-level=high`), mettre à jour ou appliquer des overrides
-  - Activer `pnpm audit --audit-level=high` en CI comme gate bloquant
-
-- [ ] **Pre-commit hooks (Husky + lint-staged)**
-  - Aucun hook git local actuellement — les erreurs TS/lint ne sont détectées qu'en CI
-  - Hook `pre-commit` : typecheck + eslint sur fichiers modifiés
-  - Hook `commit-msg` : validation format commits conventionnels
-
-- [ ] **Retirer \****`unsafe-eval`**\*\* du Content Security Policy**
-  - `script-src` inclut `'unsafe-eval'` — affaiblit la protection XSS
-  - Solution : nonces CSP via middleware Next.js (`experimental.nonce`) pour une politique stricte
-  - Tester en staging avant déploiement prod
-
-- [ ] **CI/CD enrichi**
-  - [x] Typecheck + tests unitaires sur chaque PR ✅
-  - [x] DAST ZAP baseline hebdomadaire + full scan manuel ✅
-  - [x] Release-please (changelog automatique) ✅
-  - [ ] `pnpm audit --audit-level=high` comme gate bloquant
-  - [ ] Tests d'intégration (job dédié avec service PostgreSQL GitHub Actions)
-  - [ ] Lighthouse CI sur pages clés (`/m/[slug]`, `/`) — seuils : Performance ≥ 90, A11y ≥ 90
-
-- [ ] **Rate limiting sur les actions sensibles**
-  - Aucune protection contre les abus (inscription, création de Communauté, commentaires)
-  - Solution : Upstash Rate Limit (Redis serverless, compatible Vercel Edge)
-  - Limites suggérées : 10 inscriptions/min/IP, 5 créations/heure/user
-
-- [x] **Tests unitaires complets** — 690 tests, 68 fichiers, tous usecases couverts (37 racine + 11 admin) ✅
-  - **Note** : `joinCircleDirectly` n'a pas encore de fichier de test unitaire dédié (`join-circle-directly.test.ts` manquant)
-- [x] **Tests de sécurité** — RBAC, IDOR cross-tenant, accès admin, avatar isolation, onboarding guards, invite token (99+ tests dédiés sécurité) ✅
-- [x] **Tests E2E Playwright** — 11 specs (auth, join-moment, host-flow, cancel-registration, comments, onboarding, waitlist, explore, dashboard-mode-switcher, broadcast-moment, circle-invite). Infrastructure `globalSetup` + `globalTeardown` (nettoyage propre des données `@test.playground` après chaque run). ✅
-  - **Note** : le parcours "rejoindre une Communauté directement via `JoinCircleButton`" (sans événement) n'est pas encore couvert en E2E
-- [ ] **Accessibilité axe-core** dans Playwright
-
-- [ ] **Bundle analyzer** (`@next/bundle-analyzer`)
-  - Aucune visibilité sur la taille du bundle JS
-  - Lancer ponctuellement après l'ajout de dépendances majeures (`pnpm analyze`)
-
-- [ ] **Diagramme d'architecture**
-  - L'architecture hexagonale est documentée textuellement dans CLAUDE.md mais sans schéma visuel
-  - Créer un diagramme C4 niveau 2 ou schéma des couches dans `spec/architecture.md`
-  - Utile pour l'onboarding de nouveaux contributeurs
+| # | Feature | Contexte | Spec |
+|---|---------|----------|------|
+| I-01 | **Stratégie migrations DB + rollback prod** | Passer de `db:push` à `prisma migrate`. `db:push` peut silencieusement supprimer des données en prod (drop+recreate sur renommage). Snapshot Neon + PITR comme filet. | `spec/infra/db-migration-rollback-strategy.md` |
+| I-02 | **Corriger vulnérabilités dépendances** | `pnpm audit` remontait 6 high + 5 moderate (état 2026-02-27). À réévaluer. | — |
+| I-03 | **Pre-commit hooks (Husky + lint-staged)** | Aucun hook git local — erreurs TS/lint détectées uniquement en CI. Hook `pre-commit` + `commit-msg`. | — |
+| I-04 | **Retirer `unsafe-eval` du CSP** | `script-src` inclut `'unsafe-eval'`. Solution : nonces CSP via middleware Next.js. | — |
+| I-05 | **CI : `pnpm audit --audit-level=high` gate bloquant** | Gate manquant en CI. | — |
+| I-06 | **CI : Tests d'intégration** | Job dédié avec service PostgreSQL GitHub Actions. | — |
+| I-07 | **CI : Lighthouse CI** | Pages clés (`/m/[slug]`, `/`). Seuils : Performance ≥ 90, A11y ≥ 90. | — |
+| I-08 | **Rate limiting actions sensibles** | Aucune protection anti-abus. Solution : Upstash Rate Limit. Limites : 10 inscriptions/min/IP, 5 créations/heure/user. | — |
+| I-09 | **Accessibilité axe-core dans Playwright** | Intégrer axe-core dans les tests E2E existants. | — |
+| I-10 | **Bundle analyzer** | `@next/bundle-analyzer`. Aucune visibilité sur la taille du bundle JS. | — |
+| I-11 | **Diagramme d'architecture** | L'architecture hexagonale est documentée textuellement (CLAUDE.md) mais sans schéma visuel. C4 niveau 2 dans `spec/architecture.md`. | — |
+| I-12 | **Test unitaire `joinCircleDirectly`** | Fichier de test dédié manquant. | — |
+| I-13 | **E2E : rejoindre Communauté directement** | Parcours `JoinCircleButton` (sans événement) non couvert en E2E. | — |
 
 ---
 
 ## Phase 2 (post-MVP)
 
-- [ ] **Perf DB : migrer vers le driver WebSocket Neon (`@neondatabase/serverless` Pool mode)**
-  - **Contexte** : suite à la migration TCP (`@prisma/adapter-pg`, PR #157), on observe que les connexions TCP concurrentes sur cold start Vercel causent 650-750ms d'attente (Neon queue les connexions). Le fix immédiat (React.cache()) réduit les connexions concurrentes. La solution structurelle est le **driver WebSocket Neon**.
-  - **Pourquoi WebSocket** : `@neondatabase/serverless` en mode `Pool` maintient des connexions WebSocket persistantes. Avantages vs TCP brut :
-    - Pas de TCP+TLS handshake sur cold start (WebSocket = HTTP upgrade, plus rapide)
-    - Conçu spécifiquement pour Vercel Serverless + Neon
-    - Meilleure gestion du multiplexage de connexions
-    - Compatible Vercel Edge (contrairement à TCP)
-  - **Pré-requis** : valider d'abord le fix React.cache() pour mesurer la baseline propre
-  - **Migration** : remplacer `@prisma/adapter-pg` + `PrismaPg` par `@neondatabase/serverless` Pool + `PrismaNeon` en mode Pool. Garder `PRISMA_USE_HTTP_ADAPTER=true` comme rollback. Mesurer l'impact en prod.
-  - **Risque** : migration plus complexe, à planifier après stabilisation des performances post React.cache()
+### Performance DB
 
-- [ ] **Suivre une Communauté (Follow)** — *système Follow supprimé* (2026-03-14) et remplacé par `joinCircleDirectly`. Si une fonctionnalité d'abonnement sans adhésion complète est souhaitée à terme, à repenser.
+- [ ] **Migrer vers le driver WebSocket Neon** (`@neondatabase/serverless` Pool mode)
+  - Connexions TCP concurrentes sur cold start Vercel causent 650-750ms d'attente
+  - WebSocket = HTTP upgrade, plus rapide, conçu pour Vercel Serverless + Neon
+  - Pré-requis : baseline propre post React.cache() (déjà en place)
 
-- [ ] Track (série d'événements récurrents dans une Communauté)
-- [ ] Check-in (marquer présent sur place)
-- [ ] **Galerie photos post-événement**
-  - Les Participants et l'Organisateur peuvent uploader des photos après un événement PAST
-  - Galerie visible sur la page publique `/m/[slug]` et sur la page Communauté (onglet dédié ou section en bas)
-  - Upload via `StorageService` existant (Vercel Blob) — infrastructure déjà en place
-  - Contraintes : formats JPEG/PNG/WebP, taille max (resize côté client), N photos max par événement
-  - Option modération : l'Organisateur peut supprimer une photo
-  - Viralité : lien partageable vers la galerie, CTA "Voir les photos" dans l'email post-événement
-- [x] **Radar concurrentiel** ✅ — PRs #95 #96 #97
-  - POC isolé accessible en interne sous `/lab/events-radar` (pas intégré au formulaire de création d'événement)
-  - Agent IA (Claude) qui scrape Luma, Meetup, Eventbrite pour trouver les événements concurrents dans une ville et un créneau donnés
-  - Interface : sélecteur de ville (11 villes FR/EU), date de début/fin, mots-clés, streaming des résultats en temps réel
-  - Table `RadarUsage` en DB pour le suivi d'usage par utilisateur et par jour
-  - **Note** : l'intégration dans le formulaire de création d'événement (objectif initial) reste à faire
+### Fonctionnalités produit
 
-- [ ] Plan Pro (analytics, branding, IA avancée, API, multi-canal)
-- [ ] **Emails de rappel pré-événement** (24h + 1h avant) — jobs planifiés Vercel Cron ou Upstash QStash, flags `reminder24hSentAt` / `reminder1hSentAt` sur `Moment`
-- [ ] Visual regression testing (Chromatic/Percy)
-- [ ] SAST/DAST (Snyk/SonarCloud)
-- [ ] Load testing (k6/Artillery)
-- [ ] Pentest externe
+- [ ] **Track** — Série d'événements récurrents dans une Communauté (retiré du MVP v1)
+- [ ] **Check-in** — Marquer présent sur place (retiré du MVP v1)
+- [ ] **Galerie photos post-événement** — Upload par Participants et Organisateur après un événement PAST. Galerie sur `/m/[slug]` et page Communauté. Modération par l'Organisateur. CTA "Voir les photos" dans l'email post-événement. Infrastructure `StorageService` (Vercel Blob) déjà en place.
+- [ ] **Plan Pro** — Analytics avancés, branding personnalisé, IA avancée, API, notifications multi-canal
+- [ ] **Suppression lien d'invitation** — Remplacer le système de token par email uniquement — `spec/features/remove-invite-token.md`
+- [ ] **White-label / mono-community** — `spec/product/white-label-mono-community.md`
+
+### Qualité & Sécurité
+
+- [ ] **Visual regression testing** (Chromatic/Percy)
+- [ ] **SAST complet** (Snyk/SonarCloud) — le DAST ZAP baseline est déjà en CI
+- [ ] **Load testing** (k6/Artillery) — uniquement en phase pré-lancement
+- [ ] **Pentest externe** — pré-lancement
 
 ---
 
 ## Bugs connus
 
 | # | Description | Statut | Détail |
-| --- | --- | --- | --- |
-| B-01 | OAuth Google bloquée depuis les navigateurs in-app (Instagram, WhatsApp, Facebook…) | ⚠️ Workaround utilisateur | Google refuse les WebViews (`Error 403: disallowed_useragent`). Fix possible : détecter le user-agent et afficher un message explicatif sur `/auth/error` à la place de l'erreur Google. |
-| B-02 | Page `/changelog` — RangeError stack overflow en prod | ✅ Corrigé `3fd5a2b` | `readFileSync(CHANGELOG.md)` pouvait crasher si le fichier absent du bundle serverless Vercel → boucle error boundary React. Fix : `outputFileTracingIncludes` + try/catch. |
-| B-03 | OAuth Google `redirect_uri_mismatch` pour certains users | ✅ Corrigé (config Vercel) | `AUTH_URL` absent → Auth.js utilisait `VERCEL_URL` ou le header `x-forwarded-host` de façon non déterministe. Fix : ajouter `AUTH_URL=https://the-playground.fr` dans les variables Vercel. |
-| B-04 | Page `/changelog` uniquement en français | 🔴 Ouvert | Contenu de `CHANGELOG.md` rédigé en FR uniquement. Fix possible : deux fichiers `CHANGELOG.fr.md` / `CHANGELOG.en.md`, ou sections FR/EN dans un seul fichier, ou afficher le même contenu FR pour les deux locales (acceptable pour un changelog technique). |
+|---|-------------|--------|--------|
+| B-01 | OAuth Google bloquée depuis les navigateurs in-app (Instagram, WhatsApp, Facebook) | **Workaround utilisateur** | Google refuse les WebViews (`Error 403: disallowed_useragent`). Fix possible : détecter le user-agent et afficher un message explicatif sur `/auth/error`. |
+| B-04 | Page `/changelog` uniquement en français | **Ouvert** | Contenu de `CHANGELOG.md` rédigé en FR uniquement. Fix possible : deux fichiers FR/EN, ou afficher le même contenu FR (acceptable pour un changelog technique). |
 
----
-
-## Décisions clés
-
-| Date | Décision |
-| --- | --- |
-| 2026-02-19 | Usecases = fonctions (pas de classes) |
-| 2026-02-19 | ActionResult pattern pour les server actions |
-| 2026-02-19 | Slug généré dans le usecase (règle métier) |
-| 2026-02-19 | Circle = Cercle en français (renommé en **Communauté** le 2026-02-22), Host/Player en anglais dans le code |
-| 2026-02-20 | Host = Player + droits de gestion (rôle hiérarchique, une seule membership par user/circle) |
-| 2026-02-20 | Neon branching dev/prod (`pnpm db:dev:reset` pour snapshot frais) |
-| 2026-02-20 | Onboarding profil obligatoire au premier login |
-| 2026-02-20 | Email non éditable dans le profil (clé unique Auth.js, pivot de liaison entre providers) |
-| 2026-02-20 | Pas de merge/liaison manuelle de comptes dans le MVP (si emails différents = comptes différents) |
-| 2026-02-20 | Positionnement clarifié : community-centric (modèle Meetup) + UX premium (expérience Luma) + 100% gratuit. La Communauté est l'entité centrale, l'événement est la porte d'entrée virale, la page Communauté est la couche de rétention (absente chez Luma). Dashboard Organisateur = Communauté-first. *(Terminologie FR mise à jour le 2026-02-22 : Cercle → Communauté, Escale → événement)* |
-| 2026-02-20 | L'organisateur est automatiquement inscrit (REGISTERED) à l'événement qu'il crée — règle métier dans `createMoment`. |
-| 2026-03-14 | Statut DRAFT : tout événement créé est en Brouillon par défaut. Transition DRAFT → PUBLISHED via `publishMoment` (sens unique). Notifications membres et email Organisateur déplacés à la publication. Événements DRAFT exclus de l'Explorer et du sitemap. |
-| 2026-02-20 | Check-in retiré du MVP → Phase 2 (pas prioritaire pour le lancement) |
-| 2026-02-20 | ~~La Carte = Circles uniquement (pas d'événements).~~ **Révisée le 2026-02-21** : La Carte = Circles + événements à venir de Circles publics. *(Renommé "Découvrir" le 2026-02-22)* |
-| 2026-02-21 | Événements passés accessibles sur la page publique `/m/[slug]` (avec UI "Événement terminé"). Seuls les CANCELLED renvoient une 404. |
-| 2026-02-21 | Page Communauté = même layout 2 colonnes que la page événement (cover gradient LEFT sticky, contenu RIGHT). Cohérence design inter-pages. |
-| 2026-02-21 | Carte "Événement terminé" (vue publique événement passé) inclut un CTA "Voir les prochains événements de la Communauté" — rétention vers la Communauté. |
-| 2026-02-21 | Fil de commentaires plat (pas de réponses imbriquées). Max 2000 chars. Tout utilisateur authentifié peut commenter, même sans être membre. Auteur et Organisateur peuvent supprimer. Sur événements PAST, le formulaire est masqué mais les commentaires restent visibles. |
-| 2026-02-21 | Convention pérenne utilisateurs test : domaine `@test.playground` en dev ET en prod. Pas de champ DB supplémentaire. Suppression via `DELETE WHERE email LIKE '%@test.playground'`. |
-| 2026-02-21 | Scripts données test : seed idempotent (`upsert` partout), cleanup avec flag `--execute` (dry-run par défaut). Variantes prod via scripts shell Neon (même pattern que `db-push-prod.sh`). Données FR uniquement (noms, lieux). |
-| 2026-02-21 | Page profil : layout single-column centré (pas 2 colonnes), avatar + nom + email + stats en header, formulaire prénom/nom, meta rows read-only (email, membre depuis). Email retiré du formulaire (lecture seule dans meta row). |
-| 2026-02-21 | Fils d'ariane : obligatoires sur toutes les pages dashboard sauf racine `/dashboard` et onboarding `profile/setup`. Pattern CSS unifié. |
-| 2026-02-21 | Badges unifiés : fond plein (`default`) = engagement positif (Inscrit, Publié). Outline = tout le reste (Organisateur en `outline` + accent primary, Annulé en `outline` + accent destructive, Passé en `outline` neutre, Participant en `secondary`). |
-| 2026-02-21 | Couleur unique : `--destructive` = `--primary` (même rose). Le danger est communiqué par le contexte (mot, modale), pas par une couleur différente. Approche Luma : un seul accent. |
-| 2026-02-21 | Bouton Modifier : toujours `default` (rose plein) + `size="sm"` sur les pages de détail (Communauté et événement). Cohérence inter-pages. |
-| 2026-02-21 | Analyse UX JTBD complète (spec/ux-parcours-jtbd.md) : 8 personas, 25 JTBD, 7 parcours. 4 casseurs de loop identifiés (emails transactionnels), 8 gaps haute priorité, 7 moyens. Ajoutés au backlog sous "Rétention & viralité". |
-| 2026-02-21 | Découvrir (spec/feature-explorer-la-carte.md) : `/explorer` avec tabs Communautés + Événements, community-first, pas d'algorithme. Décision révisée : Découvrir = Communautés + événements à venir de Communautés publiques (pas Communautés uniquement). Métaphore : "répertoire de tous les possibles" = incarnation du nom Playground. Schema : `category` + `city` sur Communauté. Page Communauté publique `/circles/[slug]` pour le cold traffic et le SEO. |
-| 2026-02-21 | Dashboard redesigné : pill tabs + timeline unifiée. Pas de CTAs dans les tab headers, uniquement dans les empty states. Page de consultation, pas de création. |
-| 2026-02-21 | Terminologie i18n rebranding (intermédiaire). FR : Moment → **Escale** (féminin — Publiée, Annulée, Passée), S'inscrire → **Rejoindre**, Dashboard → **Mon Playground**. EN : Player → **Member**, Register → **Join**, Dashboard → **My Playground**. *(Terminologie FR finalisée le 2026-02-22 : Escale → événement, Mon Playground → Mon espace, Rejoindre → S'inscrire)* |
-| 2026-02-21 | Le Répertoire renommé **La Carte** (FR) / **Explore** (EN). Route `/explorer` et namespace i18n `Explorer` inchangés. **La Boussole** réservée pour l'assistant IA (futur). *(La Carte renommée ****\*\*\*\*\*\*Découvrir****\*\*\*\*\*\* en FR le 2026-02-22)* |
-| 2026-02-21 | Convention démo : domaine **`@demo.playground`** distinct de `@test.playground`. Démo = contenu réaliste pour présentation/validation produit. Test = données techniques pour QA/dev. Reset complet de base (dev + prod) via `prisma db push --force-reset` avant injection démo. |
-| 2026-02-21 | Données démo : 6 Communautés publiques (TECH/Paris, DESIGN/Lyon, SPORT_WELLNESS/Paris, BUSINESS/Bordeaux, ART_CULTURE/Nantes, SCIENCE_EDUCATION/online), 20 users FR, 30 événements (1 passé + 4 à venir par Communauté), ratio 20%/80%, contenu entièrement en français. |
-| 2026-02-21 | Emails transactionnels : envoyés depuis les server actions (pas les usecases). Usecases restent purs (pas de side effects). Fire-and-forget (si email échoue, inscription réussit). Traductions i18n résolues dans le flux principal avant le fire-and-forget. Port `EmailService` avec 8 méthodes + adapter `ResendEmailService` (Resend + react-email). 4 emails MVP : confirmation inscription, confirmation liste d'attente, promotion liste d'attente, notification Organisateur. |
-| 2026-02-21 | Agents Claude Code : définis dans `.claude/agents/` (gitignored). `test-coverage-guardian` — audit usecase vs test, création des manquants, run en boucle jusqu'à 100% vert. `security-guardian` — cartographie des points d'autorisation, tests RBAC/IDOR/admin, correction des vulnérabilités réelles dans le code source si détectées. Pattern : lancer en worktree isolé pour zéro risque sur main. |
-| 2026-02-21 | Sécurité — defense-in-depth : les usecases admin ne doivent PAS faire confiance à la couche action seule. Chaque usecase admin accepte `callerRole: UserRole` et lève `AdminUnauthorizedError` si `callerRole !== "ADMIN"`. Principe : la sécurité est dans le domaine, pas uniquement à la périphérie. |
-| 2026-02-21 | Observation architecturale : les pages admin (`/admin/*.tsx`) appellent `prismaAdminRepository` directement (sans passer par les usecases). Elles sont protégées par le layout guard mais ne bénéficient pas de la defense-in-depth des usecases. À adresser post-MVP. |
-| 2026-02-22 | Terminologie FR simplifiée pour accessibilité : Cercle → **Communauté** (féminin), Escale → **événement** (masculin : Publié, Annulé, Passé), Mon Playground → **Mon espace**, La Carte → **Découvrir**, Rejoindre → **S'inscrire**. Code identifiers, clés JSON et noms de fichiers restent en anglais. EN inchangé. Motivation : termes plus accessibles pour les utilisateurs non familiers avec les concepts Meetup/Luma. |
-| 2026-02-23 | CoverImagePicker — photos d'ouverture = **random Unsplash** (8 thématiques fixes : technology, design studio, business meeting, fitness sport, art painting, science laboratory, community people, nature landscape). Route `/api/unsplash/random` : 8 appels `/photos/random` en parallèle. Résultat mis en cache côté composant (pas de re-fetch aux réouvertures). Abandonne les photos curées statiques par catégorie (fragiles, non représentatives). |
-| 2026-02-23 | CoverImagePicker — **Radix UI mode contrôlé** : en mode `open` contrôlé, changer l'état `open` programmatiquement via `setOpen(false)` ne déclenche PAS le callback `onOpenChange`. Pour garantir le reset de l'état interne, toujours passer par la fonction `handleOpenChange`. Règle : `handleApply` et `handleRemove` appellent `handleOpenChange(false)`, jamais `setOpen(false)` directement. |
-| 2026-02-23 | CoverImagePicker — **pagination search** : navigation prev/next (remplace les photos en place) plutôt qu'un "Voir plus" (qui agrandissait la modale). Le param `page` est propagé à la route `/api/unsplash/search`. |
-| 2026-02-28 | **Dashboard Mode Switcher** : enum `DashboardMode` (`PARTICIPANT` / `ORGANIZER`) sur `User`. Persisté en DB et en session Auth.js. Pill switcher dans le header du dashboard (client component). Le mode contrôle le contenu affiché (vue Participant = événements inscrits / vue Organisateur = événements créés + CTAs). Transition via URL param `?mode=participant\|organizer` + `setDashboardModeAction` en background. |
-| 2026-02-28 | **Welcome page redesignée** : deux cartes cliquables ("Je participe" / "J'organise") remplacent les deux cartes CTA statiques ("Créer ma Communauté" / "Découvrir des Communautés"). Le choix persiste en DB. Trigger : `dashboardMode === null` ET aucune activité. Utilisateurs existants avec activité mais sans mode → PARTICIPANT par défaut (évite boucle infinie). |
-| 2026-02-28 | **CTA Créer un événement adaptatif** : `CreateMomentButton` (Server Component) adapte le CTA selon le nombre de Communautés hébergées — 0 → redirect `/circles/new`, 1 → lien direct, 2+ → `CreateMomentDropdown` (Popover). |
-| 2026-02-28 | **Infrastructure E2E — globalTeardown** : `tests/e2e/global-teardown.ts` ajouté dans `playwright.config.ts`. Nettoyage propre des données `@test.playground` après chaque run E2E (Moments → Circles → Users, dans l'ordre des contraintes FK). Le prochain run repart d'un état propre via `globalSetup`. |
-| 2026-02-28 | **Données démo enrichies** : `thomas@demo.playground` ajouté dans `db-seed-demo-data.ts` — user "blank slate" avec `dashboardMode: null` (reset à chaque run du seed). Permet de tester le flux welcome page en prod sans créer un compte. |
-| 2026-03-03 | **Broadcast — cooldown 24h** : le verrou permanent "envoi unique par événement" a été remplacé par un cooldown 24h (`COOLDOWN_MS = 24 * 60 * 60 * 1000`). Après expiration du cooldown, l'Organisateur peut renvoyer l'invitation. Pendant le cooldown, le bouton affiche "Envoyée" (disabled) avec un tooltip Radix indiquant le temps restant avant le prochain envoi possible. `broadcastSentAt` est écrasé à chaque envoi (timestamp mis à jour). |
-| 2026-03-13 | Terminologie FR : "Découvrir" → **"Explorer"** pour aligner FR et EN (Explore). Nom de page plus cohérent entre les deux langues. Clé i18n `Explorer` et route `/explorer` inchangées. |
+> **Résolus** : B-02 (RangeError changelog, `3fd5a2b`), B-03 (OAuth `redirect_uri_mismatch`, config Vercel `AUTH_URL`).
 
 ---
 
@@ -473,10 +334,83 @@
 
 | # | Sujet | Détail |
 |---|-------|--------|
-| 1 | Redesign bloc CTA + Participants | Dédupliquer les stats (inscrits + places) entre le bloc CTA et le bloc Participants sur la page événement publique. Intégrer la mention de politique de remboursement dans ce redesign. |
-| 2 | Section Paiements à la création de Communauté | Afficher la section "Paiements" en mode désactivé sur la page de création (pas seulement sur la page modifier). Message : "Disponible après la création de votre Communauté". |
-| 3 | Banner vert confirmation inscription | Changer la couleur du banner "Vous participez à cet événement" de rose à vert pour mieux communiquer "confirmé". |
-| 4 | Sécuriser checkout-return URL | Remplacer `userId`/`momentId` dans les query params par le Stripe Checkout Session ID. Récupérer les metadata côté serveur via l'API Stripe. |
-| 5 | Renommer `isDemoEmail` | Le nom est trompeur maintenant qu'il filtre aussi `@test.playground`. Renommer en `isFilteredEmail` ou `isNonDeliverableEmail`. |
-| 6 | Frais Stripe non remboursés | Stripe ne rembourse pas ses frais (~0,59€/transaction). Si abus de désinscriptions, ajouter une limite temporelle (ex: remboursable jusqu'à 24h avant l'événement). |
-| 7 | Guard payant + approbation | Interdire la combinaison `price > 0 AND requiresApproval=true`. Actuellement le flag `requiresApproval` est silencieusement ignoré pour les événements payants (le webhook crée REGISTERED directement, bypass l'approbation). Court terme : guard dans `createMoment` + désactiver le switch UI. Long terme : supporter le flow "payer puis attendre approbation" avec remboursement si refusé. |
+| S-01 | Redesign bloc CTA + Participants | Dédupliquer les stats (inscrits + places) entre le bloc CTA et le bloc Participants. Intégrer la mention de politique de remboursement. |
+| S-02 | Section Paiements à la création de Communauté | Afficher la section "Paiements" en mode désactivé sur la page de création (message : "Disponible après la création"). |
+| S-03 | Banner vert confirmation inscription | Changer la couleur du banner "Vous participez" de rose à vert pour mieux communiquer "confirmé". |
+| S-04 | Sécuriser checkout-return URL | Remplacer `userId`/`momentId` dans les query params par le Stripe Checkout Session ID. Récupérer les metadata côté serveur. |
+| S-05 | Renommer `isDemoEmail` | Le nom est trompeur (filtre aussi `@test.playground`). Renommer en `isFilteredEmail` ou `isNonDeliverableEmail`. |
+| S-06 | Frais Stripe non rembours��s | Stripe ne rembourse pas ses frais (~0,59€/transaction). Si abus, ajouter limite temporelle (ex: remboursable jusqu'à 24h avant). |
+| S-07 | Guard payant + approbation | Interdire la combinaison `price > 0 AND requiresApproval=true`. Le webhook crée REGISTERED directement, bypass l'approbation. Court terme : guard dans `createMoment`. |
+
+---
+
+## Décisions clés
+
+> Décisions architecturales et produit prises au fil du développement. Les décisions intermédiaires supersédées ont été retirées.
+
+| Date | Décision |
+|------|----------|
+| 2026-02-19 | Usecases = fonctions (pas de classes). ActionResult pattern pour server actions. Slug généré dans le usecase (règle métier). |
+| 2026-02-19 | Stack : TypeScript full-stack (Next.js 16, Prisma, PostgreSQL, Auth.js, Stripe Connect, Tailwind + shadcn/ui, Resend, Anthropic SDK, Vercel + Neon). |
+| 2026-02-19 | Architecture hexagonale stricte : `domain/` (models, ports, usecases) + `infrastructure/` (repositories, services) + `app/` (routes Next.js). |
+| 2026-02-19 | Tests BDD lightweight (Given/When/Then natif Vitest) + Specification by Example (`test.each`), pas de Gherkin/Cucumber. |
+| 2026-02-19 | 100% gratuit, 0% commission plateforme, seuls frais Stripe. |
+| 2026-02-19 | Auth : Magic link + OAuth (Google, GitHub) via Auth.js v5. |
+| 2026-02-19 | UI bilingue FR/EN dès V1, architecture i18n native (next-intl). |
+| 2026-02-19 | Track retiré du MVP V1 → Phase 2. Check-in retiré du MVP → Phase 2. |
+| 2026-02-20 | Modèle User unique — Host = Player + droits de gestion (rôle via `CircleMembership`). |
+| 2026-02-20 | Positionnement : community-centric (modèle Meetup) + UX premium (Luma) + 100% gratuit. Communauté = entité centrale, événement = porte d'entrée virale. |
+| 2026-02-20 | L'Organisateur est automatiquement inscrit (REGISTERED) à l'événement qu'il crée. |
+| 2026-02-20 | Email non éditable dans le profil (clé unique Auth.js). Pas de merge/liaison de comptes dans le MVP. |
+| 2026-02-20 | Neon branching dev/prod (`pnpm db:dev:reset`). Prix en centimes (int, convention Stripe). |
+| 2026-02-21 | Fil de commentaires plat (pas de réponses imbriquées). Max 2000 chars. Tout authentifié peut commenter. |
+| 2026-02-21 | Convention données test : domaine `@test.playground` (dev + prod). Convention démo : `@demo.playground`. |
+| 2026-02-21 | Badges unifiés : `default` = engagement positif, `outline` = tout le reste. Couleur unique : `destructive` = `primary` (même rose). |
+| 2026-02-21 | Emails envoyés depuis server actions (pas usecases). Fire-and-forget (email échoue → inscription réussit). |
+| 2026-02-21 | Sécurité defense-in-depth : chaque usecase admin accepte `callerRole: UserRole` + lève `AdminUnauthorizedError`. |
+| 2026-02-22 | **Terminologie FR finale** : Communauté (féminin), événement (masculin), Organisateur, Participant, Mon espace, Explorer, S'inscrire. Code inchangé (Circle, Moment, Host, Player). |
+| 2026-02-23 | **Terminologie EN finale** : Community, Event, Member, Dashboard, Explore. Code inchangé. |
+| 2026-02-28 | Dashboard Mode Switcher : enum `DashboardMode` (`PARTICIPANT`/`ORGANIZER`) persisté en DB + session Auth.js. |
+| 2026-03-03 | Broadcast cooldown 24h (remplace le verrou permanent "envoi unique"). `broadcastSentAt` écrasé à chaque envoi. |
+| 2026-03-14 | Statut DRAFT : tout événement créé est en Brouillon. DRAFT → PUBLISHED via `publishMoment` (sens unique). Notifications déplacées à la publication. |
+
+---
+
+## Références
+
+### Specs par domaine
+
+| Domaine | Fichier |
+|---------|---------|
+| Produit — Vision | `spec/product/vision-produit.md` |
+| Produit — Cadrage | `spec/product/cadrage.md` |
+| Produit — UX / JTBD | `spec/product/ux-parcours-jtbd.md` |
+| Produit — Page Aide | `spec/product/help-page-content.md` |
+| Produit — Onboarding | `spec/product/options-onboarding.md` |
+| Produit — White-label | `spec/product/white-label-mono-community.md` |
+| Feature — Explorer | `spec/features/explorer-la-carte.md` |
+| Feature — Explorer rating | `spec/features/explorer-rating.md` |
+| Feature — Stripe Connect | `spec/features/stripe-connect.md` |
+| Feature — Approbation inscriptions | `spec/features/approval-registration.md` |
+| Feature — Réseaux Communautés | `spec/features/circle-network.md` |
+| Feature — Pièces jointes | `spec/features/moment-attachments.md` |
+| Feature — Profils publics | `spec/features/virality-public-profiles.md` |
+| Feature — Admin plateforme | `spec/features/admin-plateforme.md` |
+| Feature — Emails transactionnels | `spec/features/email-transactional.md` |
+| Feature — Blog SEO | `spec/features/blog-seo.md` |
+| Feature — Email onboarding | `spec/features/email-onboarding.md` |
+| Feature — Invitation bulk | `spec/features/bulk-invite.md` |
+| Feature — Co-Organisateurs | `spec/features/co-organisateurs.md` |
+| Feature — Radar | `spec/features/local-events-watcher.md` |
+| Feature — Suppression token invitation | `spec/features/remove-invite-token.md` |
+| Infra — Migration DB | `spec/infra/db-migration-rollback-strategy.md` |
+| Infra — Stratégie SEO | `spec/infra/seo-strategy.md` |
+| Infra — Workflow Git | `spec/infra/git-workflow.md` |
+| Recherche — Concurrence | `spec/research/analyse-concurrence.md` |
+| Recherche — Benchmark Luma | `spec/research/luma-benchmark.md` |
+| Recherche — MCP | `spec/research/mcp.md` |
+| Sécurité — Audit | `spec/docs/security/AUDIT-2026-04-01.md` |
+| Design — System | `spec/design/design-system.md` |
+| Design — Audit mobile | `spec/design/AUDIT-MOBILE.md` |
+| Design — Inventaire composants | `spec/design/ui-components-inventory.md` |
+| Marketing — Backlog | `spec/mkt/BACKLOG.md` |


### PR DESCRIPTION
## Summary
- Revue exhaustive du backlog cross-référencée avec le changelog, la page Aide, les PRs et les 32 specs existantes
- Restructuration par domaine fonctionnel (16 domaines) avec version et lien spec pour chaque feature livrée
- Correction des features marquées "à faire" alors qu'elles sont livrées (rappels 24h, Stripe Connect, approbation inscriptions, etc.)
- Nettoyage : items "À faire" réduits de ~50 à 21 (8 produit + 13 infra), décisions intermédiaires supersédées retirées
- Section Références ajoutée (index des 32 fichiers spec)

## Test plan
- [ ] Vérifier que les liens relatifs vers les specs sont corrects
- [ ] Pas de code modifié — doc only, build ignoré par Vercel (`ignoreCommand`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)