### PR TITLE
feat(landing): dual CTA hero + Explorer visible sans connexion

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -11,6 +11,7 @@
     "metaDescription": "The free platform to build your community and host events. A free alternative to Meetup and Luma, with no fees or subscriptions.",
     "heroSubtitle": "The free platform to build your community and host unforgettable events.",
     "cta": "Launch your community",
+    "ctaDiscover": "Explore communities",
     "mockupCircleName": "Product & AI",
     "mockupAboutText": "The community for Product enthusiasts in the age of AI.",
     "mockupCreatedDate": "Feb 21, 2026",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -11,6 +11,7 @@
     "metaDescription": "La plateforme gratuite pour créer votre communauté et organiser des événements. Alternative à Meetup et Luma, sans commission ni abonnement.",
     "heroSubtitle": "La plateforme gratuite pour créer votre communauté et organiser des événements mémorables.",
     "cta": "Lancez votre communauté",
+    "ctaDiscover": "Découvrir les communautés",
     "mockupCircleName": "Product & AI",
     "mockupAboutText": "La communauté des passionnés du Produit, à l'heure de l'IA.",
     "mockupCreatedDate": "21 février 2026",

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -110,9 +110,14 @@ export default async function HomePage() {
               <p className="text-muted-foreground mt-6 max-w-md text-lg font-light lg:max-w-none">
                 {t("heroSubtitle")}
               </p>
-              <Button asChild size="lg" className="mt-10 bg-gradient-to-r from-pink-500 via-fuchsia-500 to-violet-500 px-8 py-6 text-base text-white hover:opacity-90">
-                <Link href={session?.user ? "/dashboard/circles/new" : "/auth/sign-in"}>{t("cta")}</Link>
-              </Button>
+              <div className="mt-10 flex flex-col items-center gap-3 sm:flex-row sm:gap-4 lg:justify-start">
+                <Button asChild size="lg" className="bg-gradient-to-r from-pink-500 via-fuchsia-500 to-violet-500 px-8 py-6 text-base text-white hover:opacity-90">
+                  <Link href="/explorer">{t("ctaDiscover")}</Link>
+                </Button>
+                <Button asChild variant="outline" size="lg" className="hidden px-8 py-6 text-base sm:inline-flex">
+                  <Link href={session?.user ? "/dashboard/circles/new" : "/auth/sign-in"}>{t("cta")}</Link>
+                </Button>
+              </div>
             </div>
 
             {/* RIGHT — iPhone mockup illustration (desktop only) */}

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -46,23 +46,21 @@ export function SiteHeader() {
 
         {/* Nav — center (desktop only) */}
         <nav className="hidden flex-1 items-center justify-center gap-6 md:flex">
+          <Link
+            href="/explorer"
+            className={`flex items-center gap-1.5 text-sm font-medium transition-colors ${pathname.startsWith("/explorer") ? "text-foreground" : "text-muted-foreground hover:text-foreground"}`}
+          >
+            <Compass className="size-3.5" />
+            {tExplorer("navLink")}
+          </Link>
           {user && (
-            <>
-              <Link
-                href="/explorer"
-                className={`flex items-center gap-1.5 text-sm font-medium transition-colors ${pathname.startsWith("/explorer") ? "text-foreground" : "text-muted-foreground hover:text-foreground"}`}
-              >
-                <Compass className="size-3.5" />
-                {tExplorer("navLink")}
-              </Link>
-              <Link
-                href={dashboardHref}
-                className={`flex items-center gap-1.5 text-sm font-medium transition-colors ${pathname.startsWith("/dashboard") ? "text-foreground" : "text-muted-foreground hover:text-foreground"}`}
-              >
-                <LayoutDashboard className="size-3.5" />
-                {tDashboard("title")}
-              </Link>
-            </>
+            <Link
+              href={dashboardHref}
+              className={`flex items-center gap-1.5 text-sm font-medium transition-colors ${pathname.startsWith("/dashboard") ? "text-foreground" : "text-muted-foreground hover:text-foreground"}`}
+            >
+              <LayoutDashboard className="size-3.5" />
+              {tDashboard("title")}
+            </Link>
           )}
         </nav>
 


### PR DESCRIPTION
## Summary
- **Header** : le lien "Découvrir" est visible pour tous les visiteurs, même non connectés (Dashboard reste masqué)
- **Hero** : CTA principal gradient "Découvrir les communautés" → `/explorer` (sans auth) + CTA secondaire outline "Lancez votre communauté" → sign-in
- **Mobile** : seul le CTA principal est affiché (outline masqué sous `sm`)
- **i18n** : ajout clé `ctaDiscover` (FR + EN)

## Motivation
La majorité des visiteurs de la landing sont des participants potentiels, pas des organisateurs. Le CTA principal doit les emmener vers l'Explorer (accessible sans compte) plutôt que forcer un sign-in immédiat.

## Test plan
- [ ] Ouvrir la landing en navigation privée (non connecté) — vérifier les 2 CTAs sur desktop
- [ ] Vérifier que seul "Découvrir les communautés" s'affiche en mobile
- [ ] Vérifier que "Découvrir" apparaît dans le header même non connecté
- [ ] Vérifier que le lien Explorer fonctionne (→ /explorer)
- [ ] Vérifier que "Lancez votre communauté" redirige vers sign-in
- [ ] Vérifier le comportement connecté (Dashboard visible dans header, CTAs adaptés)

🤖 Generated with [Claude Code](https://claude.com/claude-code)