### PR TITLE
feat(email): différer l'envoi de l'email d'onboarding via cron J+1

### DIFF
--- a/scripts/send-onboarding-welcome-backfill.ts
+++ b/scripts/send-onboarding-welcome-backfill.ts
@@ -1,10 +1,10 @@
 /**
  * Backfill one-shot : envoyer la lettre du fondateur aux utilisateurs existants.
  *
- * Contexte : l'email applicatif `onboarding-welcome` ne part que pour les
- * nouveaux utilisateurs via `after()` dans `completeOnboardingAction`. Pour
- * les utilisateurs déjà inscrits après la campagne Brevo du 12/03/2026 (lettre
- * ambassadeur), on envoie la lettre via ce script one-shot.
+ * Contexte : l'email applicatif `onboarding-welcome` est envoyé en différé
+ * (J+1) par le cron /api/cron/send-onboarding-welcome. Pour les utilisateurs
+ * déjà inscrits après la campagne Brevo du 12/03/2026 (lettre ambassadeur),
+ * on envoie la lettre via ce script one-shot.
  *
  * Cutoff : utilisateurs inscrits après le 12/03/2026 (avant cette date, ils
  * ont déjà reçu la lettre ambassadeur via Brevo — pas de doublon).

--- a/src/app/actions/profile.ts
+++ b/src/app/actions/profile.ts
@@ -101,24 +101,9 @@ export async function completeOnboardingAction(
       }
     });
 
-    // Fire-and-forget : lettre du fondateur. Le flag `welcomeEmailSentAt` est
-    // posé AVANT l'envoi — en cas d'échec Resend, on ne re-tente pas : mieux
-    // un email perdu qu'un doublon. Admins exclus (ils voient déjà tout).
-    const shouldSendWelcome =
-      result.data.welcomeEmailSentAt === null && result.data.role !== "ADMIN";
-    if (shouldSendWelcome) {
-      after(async () => {
-        try {
-          await prismaUserRepository.setWelcomeEmailSent(result.data.id);
-          await emailService.sendOnboardingWelcome({
-            to: result.data.email,
-            firstName: result.data.firstName,
-          });
-        } catch (e) {
-          Sentry.captureException(e, { tags: { context: "onboarding_welcome_email" } });
-        }
-      });
-    }
+    // Lettre du fondateur : envoyée en différé (J+1) par le cron
+    // /api/cron/send-onboarding-welcome. Le cron cherche les utilisateurs
+    // avec onboardingCompleted=true et welcomeEmailSentAt=null.
   }
 
   return result;

--- a/src/app/api/cron/send-onboarding-welcome/route.ts
+++ b/src/app/api/cron/send-onboarding-welcome/route.ts
@@ -14,14 +14,14 @@ import { prismaUserRepository } from "@/infrastructure/repositories";
  * - onboardingCompleted = true
  * - welcomeEmailSentAt = null (pas encore envoyé)
  * - role != ADMIN
- * - createdAt <= now - 24h (J+1)
+ * - createdAt <= now - 3h (délai minimum avant envoi)
  * - Exclut les emails @test.playground et @demo.playground
  *
  * Déclenché chaque jour à 6h UTC (≈ 8h Paris été / 7h Paris hiver)
  * via Vercel Cron (vercel.json).
  */
 
-const DELAY_HOURS = 24;
+const DELAY_HOURS = 3;
 
 const emailService = createResendEmailService();
 

--- a/src/app/api/cron/send-onboarding-welcome/route.ts
+++ b/src/app/api/cron/send-onboarding-welcome/route.ts
@@ -1,0 +1,106 @@
+import * as Sentry from "@sentry/nextjs";
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/infrastructure/db/prisma";
+import { createResendEmailService } from "@/infrastructure/services";
+import { prismaUserRepository } from "@/infrastructure/repositories";
+
+/**
+ * GET /api/cron/send-onboarding-welcome
+ *
+ * Envoie la lettre du fondateur (email d'onboarding) aux utilisateurs
+ * ayant complété leur profil depuis plus de 24h.
+ *
+ * Critères d'éligibilité :
+ * - onboardingCompleted = true
+ * - welcomeEmailSentAt = null (pas encore envoyé)
+ * - role != ADMIN
+ * - createdAt <= now - 24h (J+1)
+ * - Exclut les emails @test.playground et @demo.playground
+ *
+ * Déclenché chaque jour à 6h UTC (≈ 8h Paris été / 7h Paris hiver)
+ * via Vercel Cron (vercel.json).
+ */
+
+const DELAY_HOURS = 24;
+
+const emailService = createResendEmailService();
+
+async function handler(request: NextRequest) {
+  const authHeader = request.headers.get("authorization");
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    Sentry.captureMessage(
+      "[cron] send-onboarding-welcome: unauthorized request",
+      "warning",
+    );
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const startedAt = Date.now();
+  const cutoff = new Date(Date.now() - DELAY_HOURS * 60 * 60 * 1000);
+
+  try {
+    const users = await prisma.user.findMany({
+      where: {
+        onboardingCompleted: true,
+        welcomeEmailSentAt: null,
+        role: { not: "ADMIN" },
+        createdAt: { lte: cutoff },
+        AND: [
+          { email: { not: { endsWith: "@test.playground" } } },
+          { email: { not: { endsWith: "@demo.playground" } } },
+        ],
+      },
+      select: {
+        id: true,
+        email: true,
+        firstName: true,
+      },
+    });
+
+    let sent = 0;
+    let failed = 0;
+
+    for (const user of users) {
+      try {
+        await prismaUserRepository.setWelcomeEmailSent(user.id);
+        await emailService.sendOnboardingWelcome({
+          to: user.email,
+          firstName: user.firstName,
+        });
+        sent++;
+      } catch (e) {
+        failed++;
+        Sentry.captureException(e, {
+          tags: { cron: "send-onboarding-welcome" },
+          extra: { userId: user.id, email: user.email },
+        });
+      }
+    }
+
+    const durationMs = Date.now() - startedAt;
+    console.log(
+      `[send-onboarding-welcome] ${users.length} éligible(s), ${sent} envoyé(s), ${failed} échoué(s) en ${durationMs}ms`,
+    );
+
+    return NextResponse.json({
+      success: true,
+      eligible: users.length,
+      sent,
+      failed,
+      durationMs,
+    });
+  } catch (error) {
+    const durationMs = Date.now() - startedAt;
+    console.error(`[send-onboarding-welcome] Erreur après ${durationMs}ms :`, error);
+    Sentry.captureException(error, {
+      tags: { cron: "send-onboarding-welcome" },
+      extra: { durationMs },
+    });
+    return NextResponse.json(
+      { error: "Onboarding welcome sending failed" },
+      { status: 500 },
+    );
+  }
+}
+
+export { handler as GET, handler as POST };

--- a/vercel.json
+++ b/vercel.json
@@ -16,6 +16,10 @@
     {
       "path": "/api/cron/posthog-weekly-report",
       "schedule": "7 8 * * 1"
+    },
+    {
+      "path": "/api/cron/send-onboarding-welcome",
+      "schedule": "0 6 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Retire l'envoi immédiat de la lettre du fondateur dans `completeOnboardingAction` (trop d'emails au moment de l'inscription)
- Ajoute un cron quotidien `/api/cron/send-onboarding-welcome` (6h UTC ~ 8h Paris) qui envoie l'email aux utilisateurs éligibles :
  - `onboardingCompleted = true`
  - `welcomeEmailSentAt = null`
  - `createdAt <= now - 3h` (délai minimum)
  - Exclut admins, comptes test et démo
- Met à jour la doc du script de backfill

## Test plan

- [ ] Vérifier qu'un nouvel utilisateur ne reçoit plus l'email immédiatement après l'onboarding
- [ ] Tester le cron manuellement : `curl -H "Authorization: Bearer $CRON_SECRET" http://localhost:3000/api/cron/send-onboarding-welcome`
- [ ] Vérifier que les utilisateurs existants (avec `welcomeEmailSentAt` déjà posé) ne sont pas renvoyés
- [ ] TypeScript typecheck passe

🤖 Generated with [Claude Code](https://claude.com/claude-code)