### PR TITLE
fix(analytics): move user_signed_up tracking from server to client

### DIFF
--- a/src/components/providers/posthog-identity.tsx
+++ b/src/components/providers/posthog-identity.tsx
@@ -1,11 +1,14 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useSession } from "next-auth/react";
 import posthog from "posthog-js";
 
+const SIGNUP_TRACKED_PREFIX = "ph_signup_tracked_";
+
 export function PostHogIdentity() {
   const { data: session } = useSession();
+  const trackedRef = useRef(false);
 
   useEffect(() => {
     if (session?.user?.id) {
@@ -13,10 +16,20 @@ export function PostHogIdentity() {
         email: session.user.email ?? undefined,
         name: session.user.name ?? undefined,
       });
+
+      // Tracking nouvel utilisateur — côté client pour fiabilité en serverless
+      if (session.user.isNewUser && !trackedRef.current) {
+        const storageKey = `${SIGNUP_TRACKED_PREFIX}${session.user.id}`;
+        if (!localStorage.getItem(storageKey)) {
+          posthog.capture("user_signed_up");
+          localStorage.setItem(storageKey, "1");
+        }
+        trackedRef.current = true;
+      }
     } else {
       posthog.reset();
     }
-  }, [session?.user?.id]);
+  }, [session?.user?.id, session?.user?.isNewUser]);
 
   return null;
 }

--- a/src/infrastructure/auth/auth.config.ts
+++ b/src/infrastructure/auth/auth.config.ts
@@ -8,7 +8,6 @@ import { prisma } from "@/infrastructure/db/prisma";
 import { Resend } from "resend";
 import { MagicLinkEmail } from "@/infrastructure/services/email/templates/magic-link";
 import { isUploadedUrl } from "@/lib/blob";
-import { captureServerEvent } from "@/lib/posthog-server";
 import { prismaUserRepository } from "@/infrastructure/repositories/prisma-user-repository";
 
 export const { handlers, auth, signIn, signOut } = NextAuth({
@@ -83,26 +82,6 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         console.error("[AUTH] OAuth image sync failed (non-blocking):", err);
       }
 
-      // Tracking nouvel utilisateur — createdAt dans les 30 dernières secondes
-      try {
-        if (user.id) {
-          const dbUser = await prisma.user.findUnique({
-            where: { id: user.id },
-            select: { createdAt: true },
-          });
-          if (dbUser) {
-            const ageMs = Date.now() - dbUser.createdAt.getTime();
-            if (ageMs < 30_000) {
-              await captureServerEvent(user.id, "user_signed_up", {
-                provider: profile ? "oauth" : "email",
-              });
-            }
-          }
-        }
-      } catch (err) {
-        console.error("[AUTH] PostHog user_signed_up tracking failed (non-blocking):", err);
-      }
-
       // Génération du publicId si absent — non bloquant
       try {
         if (user.id) {
@@ -131,10 +110,14 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         onboardingCompleted: boolean;
         role: "USER" | "ADMIN";
         dashboardMode: "PARTICIPANT" | "ORGANIZER" | null;
+        createdAt: Date;
       };
       session.user.onboardingCompleted = dbUser.onboardingCompleted;
       session.user.role = dbUser.role;
       session.user.dashboardMode = dbUser.dashboardMode ?? null;
+      // Nouveau user = compte créé il y a moins de 2 minutes
+      const ageMs = Date.now() - new Date(dbUser.createdAt).getTime();
+      session.user.isNewUser = ageMs < 120_000;
       return session;
     },
   },

--- a/src/infrastructure/auth/auth.d.ts
+++ b/src/infrastructure/auth/auth.d.ts
@@ -10,6 +10,7 @@ declare module "next-auth" {
       onboardingCompleted: boolean;
       role: "USER" | "ADMIN";
       dashboardMode: "PARTICIPANT" | "ORGANIZER" | null;
+      isNewUser?: boolean;
     };
   }
 }


### PR DESCRIPTION
## Summary
- Le tracking `user_signed_up` via `captureServerEvent` (fetch serveur) échouait silencieusement en serverless Vercel — seulement **1 événement capturé sur 79+ utilisateurs réels**
- Déplacé le tracking côté client dans `PostHogIdentity` avec double garde (useRef + localStorage) pour garantir exactement un tir par utilisateur
- `isNewUser` est calculé dans le callback `session` Auth.js (basé sur `createdAt < 2 min`) et exposé dans la session

## Test plan
- [ ] Créer un nouveau compte (magic link ou OAuth) → vérifier que `user_signed_up` apparaît dans PostHog
- [ ] Se reconnecter avec un compte existant → vérifier qu'aucun événement n'est émis
- [ ] Rafraîchir la page après inscription → vérifier que l'événement n'est pas dupliqué (garde localStorage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)