### PR TITLE
chore(blog): remplacer les tirets cadratins par des virgules et points

### DIFF
--- a/src/content/blog/en/alternative-meetup-gratuite.md
+++ b/src/content/blog/en/alternative-meetup-gratuite.md
@@ -9,17 +9,17 @@ keywords:
   - meetup alternative 2026
 ---
 
-Meetup was the go-to platform for community events for nearly two decades. But since its acquisition by Bending Spoons in 2024, the platform has changed direction — and many organisers are looking for alternatives. If that's you, here's a comprehensive look at the best free options in 2026.
+Meetup was the go-to platform for community events for nearly two decades. But since its acquisition by Bending Spoons in 2024, the platform has changed direction, and many organisers are looking for alternatives. If that's you, here's a comprehensive look at the best free options in 2026.
 
 ## Why organisers are leaving Meetup
 
 In January 2024, Bending Spoons acquired Meetup and applied its usual playbook: massive staff cuts and aggressive monetisation. The result is an unprecedented **double paywall**.
 
-**Organisers** pay a subscription to keep their group active. **Members** also pay — around $2 per RSVP, or a Meetup+ subscription at ~$5/month for unlimited RSVPs. Both sides of the table pay.
+**Organisers** pay a subscription to keep their group active. **Members** also pay, around $2 per RSVP, or a Meetup+ subscription at ~$5/month for unlimited RSVPs. Both sides of the table pay.
 
 Meanwhile, the public API has been heavily restricted, making integration with other tools difficult. And the interface, though revamped, still falls short of current standards.
 
-Meetup's community model remains sound — it's the pricing and experience that have become the problem.
+Meetup's community model remains sound. It's the pricing and experience that have become the problem.
 
 ## What to look for in an alternative
 
@@ -34,19 +34,19 @@ Before choosing, ask yourself the right questions:
 
 ## The alternatives
 
-### The Playground — community first, built in Europe
+### The Playground, community first, built in Europe
 
-The Playground takes Meetup's community model — a persistent community, members who stay from one event to the next — and pairs it with a modern experience and total free pricing.
+The Playground takes Meetup's community model, a persistent community where members stay from one event to the next, and pairs it with a modern experience and total free pricing.
 
 **The principle**: when someone registers for your event, they automatically join your community. After the event, they see the next meetups, the other members, your group's identity. The connection doesn't break.
 
-**Pricing**: 0% commission, no subscription. Only standard Stripe fees (~2.9% + €0.30) apply on paid events — the full amount goes to the organiser.
+**Pricing**: 0% commission, no subscription. Only standard Stripe fees (~2.9% + €0.30) apply on paid events. The full amount goes to the organiser.
 
-**The European angle** — and this matters more than you might think:
+**The European angle.** This matters more than you might think:
 
 - **Designed in France**, with a native bilingual FR/EN interface
 - **Infrastructure hosted in Europe**: application on Vercel EU region, database on Neon EU region
-- **Data stored in the European Union** — no transatlantic transfer by default
+- **Data stored in the European Union.** No transatlantic transfer by default
 - **Data protection built in from the ground up**, not bolted on as a GDPR afterthought
 - **Support in French and English**
 
@@ -54,35 +54,35 @@ For organisers based in Europe, this is a concrete advantage: your data and your
 
 **The limitations**: smaller user base than Meetup (distribution relies on the organiser), email-only notifications for now (no SMS/WhatsApp), young platform with fewer advanced features than established players.
 
-### Luma — the event page benchmark
+### Luma, the event page benchmark
 
 Luma set a new standard for the event page. Polished design, registration in seconds (email only, no account), automatic calendar integration. It has become the go-to tool for tech events and conferences.
 
 **Pricing**: free for organisers. 5% commission on paid events (on top of Stripe fees). To remove that commission: Luma Plus at $59/month.
 
-Luma has evolved with **Calendars** (a public page listing your events) and **Calendar Memberships** (membership tiers). It's a step towards persistence, but the Calendar shows your events without displaying your members — the sense of belonging to a group is missing.
+Luma has evolved with **Calendars** (a public page listing your events) and **Calendar Memberships** (membership tiers). It's a step towards persistence, but the Calendar shows your events without displaying your members. The sense of belonging to a group is missing.
 
 **The limitations**: no real community page with visible members, commission that adds up on recurring paid events, US-based infrastructure.
 
-### Eventbrite — ticketing for large events
+### Eventbrite, ticketing for large events
 
 Eventbrite is a ticketing platform, not a community platform. The distinction matters.
 
-**Pricing**: free for free events. For paid events, Eventbrite charges fees that vary by region — in Europe, expect roughly 3.7% + €0.79 per ticket (the exact model has changed several times in recent years).
+**Pricing**: free for free events. For paid events, Eventbrite charges fees that vary by region. In Europe, expect roughly 3.7% + €0.79 per ticket (the exact model has changed several times in recent years).
 
 Eventbrite excels at **large-scale one-off events**: conferences, expos, launch parties. The ticketing is robust, the check-in system is mature, and the platform offers good visibility for big public events.
 
-**The limitations**: no community model whatsoever — each event is an isolated transaction. No group page, no persistent members. If you're looking to build a lasting community, Eventbrite isn't designed for that.
+**The limitations**: no community model whatsoever. Each event is an isolated transaction. No group page, no persistent members. If you're looking to build a lasting community, Eventbrite isn't designed for that.
 
-### Discord / Slack — conversation, not events
+### Discord / Slack, conversation, not events
 
-Discord and Slack are excellent community communication tools. Many organisers use them as a complement — and that's exactly the right use.
+Discord and Slack are excellent community communication tools. Many organisers use them as a complement, and that's exactly the right use.
 
 **Pricing**: free (with paid plans for advanced features).
 
 These platforms offer what event tools don't: **ongoing conversation** between events. Discussions, resource sharing, mutual support.
 
-**The limitations**: they are not event platforms. No shareable event page, no registration system, no calendar integration, no capacity management or waitlist. If you announce your events only on Discord or Slack, you lose conversion — a message in a channel doesn't have the same impact as a dedicated event page with a registration button.
+**The limitations**: they are not event platforms. No shareable event page, no registration system, no calendar integration, no capacity management or waitlist. If you announce your events only on Discord or Slack, you lose conversion. A message in a channel doesn't have the same impact as a dedicated event page with a registration button.
 
 **The right use**: Discord/Slack as a complement to an event platform, not a replacement.
 
@@ -103,12 +103,12 @@ These platforms offer what event tools don't: **ongoing conversation** between e
 
 The choice depends on what you're building:
 
-> **You're building a lasting local community** — you want your attendees to come back from one event to the next, with no commission, and your data in Europe → **The Playground**
+> **You're building a lasting local community.** You want your attendees to come back from one event to the next, with no commission, and your data in Europe → **The Playground**
 
-> **You organise one-off premium events** — event page quality is decisive, you need SMS/WhatsApp, community isn't your priority → **Luma**
+> **You organise one-off premium events.** Event page quality is decisive, you need SMS/WhatsApp, community isn't your priority → **Luma**
 
-> **You're hosting a large public event with ticketing** — conference, expo, 200+ attendees, you need a robust ticketing system → **Eventbrite**
+> **You're hosting a large public event with ticketing.** Conference, expo, 200+ attendees, you need a robust ticketing system → **Eventbrite**
 
-> **You already have an active community on Discord/Slack** — keep it for conversation, but use a dedicated platform for your events
+> **You already have an active community on Discord/Slack.** Keep it for conversation, but use a dedicated platform for your events
 
-The fundamental question isn't "which platform has the most features" — it's "do your attendees come back after the first event?". If the answer is no, maybe it's the tool that needs changing.
+The fundamental question isn't "which platform has the most features". It's "do your attendees come back after the first event?". If the answer is no, maybe it's the tool that needs changing.

--- a/src/content/blog/en/creer-communaute-en-ligne.md
+++ b/src/content/blog/en/creer-communaute-en-ligne.md
@@ -9,13 +9,13 @@ keywords:
   - grow community
 ---
 
-You've probably done it before: created a WhatsApp group, a Discord server or a Slack channel to "keep in touch" after an event. Three months later, the group is silent. People didn't leave — they just stopped looking.
+You've probably done it before: created a WhatsApp group, a Discord server or a Slack channel to "keep in touch" after an event. Three months later, the group is silent. People didn't leave. They just stopped looking.
 
 That's not a platform problem. It's a method problem. Creating a space doesn't create a community. Here are five practical steps to build something that actually lasts.
 
 ## 1. Start with a clear identity
 
-The most common mistake is launching a group without knowing who it's for. "A group for people who like tech" isn't an identity — it's a category. "Freelance developers in Manchester who want to break out of isolation" is one.
+The most common mistake is launching a group without knowing who it's for. "A group for people who like tech" isn't an identity, it's a category. "Freelance developers in Manchester who want to break out of isolation" is one.
 
 A community needs three things from day one:
 
@@ -23,15 +23,15 @@ A community needs three things from day one:
 - **A promise**: what do members get out of it? Networking, learning, support, inspiration?
 - **A name and description** that say both in one sentence.
 
-This sounds basic. But most communities that die within two months never clearly articulated their identity. Features don't compensate for vague positioning. A Slack workspace with 200 people who don't know why they're there is noise — not a community.
+This sounds basic. But most communities that die within two months never clearly articulated their identity. Features don't compensate for vague positioning. A Slack workspace with 200 people who don't know why they're there is noise, not a community.
 
 ## 2. Make the first event happen fast
 
 Don't look for the perfect venue, the ideal number of attendees or the definitive theme. Organise a first gathering. Quickly.
 
-Ten people in a pub, an informal drinks, a one-hour video call — the format doesn't matter. The first event has one single objective: **prove the concept works**. Do people show up? Do they leave happy? Do they tell others about it?
+Ten people in a pub, an informal drinks, a one-hour video call. The format doesn't matter. The first event has one single objective: **prove the concept works**. Do people show up? Do they leave happy? Do they tell others about it?
 
-The temptation is to plan for weeks. To polish the registration page, find a speaker, design a visual. All of that can come later. The number one risk for a nascent community isn't being imperfect — it's never starting.
+The temptation is to plan for weeks. To polish the registration page, find a speaker, design a visual. All of that can come later. The number one risk for a nascent community isn't being imperfect. It's never starting.
 
 > A failed first event teaches you more than a month of planning.
 
@@ -49,24 +49,24 @@ In practice, you need a space where attendees stay connected between events. Sev
 - **A Discord server**: more structured, but the barrier to entry is real. Not everyone has Discord, and not everyone wants to install it for a meetup.
 - **A dedicated community platform**: this is the approach taken by The Playground, for instance. When someone registers for your event, they automatically join your community. The community page shows upcoming events, past events and members. The link doesn't break between events, without you having to manage a chat group.
 
-The tool matters less than the principle: **there must be a continuous thread between events**. If your attendees have to re-register each time as though they've never met you, you're not building a community — you're starting from scratch every time.
+The tool matters less than the principle: **there must be a continuous thread between events**. If your attendees have to re-register each time as though they've never met you, you're not building a community. You're starting from scratch every time.
 
 ## 4. Create a rhythm
 
 A community without regularity is a group of friends who say "we should meet up again" and never do.
 
-Rhythm is the strongest signal you send to your members. Monthly, fortnightly, weekly — the frequency matters less than the consistency. What counts is that members can anticipate. "First Thursday of the month" becomes a mental anchor. "Now and then, when I have time" creates no habit at all.
+Rhythm is the strongest signal you send to your members. Monthly, fortnightly, weekly. The frequency matters less than the consistency. What counts is that members can anticipate. "First Thursday of the month" becomes a mental anchor. "Now and then, when I have time" creates no habit at all.
 
 Two practices that change everything:
 
 - **Announce the next event before the current one ends.** When people are still in the energy of the moment, give them the next date. "The next meetup is on 14 March" is more powerful than any follow-up email sent two weeks later.
-- **Maintain the rhythm even when it's hard.** One month without an event is fine. Two months, people start to forget. Three months, you're essentially relaunching the community from scratch. If you don't have time for a full event, do a lighter format — an informal coffee, a discussion thread, a quick call. The important thing is not to disappear.
+- **Maintain the rhythm even when it's hard.** One month without an event is fine. Two months, people start to forget. Three months, you're essentially relaunching the community from scratch. If you don't have time for a full event, do a lighter format. An informal coffee, a discussion thread, a quick call. The important thing is not to disappear.
 
 > Regularity builds trust. Trust builds engagement. Engagement builds community.
 
 ## 5. Let members shape the community
 
-If you're the only person proposing topics, organising events and driving discussions, you don't have a community — you have a one-person show. And the day you're tired, everything stops.
+If you're the only person proposing topics, organising events and driving discussions, you don't have a community. You have a one-person show. And the day you're tired, everything stops.
 
 The strongest communities are those where members take initiative:
 
@@ -74,7 +74,7 @@ The strongest communities are those where members take initiative:
 - **Co-organise**: identify the most engaged members and offer them the chance to co-host an event. It involves them and takes weight off your shoulders.
 - **Bring people**: word of mouth is your best growth channel. If your members invite their contacts, it means the community is creating value.
 
-Your role naturally evolves: you shift from organiser to facilitator. You're no longer carrying everything — you're creating the framework within which things happen.
+Your role naturally evolves: you shift from organiser to facilitator. You're no longer carrying everything. You're creating the framework within which things happen.
 
 This is also a sign of maturity. A community that depends on one person is fragile. A community where several people contribute is resilient.
 
@@ -90,4 +90,4 @@ Building an online community that lasts isn't a question of tools or budget. It'
 4. **Rhythm**: be consistent, not perfect.
 5. **Participation**: let members contribute.
 
-None of these steps require a particular tool. But the right tools make the right habits easier. Choose the one that fits your approach — and focus on what truly matters: the people who come back.
+None of these steps require a particular tool. But the right tools make the right habits easier. Choose the one that fits your approach, and focus on what truly matters: the people who come back.

--- a/src/content/blog/en/evenements-ne-suffisent-pas.md
+++ b/src/content/blog/en/evenements-ne-suffisent-pas.md
@@ -1,5 +1,5 @@
 ---
-title: "Why events alone aren't enough — the community model"
+title: "Why events alone aren't enough, the community model"
 description: "You host events but your attendees don't come back? The problem isn't the event, it's the lack of community."
 date: "2026-03-18"
 keywords:
@@ -19,7 +19,7 @@ Most event tools operate on a simple model: create an event, share it, people re
 
 This model is not inherently flawed. For an annual conference, a one-off workshop, or a product launch, it works perfectly well. The event is the destination. Nobody expects recurrence.
 
-But if you run events regularly — meetups, monthly workshops, networking evenings, practice sessions — this model condemns you to starting from scratch every time. Your audience has no structural reason to return. They need to stumble upon your next announcement at the right moment, on the right channel, with the right availability. That is chance, not retention.
+But if you run events regularly (meetups, monthly workshops, networking evenings, practice sessions), this model condemns you to starting from scratch every time. Your audience has no structural reason to return. They need to stumble upon your next announcement at the right moment, on the right channel, with the right availability. That is chance, not retention.
 
 Think about it: when an attendee leaves your event, what link remains between you and them? A confirmation email buried in their inbox. Perhaps a LinkedIn post they liked. The relationship ends there. You cannot rely on goodwill to replace a retention mechanism.
 
@@ -27,7 +27,7 @@ Think about it: when an attendee leaves your event, what link remains between yo
 
 Consider the most popular platforms. Luma offers an elegant registration experience and polished event pages. Eventbrite handles ticketing at scale. Google Forms is free and frictionless. But they all share the same limitation: the event is terminal.
 
-On Luma, once your event has passed, the page becomes an archive. The attendee has no reason to return to it. There is no page that gathers your upcoming events, your past attendees, your group's identity. Luma has introduced a personal calendar feature — a step in the right direction — but following a calendar is not the same as belonging to a group.
+On Luma, once your event has passed, the page becomes an archive. The attendee has no reason to return to it. There is no page that gathers your upcoming events, your past attendees, your group's identity. Luma has introduced a personal calendar feature, a step in the right direction, but following a calendar is not the same as belonging to a group.
 
 Eventbrite lets people follow an organiser, but the relationship stays transactional. You receive an email when they publish a new event. That is a notification, not a sense of belonging.
 
@@ -35,7 +35,7 @@ The issue is not the quality of these tools. It is their mental architecture. Wh
 
 ## What a community actually changes
 
-Meetup understood something that event-centric platforms have not internalised: the persistence of the group. When you join a Meetup group, you are not registering for an event — you are joining a community. You see the other members. You see the upcoming events. You receive notifications because you belong to the group, not because you clicked a link at the right moment.
+Meetup understood something that event-centric platforms have not internalised: the persistence of the group. When you join a Meetup group, you are not registering for an event. You are joining a community. You see the other members. You see the upcoming events. You receive notifications because you belong to the group, not because you clicked a link at the right moment.
 
 This mechanism transforms the retention dynamic:
 
@@ -61,12 +61,12 @@ Let us compare the two flows from the attendee's perspective.
 
 **Community-centric model:**
 1. A friend shares a link to an event
-2. Quick registration — and automatic membership in the community
+2. Quick registration, and automatic membership in the community
 3. Attend the event
 4. The event ends
 5. The attendee sees the community page: upcoming events, members, history
 6. They receive a notification for the next event because they are a member
-7. They return — and bring a friend
+7. They return, and bring a friend
 
 The difference does not play out during the event. It plays out in the space between events. The event-centric model leaves a void. The community model fills it.
 

--- a/src/content/blog/en/meetup-vs-luma-vs-the-playground.md
+++ b/src/content/blog/en/meetup-vs-luma-vs-the-playground.md
@@ -1,5 +1,5 @@
 ---
-title: "Meetup vs Luma vs The Playground — 2026 comparison"
+title: "Meetup vs Luma vs The Playground, 2026 comparison"
 description: "Detailed comparison of community platforms: features, pricing, model. Which platform should you choose to host events and build your community?"
 date: "2026-03-24"
 keywords:
@@ -10,7 +10,7 @@ keywords:
   - free event platform
 ---
 
-You're organising meetups, workshops or community events and looking for the right platform? This comparison analyses three popular options — Meetup, Luma and The Playground — breaking down their models, pricing and limitations.
+You're organising meetups, workshops or community events and looking for the right platform? This comparison analyses three popular options (Meetup, Luma and The Playground), breaking down their models, pricing and limitations.
 
 ## The real question: events or community?
 
@@ -20,7 +20,7 @@ Before comparing features, you need to understand a structural difference betwee
 
 **Others are community-centric**: attendees join a group. They receive upcoming events, see other members, and come back naturally.
 
-This distinction changes everything for retention. If your attendees don't come back from one event to the next, the problem might not be your content — it might be your tool.
+This distinction changes everything for retention. If your attendees don't come back from one event to the next, the problem might not be your content. It might be your tool.
 
 ## The comparison at a glance
 
@@ -38,7 +38,7 @@ This distinction changes everything for retention. If your attendees don't come 
 
 ## Meetup: the original community model
 
-Meetup invented the concept of local online groups. You create a group, people join it, and they get notified with every new event. It's the right model — and it's been proven for 20 years.
+Meetup invented the concept of local online groups. You create a group, people join it, and they get notified with every new event. It's the right model, and it's been proven for 20 years.
 
 Since the acquisition by Bending Spoons in 2024, Meetup has changed course. The company cut its teams and revised its pricing: organisers still pay a subscription on certain plans, and **members** also pay (around $2 per RSVP, or a Meetup+ subscription at ~$5/month for unlimited RSVPs). Both sides pay.
 
@@ -56,13 +56,13 @@ Since the acquisition by Bending Spoons in 2024, Meetup has changed course. The 
 
 ### When to choose Meetup
 
-Meetup remains relevant if you're relying on **organic discovery**: you want strangers to find your group via the directory. That's its unique strength. If your community already exists and you distribute your events through other channels (WhatsApp, Slack, LinkedIn), the Meetup directory loses its value — and the cost becomes hard to justify.
+Meetup remains relevant if you're relying on **organic discovery**: you want strangers to find your group via the directory. That's its unique strength. If your community already exists and you distribute your events through other channels (WhatsApp, Slack, LinkedIn), the Meetup directory loses its value, and the cost becomes hard to justify.
 
 ## Luma: the event page benchmark
 
 Luma set a new standard for the event page. Polished design, registration in seconds (email only, no account), automatic calendar integration. It has become the go-to tool for tech events, creative gatherings and conferences.
 
-On pricing, Luma is free for organisers. The platform takes a **5% commission** on paid events (on top of Stripe fees). To remove that commission, you need Luma Plus at **$59/month** — which also unlocks API access, custom URLs and higher email sending limits.
+On pricing, Luma is free for organisers. The platform takes a **5% commission** on paid events (on top of Stripe fees). To remove that commission, you need Luma Plus at **$59/month**, which also unlocks API access, custom URLs and higher email sending limits.
 
 Luma has evolved beyond the purely event-centric model with **Calendars**: a public page listing your events, which visitors can subscribe to. And more recently, **Calendar Memberships** allow you to create membership tiers (free or paid).
 
@@ -70,14 +70,14 @@ Luma has evolved beyond the purely event-centric model with **Calendars**: a pub
 
 - **The event page**: the market benchmark. Beautiful, fast, optimised for sharing.
 - **Frictionless registration**: email only, no account, no password. Conversion rate is excellent.
-- **Communications**: email, SMS, push, WhatsApp — all included in the free plan.
+- **Communications**: email, SMS, push, WhatsApp. All included in the free plan.
 - **The Calendar**: a first layer of persistence to stay in touch with your audience.
 
 ### The limitations
 
 - **No real community page**: the Calendar shows your events, but not your members. There's no sense of belonging to a group. Attendees subscribe to an event list, they don't join a community.
 - **The 5% commission**: on recurring paid events, it adds up fast. The alternative ($59/month) is only worth it above a certain volume.
-- **No native recurrence**: no recurring events as such — you have to duplicate manually (up to 30 times). Attendee lists are not copied.
+- **No native recurrence**: no recurring events as such. You have to duplicate manually (up to 30 times). Attendee lists are not copied.
 
 ### When to choose Luma
 
@@ -89,7 +89,7 @@ The Playground starts from a simple observation: Meetup has the right model (per
 
 The core principle: **when someone registers for your event, they automatically join your community**. After the event, they see the next meetups, the other members, your group's identity. The link doesn't break between events.
 
-On pricing: **0% commission**, no subscription, no limits. Only standard Stripe fees (~2.9% + €0.30) apply on paid events — and the full amount goes to the organiser.
+On pricing: **0% commission**, no subscription, no limits. Only standard Stripe fees (~2.9% + €0.30) apply on paid events. The full amount goes to the organiser.
 
 ### What works
 
@@ -100,7 +100,7 @@ On pricing: **0% commission**, no subscription, no limits. Only standard Stripe 
 - **CSV export** of attendees per event.
 - **Calendar add** (Google Calendar + ICS file) after registration.
 
-### The limitations — let's be honest
+### The limitations. Let's be honest
 
 - **No Discover as large as Meetup's**: the directory exists, but the user base is smaller. Distribution relies on the organiser (shared links via WhatsApp, LinkedIn, etc.), not on a discovery algorithm.
 - **Registration via magic link or OAuth**: more secure than a password, but one more step than Luma (which only requires an email). It's a security vs. friction trade-off.
@@ -109,7 +109,7 @@ On pricing: **0% commission**, no subscription, no limits. Only standard Stripe 
 
 ### When to choose The Playground
 
-The Playground is built for organisers who want to **build a community over time** — not just manage events on a case-by-case basis. If your attendees come once and don't return, that's the problem The Playground solves. And if budget matters, the total free model removes the question entirely.
+The Playground is built for organisers who want to **build a community over time**, not just manage events on a case-by-case basis. If your attendees come once and don't return, that's the problem The Playground solves. And if budget matters, the total free model removes the question entirely.
 
 ---
 
@@ -121,4 +121,4 @@ There's no universal "best tool". The choice depends on what you're building:
 - **You organise one-off premium events** and community isn't your priority → **Luma**
 - **You're building a lasting community**, without budget, with a modern experience → **The Playground**
 
-The real question isn't "which tool has the most features" — it's "do your attendees come back?". If the answer is no, maybe it's the tool that needs to change.
+The real question isn't "which tool has the most features". It's "do your attendees come back?". If the answer is no, maybe it's the tool that needs to change.

--- a/src/content/blog/en/organiser-meetup-gratuit.md
+++ b/src/content/blog/en/organiser-meetup-gratuit.md
@@ -1,5 +1,5 @@
 ---
-title: "How to organise a free meetup in 2026 — complete guide"
+title: "How to organise a free meetup in 2026, the complete guide"
 description: "Everything you need to know to organise a free meetup: venue, promotion, registration, tools. A practical step-by-step guide."
 date: "2026-03-05"
 keywords:
@@ -19,11 +19,11 @@ Because the best communities are built in real life. A meetup, even a small one,
 
 Before hunting for a venue or setting up a registration page, ask yourself one simple question: **what format fits your topic and your audience?**
 
-**In person** — The most natural format for a meetup. People meet, chat, stick around after the official end. The downside: you need a venue, and attendees need to travel.
+**In person.** The most natural format for a meetup. People meet, chat, stick around after the official end. The downside: you need a venue, and attendees need to travel.
 
-**Online** — Easier to organise (no venue to find, no geographical limits), but engagement is lower. People turn off their cameras, leave after 30 minutes. It works well for short, structured formats: lightning talks, hands-on workshops, Q&A sessions.
+**Online.** Easier to organise (no venue to find, no geographical limits), but engagement is lower. People turn off their cameras, leave after 30 minutes. It works well for short, structured formats: lightning talks, hands-on workshops, Q&A sessions.
 
-**Hybrid** — Sounds like the best of both worlds on paper. In practice, it's the worst: a degraded experience for both groups. Avoid it unless you have experience and the right equipment.
+**Hybrid.** Sounds like the best of both worlds on paper. In practice, it's the worst: a degraded experience for both groups. Avoid it unless you have experience and the right equipment.
 
 > Our advice: start in person. Even with 8 people. The energy of a room changes everything.
 
@@ -31,11 +31,11 @@ Before hunting for a venue or setting up a registration page, ask yourself one s
 
 This is often the first roadblock. Here are concrete options that work:
 
-- **Coworking spaces** — Many offer a free room in the evening in exchange for visibility. Send a short email with your topic, expected number of attendees, and what you can offer in return (a mention on your social channels, for instance).
-- **Bars and restaurants** — Reserve a space in exchange for one drink per person. Ideally, negotiate a semi-private area. Make sure to clarify "no minimum spend" in your agreement.
-- **Company offices** — Tech companies happily lend their spaces in the evening. It's passive recruiting for them, a free venue for you. Everyone wins.
-- **Public libraries** — Free rooms, often underused. Book early.
-- **Parks and public spaces** — Free by definition. Perfect for spring and summer. Have a rain plan.
+- **Coworking spaces.** Many offer a free room in the evening in exchange for visibility. Send a short email with your topic, expected number of attendees, and what you can offer in return (a mention on your social channels, for instance).
+- **Bars and restaurants.** Reserve a space in exchange for one drink per person. Ideally, negotiate a semi-private area. Make sure to clarify "no minimum spend" in your agreement.
+- **Company offices.** Tech companies happily lend their spaces in the evening. It's passive recruiting for them, a free venue for you. Everyone wins.
+- **Public libraries.** Free rooms, often underused. Book early.
+- **Parks and public spaces.** Free by definition. Perfect for spring and summer. Have a rain plan.
 
 Don't look for the perfect venue for your first meetup. A reachable place with enough chairs is more than enough.
 
@@ -47,10 +47,10 @@ You need three things: a **registration page**, a way to **communicate** with yo
 
 Several platforms exist, each with its own trade-offs:
 
-- **Meetup.com** — The historical reference, large user base, good for discoverability. But it costs money for organisers (monthly subscription). If your goal is "free", it's out.
-- **Luma** — Clean design, magic link registration with no account creation. Free for free events. However, there's no community layer: each event starts from scratch, with no attendee retention.
-- **Eventbrite** — Powerful but heavy. The interface is designed for conferences, not informal meetups. Free for free events.
-- **The Playground** — Free, with polished event pages and a community layer (attendees who register for an event automatically join your community). CSV export, calendar integration (Google Calendar, Apple Calendar, ICS), magic link authentication. It's a newer platform, so the user base is smaller than Meetup or Eventbrite.
+- **Meetup.com.** The historical reference, large user base, good for discoverability. But it costs money for organisers (monthly subscription). If your goal is "free", it's out.
+- **Luma.** Clean design, magic link registration with no account creation. Free for free events. However, there's no community layer: each event starts from scratch, with no attendee retention.
+- **Eventbrite.** Powerful but heavy. The interface is designed for conferences, not informal meetups. Free for free events.
+- **The Playground.** Free, with polished event pages and a community layer (attendees who register for an event automatically join your community). CSV export, calendar integration (Google Calendar, Apple Calendar, ICS), magic link authentication. It's a newer platform, so the user base is smaller than Meetup or Eventbrite.
 
 Whatever tool you pick, the essential thing is a clear page with the title, date, venue, and a visible registration button.
 
@@ -68,10 +68,10 @@ Promotion is the hard part. Here's what actually works, and what's a waste of ti
 
 **What works:**
 
-- **Word of mouth** — By far the most effective channel. Tell 5 people who'll tell 5 more.
-- **Themed WhatsApp/Telegram groups** — If you're organising a Python meetup, the WhatsApp group for Python developers in your city is your best ally.
-- **LinkedIn** — A personal post (not a company page) with authentic copy. Posts like "I'm starting a meetup, here's why" perform well.
-- **Existing Slack/Discord communities** — Share your event there, but contribute first. Nobody likes spam.
+- **Word of mouth.** By far the most effective channel. Tell 5 people who'll tell 5 more.
+- **Themed WhatsApp/Telegram groups.** If you're organising a Python meetup, the WhatsApp group for Python developers in your city is your best ally.
+- **LinkedIn.** A personal post (not a company page) with authentic copy. Posts like "I'm starting a meetup, here's why" perform well.
+- **Existing Slack/Discord communities.** Share your event there, but contribute first. Nobody likes spam.
 
 **What doesn't work (or barely):**
 
@@ -92,7 +92,7 @@ A few practical tips that make the difference:
 - **Respect the schedule.** Start on time, end on time. People have lives.
 - **Keep 15-20 minutes of free networking** at the end. That's often where the best conversations happen.
 
-## After the event — the step most people skip
+## After the event, the step most people skip
 
 This is where the difference between "a one-off event" and "a community" is made. Most organisers stop at the day itself. Don't make that mistake.
 

--- a/src/content/blog/fr/alternative-meetup-gratuite.md
+++ b/src/content/blog/fr/alternative-meetup-gratuite.md
@@ -9,17 +9,17 @@ keywords:
   - plateforme communauté gratuite
 ---
 
-Meetup a longtemps été la référence pour organiser des événements communautaires. Mais depuis son rachat par Bending Spoons en 2024, la plateforme a changé de cap — et beaucoup d'organisateurs cherchent une alternative. Si c'est votre cas, voici un tour d'horizon des meilleures options gratuites en 2026.
+Meetup a longtemps été la référence pour organiser des événements communautaires. Mais depuis son rachat par Bending Spoons en 2024, la plateforme a changé de cap, et beaucoup d'organisateurs cherchent une alternative. Si c'est votre cas, voici un tour d'horizon des meilleures options gratuites en 2026.
 
 ## Pourquoi tant d'organisateurs quittent Meetup
 
 En janvier 2024, Bending Spoons rachète Meetup et applique son playbook habituel : réduction massive des équipes et monétisation agressive. Le résultat est un **double paywall** sans précédent dans l'histoire de la plateforme.
 
-Les **organisateurs** paient un abonnement pour maintenir leur groupe actif. Les **membres** paient aussi — environ 2$ par inscription (RSVP), ou un abonnement Meetup+ à ~5$/mois pour des inscriptions illimitées. Les deux côtés de la table paient.
+Les **organisateurs** paient un abonnement pour maintenir leur groupe actif. Les **membres** paient aussi, environ 2$ par inscription (RSVP), ou un abonnement Meetup+ à ~5$/mois pour des inscriptions illimitées. Les deux côtés de la table paient.
 
 En parallèle, l'API publique a été fortement restreinte, rendant difficile l'intégration avec d'autres outils. Et l'interface, bien que remaniée, reste en retrait par rapport aux standards actuels.
 
-Le modèle communautaire de Meetup reste pertinent — c'est la tarification et l'expérience qui posent problème.
+Le modèle communautaire de Meetup reste pertinent. C'est la tarification et l'expérience qui posent problème.
 
 ## Ce qu'il faut chercher dans une alternative
 
@@ -34,19 +34,19 @@ Avant de choisir, posez-vous les bonnes questions :
 
 ## Les alternatives
 
-### The Playground — la communauté d'abord, conçue en France
+### The Playground, la communauté d'abord, conçue en France
 
-The Playground reprend le modèle communautaire de Meetup — une communauté persistante, des membres qui restent d'un événement à l'autre — mais avec une expérience moderne et une gratuité totale.
+The Playground reprend le modèle communautaire de Meetup, une communauté persistante où les membres restent d'un événement à l'autre, mais avec une expérience moderne et une gratuité totale.
 
 **Le principe** : quand quelqu'un s'inscrit à votre événement, il rejoint automatiquement votre communauté. Après l'événement, il voit les prochains rendez-vous, les autres membres, l'identité de votre groupe. Le lien ne se casse pas.
 
-**Tarification** : 0% de commission, aucun abonnement. Seuls les frais Stripe standards (~2.9% + 0.30€) s'appliquent sur les événements payants — l'intégralité du montant va à l'organisateur.
+**Tarification** : 0% de commission, aucun abonnement. Seuls les frais Stripe standards (~2.9% + 0.30€) s'appliquent sur les événements payants. L'intégralité du montant va à l'organisateur.
 
-**L'angle européen** — et c'est un point qui compte de plus en plus :
+**L'angle européen.** C'est un point qui compte de plus en plus :
 
 - **Conçue en France**, avec une interface bilingue FR/EN native
 - **Infrastructure hébergée en Europe** : application sur Vercel région EU, base de données Neon région EU
-- **Données stockées en Union européenne** — pas de transfert transatlantique par défaut
+- **Données stockées en Union européenne.** Pas de transfert transatlantique par défaut
 - **Protection des données pensée dès la conception**, pas ajoutée après coup pour cocher une case RGPD
 - **Support en français**
 
@@ -54,35 +54,35 @@ Pour les organisateurs basés en France ou en Europe, c'est un avantage concret 
 
 **Les limites** : base d'utilisateurs plus petite que Meetup (la distribution repose sur l'organisateur), notifications email uniquement pour l'instant (pas de SMS/WhatsApp), plateforme jeune avec moins de fonctionnalités avancées que les acteurs établis.
 
-### Luma — la référence de la page événement
+### Luma, la référence de la page événement
 
 Luma a posé un nouveau standard pour la page événement. Design soigné, inscription en quelques secondes (email seul, pas de compte), intégration calendrier automatique. C'est devenu l'outil de référence pour les événements tech et les conférences.
 
 **Tarification** : gratuit pour l'organisateur. Commission de 5% sur les événements payants (en plus des frais Stripe). Pour supprimer cette commission : Luma Plus à 59$/mois.
 
-Luma a évolué avec les **Calendars** (une page publique listant vos événements) et les **Calendar Memberships** (tiers d'adhésion). C'est un pas vers la persistance, mais le Calendar affiche vos événements sans montrer vos membres — il manque le sentiment d'appartenance à un groupe.
+Luma a évolué avec les **Calendars** (une page publique listant vos événements) et les **Calendar Memberships** (tiers d'adhésion). C'est un pas vers la persistance, mais le Calendar affiche vos événements sans montrer vos membres. Il manque le sentiment d'appartenance à un groupe.
 
 **Les limites** : pas de vraie page communauté avec membres visibles, commission qui s'accumule sur les événements payants récurrents, infrastructure basée aux États-Unis.
 
-### Eventbrite — la billetterie pour les grands événements
+### Eventbrite, la billetterie pour les grands événements
 
 Eventbrite est une plateforme de billetterie, pas une plateforme communautaire. La distinction est importante.
 
-**Tarification** : gratuit pour les événements gratuits. Pour les événements payants, Eventbrite applique des frais qui varient selon les régions — en Europe, comptez environ 3.7% + 0.79€ par billet (le modèle exact a changé plusieurs fois ces dernières années).
+**Tarification** : gratuit pour les événements gratuits. Pour les événements payants, Eventbrite applique des frais qui varient selon les régions. En Europe, comptez environ 3.7% + 0.79€ par billet (le modèle exact a changé plusieurs fois ces dernières années).
 
 Eventbrite excelle pour les **événements ponctuels à forte affluence** : conférences, salons, soirées de lancement. La billetterie est robuste, le système de check-in est mature, et la plateforme offre une bonne visibilité pour les grands événements publics.
 
-**Les limites** : aucun modèle communautaire — chaque événement est une transaction isolée. Pas de page de groupe, pas de membres persistants. Si vous cherchez à construire une communauté qui dure, Eventbrite n'est pas conçu pour ça.
+**Les limites** : aucun modèle communautaire. Chaque événement est une transaction isolée. Pas de page de groupe, pas de membres persistants. Si vous cherchez à construire une communauté qui dure, Eventbrite n'est pas conçu pour ça.
 
-### Discord / Slack — la conversation, pas l'événement
+### Discord / Slack, la conversation, pas l'événement
 
-Discord et Slack sont d'excellents outils de communication communautaire. Beaucoup d'organisateurs les utilisent comme complément — et c'est exactement le bon usage.
+Discord et Slack sont d'excellents outils de communication communautaire. Beaucoup d'organisateurs les utilisent comme complément, et c'est exactement le bon usage.
 
 **Tarification** : gratuit (avec des plans payants pour les fonctionnalités avancées).
 
 Ces plateformes offrent ce que les outils événementiels n'ont pas : la **conversation continue** entre les événements. Discussions, partage de ressources, entraide.
 
-**Les limites** : ce ne sont pas des plateformes d'événements. Pas de page événement partageable, pas de système d'inscription, pas d'intégration calendrier, pas de gestion de capacité ou de liste d'attente. Si vous annoncez vos événements uniquement sur Discord ou Slack, vous perdez la conversion — un message dans un canal n'a pas le même impact qu'une page événement dédiée avec un bouton d'inscription.
+**Les limites** : ce ne sont pas des plateformes d'événements. Pas de page événement partageable, pas de système d'inscription, pas d'intégration calendrier, pas de gestion de capacité ou de liste d'attente. Si vous annoncez vos événements uniquement sur Discord ou Slack, vous perdez la conversion. Un message dans un canal n'a pas le même impact qu'une page événement dédiée avec un bouton d'inscription.
 
 **Le bon usage** : Discord/Slack en complément d'une plateforme d'événements, pas en remplacement.
 
@@ -103,12 +103,12 @@ Ces plateformes offrent ce que les outils événementiels n'ont pas : la **conve
 
 Le choix dépend de ce que vous construisez :
 
-> **Vous construisez une communauté locale qui dure** — vous voulez que vos participants reviennent d'un événement à l'autre, sans payer de commission, avec vos données en Europe → **The Playground**
+> **Vous construisez une communauté locale qui dure.** Vous voulez que vos participants reviennent d'un événement à l'autre, sans payer de commission, avec vos données en Europe → **The Playground**
 
-> **Vous organisez des événements ponctuels premium** — la qualité de la page d'inscription est déterminante, vous avez besoin de SMS/WhatsApp, la communauté n'est pas votre priorité → **Luma**
+> **Vous organisez des événements ponctuels premium.** La qualité de la page d'inscription est déterminante, vous avez besoin de SMS/WhatsApp, la communauté n'est pas votre priorité → **Luma**
 
-> **Vous organisez un grand événement public avec billetterie** — conférence, salon, 200+ participants, vous avez besoin d'un système de billetterie robuste → **Eventbrite**
+> **Vous organisez un grand événement public avec billetterie.** Conférence, salon, 200+ participants, vous avez besoin d'un système de billetterie robuste → **Eventbrite**
 
-> **Vous avez déjà une communauté active sur Discord/Slack** — gardez-la pour la conversation, mais utilisez une plateforme dédiée pour vos événements
+> **Vous avez déjà une communauté active sur Discord/Slack.** Gardez-la pour la conversation, mais utilisez une plateforme dédiée pour vos événements
 
-La question fondamentale n'est pas "quelle plateforme a le plus de fonctionnalités" — c'est "est-ce que vos participants reviennent après le premier événement ?". Si la réponse est non, c'est peut-être l'outil qu'il faut changer.
+La question fondamentale n'est pas "quelle plateforme a le plus de fonctionnalités". C'est "est-ce que vos participants reviennent après le premier événement ?". Si la réponse est non, c'est peut-être l'outil qu'il faut changer.

--- a/src/content/blog/fr/creer-communaute-en-ligne.md
+++ b/src/content/blog/fr/creer-communaute-en-ligne.md
@@ -9,13 +9,13 @@ keywords:
   - communauté engagée
 ---
 
-Vous avez probablement déjà créé un groupe WhatsApp, un serveur Discord ou un canal Slack pour "garder le lien" après un événement. Trois mois plus tard, le groupe est muet. Les gens n'ont pas quitté — ils ont juste cessé de regarder.
+Vous avez probablement déjà créé un groupe WhatsApp, un serveur Discord ou un canal Slack pour "garder le lien" après un événement. Trois mois plus tard, le groupe est muet. Les gens n'ont pas quitté. Ils ont juste cessé de regarder.
 
 Ce n'est pas un problème de plateforme. C'est un problème de méthode. Créer un espace ne suffit pas à créer une communauté. Voici cinq étapes concrètes pour construire quelque chose qui dure.
 
 ## 1. Commencez par une identité claire
 
-La première erreur, c'est de lancer un groupe sans savoir à qui il s'adresse. "Un groupe pour les gens qui aiment le dev" n'est pas une identité — c'est une catégorie. "Les développeurs freelances de Lyon qui veulent sortir de l'isolement" en est une.
+La première erreur, c'est de lancer un groupe sans savoir à qui il s'adresse. "Un groupe pour les gens qui aiment le dev" n'est pas une identité, c'est une catégorie. "Les développeurs freelances de Lyon qui veulent sortir de l'isolement" en est une.
 
 Une communauté a besoin de trois choses dès le départ :
 
@@ -23,15 +23,15 @@ Une communauté a besoin de trois choses dès le départ :
 - **Une promesse** : qu'est-ce que les membres y trouvent ? Du réseau, de l'apprentissage, du soutien, de l'inspiration ?
 - **Un nom et une description** qui disent les deux en une phrase.
 
-Ça paraît basique. Mais la plupart des communautés qui s'éteignent au bout de deux mois n'ont jamais formulé leur identité clairement. Les fonctionnalités ne compensent pas un positionnement flou. Un groupe Slack avec 200 personnes qui ne savent pas pourquoi elles sont là, c'est du bruit — pas une communauté.
+Ça paraît basique. Mais la plupart des communautés qui s'éteignent au bout de deux mois n'ont jamais formulé leur identité clairement. Les fonctionnalités ne compensent pas un positionnement flou. Un groupe Slack avec 200 personnes qui ne savent pas pourquoi elles sont là, c'est du bruit, pas une communauté.
 
 ## 2. Organisez le premier événement vite
 
 Ne cherchez pas la salle parfaite, le nombre idéal de participants ou le thème définitif. Organisez un premier rendez-vous. Vite.
 
-Dix personnes dans un bar, un apéro informel, un appel vidéo d'une heure — peu importe le format. Le premier événement n'a qu'un seul objectif : **prouver que le concept fonctionne**. Est-ce que des gens viennent ? Est-ce qu'ils repartent contents ? Est-ce qu'ils en parlent autour d'eux ?
+Dix personnes dans un bar, un apéro informel, un appel vidéo d'une heure. Peu importe le format. Le premier événement n'a qu'un seul objectif : **prouver que le concept fonctionne**. Est-ce que des gens viennent ? Est-ce qu'ils repartent contents ? Est-ce qu'ils en parlent autour d'eux ?
 
-La tentation, c'est de planifier pendant des semaines. De peaufiner la page d'inscription, de chercher un intervenant, de designer un visuel. Tout ça peut venir après. Le risque numéro un d'une communauté naissante, ce n'est pas d'être imparfaite — c'est de ne jamais commencer.
+La tentation, c'est de planifier pendant des semaines. De peaufiner la page d'inscription, de chercher un intervenant, de designer un visuel. Tout ça peut venir après. Le risque numéro un d'une communauté naissante, ce n'est pas d'être imparfaite. C'est de ne jamais commencer.
 
 > Un premier événement raté vous apprend plus qu'un mois de planification.
 
@@ -49,24 +49,24 @@ Concrètement, il vous faut un espace où les participants restent connectés en
 - **Un serveur Discord** : plus structuré, mais la barrière d'entrée est réelle. Tout le monde n'a pas Discord et tout le monde n'a pas envie de l'installer pour un meetup.
 - **Une plateforme communautaire dédiée** : c'est l'approche de The Playground, par exemple. Quand quelqu'un s'inscrit à votre événement, il rejoint automatiquement votre communauté. La page de la communauté montre les prochains événements, les événements passés et les membres. Le lien ne se casse pas entre deux événements, sans que vous ayez à gérer un groupe de discussion.
 
-L'outil compte moins que le principe : **il faut un fil continu entre les événements**. Si vos participants doivent se réinscrire à chaque fois comme s'ils ne vous connaissaient pas, vous ne construisez pas une communauté — vous recommencez à zéro à chaque édition.
+L'outil compte moins que le principe : **il faut un fil continu entre les événements**. Si vos participants doivent se réinscrire à chaque fois comme s'ils ne vous connaissaient pas, vous ne construisez pas une communauté. Vous recommencez à zéro à chaque édition.
 
 ## 4. Créez un rythme
 
 Une communauté sans régularité, c'est un groupe d'amis qui se dit "on devrait se revoir" et ne le fait jamais.
 
-Le rythme est le signal le plus fort que vous envoyez à vos membres. Mensuel, bimensuel, hebdomadaire — la fréquence importe moins que la constance. Ce qui compte, c'est que les membres puissent anticiper. "Le premier jeudi du mois" devient un repère mental. "De temps en temps, quand j'ai le temps" ne crée aucune habitude.
+Le rythme est le signal le plus fort que vous envoyez à vos membres. Mensuel, bimensuel, hebdomadaire. La fréquence importe moins que la constance. Ce qui compte, c'est que les membres puissent anticiper. "Le premier jeudi du mois" devient un repère mental. "De temps en temps, quand j'ai le temps" ne crée aucune habitude.
 
 Deux pratiques qui changent tout :
 
 - **Annoncez le prochain événement avant la fin du précédent.** Quand les gens sont encore dans l'énergie du moment, donnez-leur la prochaine date. "Le prochain rendez-vous est le 14 mars" est plus puissant que n'importe quel email de relance envoyé deux semaines plus tard.
-- **Maintenez le rythme même quand c'est dur.** Un mois sans événement, ce n'est pas grave. Deux mois, les gens commencent à oublier. Trois mois, il faut quasiment relancer la communauté de zéro. Si vous n'avez pas le temps d'organiser un événement complet, faites un format léger — un café informel, un thread de discussion, un appel rapide. L'important, c'est de ne pas disparaître.
+- **Maintenez le rythme même quand c'est dur.** Un mois sans événement, ce n'est pas grave. Deux mois, les gens commencent à oublier. Trois mois, il faut quasiment relancer la communauté de zéro. Si vous n'avez pas le temps d'organiser un événement complet, faites un format léger. Un café informel, un thread de discussion, un appel rapide. L'important, c'est de ne pas disparaître.
 
 > La régularité crée la confiance. La confiance crée l'engagement. L'engagement crée la communauté.
 
 ## 5. Laissez les membres façonner la communauté
 
-Si vous êtes la seule personne qui propose des sujets, organise les événements et anime les discussions, vous n'avez pas une communauté — vous avez un one-man show. Et le jour où vous êtes fatigué, tout s'arrête.
+Si vous êtes la seule personne qui propose des sujets, organise les événements et anime les discussions, vous n'avez pas une communauté. Vous avez un one-man show. Et le jour où vous êtes fatigué, tout s'arrête.
 
 Les communautés les plus solides sont celles où les membres prennent des initiatives :
 
@@ -74,7 +74,7 @@ Les communautés les plus solides sont celles où les membres prennent des initi
 - **Co-organiser** : identifiez les membres les plus engagés et proposez-leur de co-animer un événement. Ça les implique et ça vous soulage.
 - **Amener du monde** : le bouche-à-oreille est votre meilleur canal de croissance. Si vos membres invitent leurs contacts, c'est que la communauté crée de la valeur.
 
-Votre rôle évolue naturellement : vous passez d'organisateur à facilitateur. Vous ne portez plus tout — vous créez le cadre dans lequel les choses se passent.
+Votre rôle évolue naturellement : vous passez d'organisateur à facilitateur. Vous ne portez plus tout. Vous créez le cadre dans lequel les choses se passent.
 
 C'est aussi un signal de maturité. Une communauté qui dépend d'une seule personne est fragile. Une communauté où plusieurs personnes contribuent est résiliente.
 
@@ -90,4 +90,4 @@ Créer une communauté en ligne qui dure, ce n'est pas une question d'outil ou d
 4. **Rythme** : soyez régulier, pas parfait.
 5. **Participation** : laissez les membres contribuer.
 
-Aucune de ces étapes ne nécessite un outil particulier. Mais les bons outils facilitent les bonnes habitudes. Choisissez celui qui correspond à votre approche — et concentrez-vous sur ce qui compte vraiment : les gens qui reviennent.
+Aucune de ces étapes ne nécessite un outil particulier. Mais les bons outils facilitent les bonnes habitudes. Choisissez celui qui correspond à votre approche, et concentrez-vous sur ce qui compte vraiment : les gens qui reviennent.

--- a/src/content/blog/fr/evenements-ne-suffisent-pas.md
+++ b/src/content/blog/fr/evenements-ne-suffisent-pas.md
@@ -1,5 +1,5 @@
 ---
-title: "Pourquoi les événements seuls ne suffisent pas — le modèle communautaire"
+title: "Pourquoi les événements seuls ne suffisent pas, le modèle communautaire"
 description: "Vous organisez des événements mais vos participants ne reviennent pas ? Le problème n'est pas l'événement, c'est l'absence de communauté."
 date: "2026-03-18"
 keywords:
@@ -19,7 +19,7 @@ La plupart des outils événementiels fonctionnent sur un modèle simple : vous 
 
 Ce modèle n'est pas mauvais en soi. Pour une conférence annuelle, un atelier ponctuel ou un lancement de produit, il fonctionne très bien. L'événement est la destination. On n'attend pas de récurrence.
 
-Mais si vous organisez des événements réguliers — meetups, ateliers mensuels, soirées réseau, sessions de pratique — ce modèle vous condamne à recommencer de zéro à chaque fois. Votre audience n'a aucune raison structurelle de revenir. Elle doit tomber sur votre prochaine annonce au bon moment, sur le bon canal, avec la bonne disponibilité. C'est du hasard, pas de la rétention.
+Mais si vous organisez des événements réguliers (meetups, ateliers mensuels, soirées réseau, sessions de pratique), ce modèle vous condamne à recommencer de zéro à chaque fois. Votre audience n'a aucune raison structurelle de revenir. Elle doit tomber sur votre prochaine annonce au bon moment, sur le bon canal, avec la bonne disponibilité. C'est du hasard, pas de la rétention.
 
 Pensez-y : quand un participant quitte votre événement, quel lien reste entre vous et lui ? Un email de confirmation dans ses archives. Peut-être un post LinkedIn qu'il a liké. La relation s'arrête là. Vous ne pouvez pas compter sur la bonne volonté pour remplacer un mécanisme de rétention.
 
@@ -27,7 +27,7 @@ Pensez-y : quand un participant quitte votre événement, quel lien reste entre 
 
 Regardons les plateformes les plus utilisées. Luma propose une expérience d'inscription élégante et des pages événement soignées. Eventbrite gère la billetterie à grande échelle. Google Forms est gratuit et sans friction. Mais elles partagent toutes la même limite : l'événement est terminal.
 
-Sur Luma, quand votre événement est passé, la page devient une archive. Le participant n'a aucune raison d'y retourner. Il n'y a pas de page qui regroupe vos événements à venir, vos anciens participants, l'identité de votre groupe. Luma a ajouté un système de calendrier personnel — un pas dans la bonne direction — mais suivre un calendrier n'est pas la même chose qu'appartenir à un groupe.
+Sur Luma, quand votre événement est passé, la page devient une archive. Le participant n'a aucune raison d'y retourner. Il n'y a pas de page qui regroupe vos événements à venir, vos anciens participants, l'identité de votre groupe. Luma a ajouté un système de calendrier personnel, un pas dans la bonne direction, mais suivre un calendrier n'est pas la même chose qu'appartenir à un groupe.
 
 Eventbrite permet de suivre un organisateur, mais la relation reste transactionnelle. Vous recevez un email quand il publie un nouvel événement. C'est une notification, pas une appartenance.
 
@@ -35,7 +35,7 @@ Le problème n'est pas la qualité de ces outils. C'est leur architecture mental
 
 ## Ce qu'une communauté change concrètement
 
-Meetup a compris quelque chose que les plateformes event-centric n'ont pas intégré : la persistance du groupe. Quand vous rejoignez un groupe Meetup, vous ne vous inscrivez pas à un événement — vous rejoignez une communauté. Vous voyez les autres membres. Vous voyez les prochains événements. Vous recevez des notifications parce que vous appartenez au groupe, pas parce que vous avez cliqué sur un lien au bon moment.
+Meetup a compris quelque chose que les plateformes event-centric n'ont pas intégré : la persistance du groupe. Quand vous rejoignez un groupe Meetup, vous ne vous inscrivez pas à un événement. Vous rejoignez une communauté. Vous voyez les autres membres. Vous voyez les prochains événements. Vous recevez des notifications parce que vous appartenez au groupe, pas parce que vous avez cliqué sur un lien au bon moment.
 
 Ce mécanisme transforme la dynamique de rétention :
 
@@ -61,12 +61,12 @@ Comparons les deux flux du point de vue du participant.
 
 **Modèle community-centric :**
 1. Un ami partage un lien vers un événement
-2. Inscription rapide — et adhésion automatique à la communauté
+2. Inscription rapide, et adhésion automatique à la communauté
 3. Participation à l'événement
 4. L'événement se termine
 5. Le participant voit la page de la communauté : prochains événements, membres, historique
 6. Il reçoit une notification pour le prochain événement parce qu'il est membre
-7. Il revient — et il amène un ami
+7. Il revient, et il amène un ami
 
 La différence ne se joue pas au moment de l'événement. Elle se joue dans l'entre-deux. Le modèle event-centric laisse un vide. Le modèle communautaire le comble.
 

--- a/src/content/blog/fr/meetup-vs-luma-vs-the-playground.md
+++ b/src/content/blog/fr/meetup-vs-luma-vs-the-playground.md
@@ -1,5 +1,5 @@
 ---
-title: Meetup vs Luma vs The Playground — comparatif 2026
+title: Meetup vs Luma vs The Playground, comparatif 2026
 description: "Comparatif détaillé des plateformes communautaires : fonctionnalités, prix, modèle. Quelle plateforme choisir pour organiser vos événements et fédérer votre communauté ?"
 date: "2026-03-24"
 keywords:
@@ -9,7 +9,7 @@ keywords:
   - comparatif meetup luma
   - plateforme événementielle gratuite
 ---
-Vous organisez des meetups, des ateliers ou des événements communautaires et vous cherchez la bonne plateforme ? Ce comparatif analyse trois options populaires — Meetup, Luma et The Playground — en détaillant leurs modèles, leurs prix et leurs limites.
+Vous organisez des meetups, des ateliers ou des événements communautaires et vous cherchez la bonne plateforme ? Ce comparatif analyse trois options populaires (Meetup, Luma et The Playground), en détaillant leurs modèles, leurs prix et leurs limites.
 
 ## La vraie question : événement ou communauté ?
 
@@ -19,7 +19,7 @@ Avant de comparer les fonctionnalités, il faut comprendre une différence struc
 
 **D'autres sont centrées sur la communauté** : les participants rejoignent un groupe. Ils reçoivent les prochains événements, voient les autres membres, et reviennent naturellement.
 
-Cette distinction change tout pour la rétention. Si vos participants ne reviennent pas d'un événement à l'autre, le problème n'est peut-être pas votre contenu — c'est votre outil.
+Cette distinction change tout pour la rétention. Si vos participants ne reviennent pas d'un événement à l'autre, le problème n'est peut-être pas votre contenu. C'est votre outil.
 
 ## Le comparatif en un coup d'œil
 
@@ -37,7 +37,7 @@ Cette distinction change tout pour la rétention. Si vos participants ne revienn
 
 ## Meetup : le modèle communautaire d'origine
 
-Meetup a inventé le concept de groupe local en ligne. Vous créez un groupe, les gens le rejoignent, et ils sont notifiés à chaque nouvel événement. C'est le bon modèle — et il a fait ses preuves pendant 20 ans.
+Meetup a inventé le concept de groupe local en ligne. Vous créez un groupe, les gens le rejoignent, et ils sont notifiés à chaque nouvel événement. C'est le bon modèle, et il a fait ses preuves pendant 20 ans.
 
 Depuis le rachat par Bending Spoons en 2024, Meetup a changé de cap. L'entreprise a réduit ses équipes et modifié sa tarification : les organisateurs paient toujours un abonnement sur certains plans, et les **membres** paient aussi (environ 2$ par RSVP, ou un abonnement Meetup+ à ~5$/mois pour des inscriptions illimitées). Les deux côtés paient.
 
@@ -55,13 +55,13 @@ Depuis le rachat par Bending Spoons en 2024, Meetup a changé de cap. L'entrepri
 
 ### Quand choisir Meetup
 
-Meetup reste pertinent si vous misez sur **la découverte organique** : vous voulez que des inconnus trouvent votre groupe via l'annuaire. C'est sa force unique. Si votre communauté est déjà constituée et que vous distribuez vos événements par d'autres canaux (WhatsApp, Slack, LinkedIn), l'annuaire Meetup perd de sa valeur — et le coût devient difficile à justifier.
+Meetup reste pertinent si vous misez sur **la découverte organique** : vous voulez que des inconnus trouvent votre groupe via l'annuaire. C'est sa force unique. Si votre communauté est déjà constituée et que vous distribuez vos événements par d'autres canaux (WhatsApp, Slack, LinkedIn), l'annuaire Meetup perd de sa valeur, et le coût devient difficile à justifier.
 
 ## Luma : la référence de la page événement
 
 Luma a posé un nouveau standard pour la page événement. Design soigné, inscription en quelques secondes (email seul, pas de compte), intégration calendrier automatique. C'est devenu l'outil de référence pour les événements tech, créatifs et les conférences.
 
-Côté tarification, Luma est gratuit pour l'organisateur. La plateforme prend une **commission de 5%** sur les événements payants (en plus des frais Stripe). Pour supprimer cette commission, il faut passer à Luma Plus à **59$/mois** — ce qui donne aussi l'accès API, les URLs personnalisées et un volume d'envoi d'emails plus élevé.
+Côté tarification, Luma est gratuit pour l'organisateur. La plateforme prend une **commission de 5%** sur les événements payants (en plus des frais Stripe). Pour supprimer cette commission, il faut passer à Luma Plus à **59$/mois**, ce qui donne aussi l'accès API, les URLs personnalisées et un volume d'envoi d'emails plus élevé.
 
 Luma a évolué au-delà du modèle purement événementiel avec les **Calendars** : une page publique qui liste vos événements, à laquelle les visiteurs peuvent s'abonner. Et depuis peu, les **Calendar Memberships** permettent de créer des tiers d'adhésion (gratuits ou payants).
 
@@ -69,14 +69,14 @@ Luma a évolué au-delà du modèle purement événementiel avec les **Calendars
 
 - **La page événement** : le benchmark du marché. Belle, rapide, optimisée pour le partage.
 - **L'inscription sans friction** : email seul, pas de compte, pas de mot de passe. Le taux de conversion est excellent.
-- **Les communications** : email, SMS, push, WhatsApp — tout est inclus dans le plan gratuit.
+- **Les communications** : email, SMS, push, WhatsApp. Tout est inclus dans le plan gratuit.
 - **Le Calendar** : une première couche de persistance pour garder le contact avec votre audience.
 
 ### Les limites
 
 - **Pas de vraie page communauté** : le Calendar affiche vos événements, mais pas vos membres. Il n'y a pas de sentiment d'appartenance à un groupe. Les participants s'abonnent à une liste d'événements, ils ne rejoignent pas une communauté.
 - **La commission à 5%** : sur des événements payants récurrents, ça s'accumule vite. L'alternative (59$/mois) n'est rentable qu'à partir d'un certain volume.
-- **L'absence de récurrence native** : pas d'événement récurrent au sens propre — il faut dupliquer manuellement (jusqu'à 30 fois). Les listes de participants ne sont pas copiées.
+- **L'absence de récurrence native** : pas d'événement récurrent au sens propre. Il faut dupliquer manuellement (jusqu'à 30 fois). Les listes de participants ne sont pas copiées.
 
 ### Quand choisir Luma
 
@@ -88,7 +88,7 @@ The Playground part d'un constat simple : Meetup a le bon modèle (communauté p
 
 Le principe fondamental : **quand quelqu'un s'inscrit à votre événement, il rejoint automatiquement votre communauté**. Après l'événement, il voit les prochains rendez-vous, les autres membres, l'identité de votre groupe. Le lien ne se casse pas entre deux événements.
 
-Côté tarification : **0% de commission**, aucun abonnement, aucune limite. Seuls les frais Stripe standards (~2.9% + 0.30€) s'appliquent sur les événements payants — et l'intégralité du montant va à l'organisateur.
+Côté tarification : **0% de commission**, aucun abonnement, aucune limite. Seuls les frais Stripe standards (~2.9% + 0.30€) s'appliquent sur les événements payants. L'intégralité du montant va à l'organisateur.
 
 ### Ce qui fonctionne
 
@@ -99,7 +99,7 @@ Côté tarification : **0% de commission**, aucun abonnement, aucune limite. Seu
 - **L'export CSV** des participants par événement.
 - **L'ajout calendrier** (Google Calendar + fichier ICS) après inscription.
 
-### Les limites — soyons honnêtes
+### Les limites. Soyons honnêtes
 
 - **Pas de Discover aussi large que Meetup** : l'annuaire existe, mais la base d'utilisateurs est plus petite. La distribution repose sur l'organisateur (liens partagés via WhatsApp, LinkedIn, etc.), pas sur un algorithme de découverte.
 - **Inscription par magic link ou OAuth** : plus sécurisé qu'un mot de passe, mais une étape de plus que Luma (qui n'exige qu'un email). C'est un compromis sécurité vs. friction.
@@ -108,7 +108,7 @@ Côté tarification : **0% de commission**, aucun abonnement, aucune limite. Seu
 
 ### Quand choisir The Playground
 
-The Playground est fait pour les organisateurs qui veulent **construire une communauté dans la durée** — pas juste gérer des événements au cas par cas. Si vos participants viennent une fois et ne reviennent pas, c'est le problème que The Playground résout. Et si le budget est un critère, la gratuité totale élimine la question.
+The Playground est fait pour les organisateurs qui veulent **construire une communauté dans la durée**, pas juste gérer des événements au cas par cas. Si vos participants viennent une fois et ne reviennent pas, c'est le problème que The Playground résout. Et si le budget est un critère, la gratuité totale élimine la question.
 
 ---
 
@@ -120,4 +120,4 @@ Il n'y a pas de "meilleur outil" universel. Le choix dépend de ce que vous cons
 - **Vous organisez des événements ponctuels premium** et la communauté n'est pas votre priorité → **Luma**
 - **Vous construisez une communauté qui dure**, sans budget, avec une expérience moderne → **The Playground**
 
-La vraie question n'est pas "quel outil a le plus de fonctionnalités" — c'est "est-ce que vos participants reviennent ?". Si la réponse est non, c'est peut-être l'outil qu'il faut changer.
+La vraie question n'est pas "quel outil a le plus de fonctionnalités". C'est "est-ce que vos participants reviennent ?". Si la réponse est non, c'est peut-être l'outil qu'il faut changer.

--- a/src/content/blog/fr/organiser-meetup-gratuit.md
+++ b/src/content/blog/fr/organiser-meetup-gratuit.md
@@ -1,5 +1,5 @@
 ---
-title: "Comment organiser un meetup gratuit en 2026 — guide complet"
+title: "Comment organiser un meetup gratuit en 2026, le guide complet"
 description: "Tout ce qu'il faut savoir pour organiser un meetup gratuit : lieu, promotion, inscription, outils. Guide pratique étape par étape."
 date: "2026-03-05"
 keywords:
@@ -19,11 +19,11 @@ Parce que les meilleures communautés se construisent dans la vraie vie. Un meet
 
 Avant de chercher un lieu ou de créer une page d'inscription, posez-vous une question simple : **quel format correspond à votre sujet et à votre audience ?**
 
-**En présentiel** — C'est le format le plus naturel pour un meetup. Les gens se rencontrent, échangent, restent après la fin officielle. L'inconvénient : il faut un lieu, et les participants doivent se déplacer.
+**En présentiel.** C'est le format le plus naturel pour un meetup. Les gens se rencontrent, échangent, restent après la fin officielle. L'inconvénient : il faut un lieu, et les participants doivent se déplacer.
 
-**En ligne** — Plus facile à organiser (pas de lieu à trouver, pas de limite géographique), mais l'engagement est plus faible. Les gens coupent leur caméra, partent après 30 minutes. Ça fonctionne bien pour des formats courts et structurés : lightning talks, ateliers pratiques, Q&A.
+**En ligne.** Plus facile à organiser (pas de lieu à trouver, pas de limite géographique), mais l'engagement est plus faible. Les gens coupent leur caméra, partent après 30 minutes. Ça fonctionne bien pour des formats courts et structurés : lightning talks, ateliers pratiques, Q&A.
 
-**Hybride** — Sur le papier, c'est le meilleur des deux mondes. En pratique, c'est le pire : une expérience dégradée pour les deux groupes. Évitez-le sauf si vous avez de l'expérience et le matériel adapté.
+**Hybride.** Sur le papier, c'est le meilleur des deux mondes. En pratique, c'est le pire : une expérience dégradée pour les deux groupes. Évitez-le sauf si vous avez de l'expérience et le matériel adapté.
 
 > Notre conseil : commencez en présentiel. Même avec 8 personnes. L'énergie d'une salle change tout.
 
@@ -31,11 +31,11 @@ Avant de chercher un lieu ou de créer une page d'inscription, posez-vous une qu
 
 C'est souvent le premier blocage. Voici des pistes concrètes qui fonctionnent :
 
-- **Espaces de coworking** — Beaucoup proposent une salle gratuite le soir en échange de visibilité. Envoyez un email court avec votre sujet, le nombre de participants prévu et ce que vous pouvez offrir (mention sur vos réseaux, par exemple).
-- **Bars et restaurants** — Réservez un espace en échange d'une consommation par personne. Idéalement, négociez un coin semi-privé. Précisez "pas de minimum de dépense" dans votre accord.
-- **Bureaux d'entreprise** — Des entreprises tech prêtent volontiers leurs locaux le soir. C'est du recrutement passif pour elles, une salle gratuite pour vous. Tout le monde y gagne.
-- **Bibliothèques municipales** — Salles gratuites, souvent méconnues. Il faut réserver tôt.
-- **Parcs et espaces publics** — Gratuit par définition. Parfait pour le printemps et l'été. Prévoyez un plan B en cas de pluie.
+- **Espaces de coworking.** Beaucoup proposent une salle gratuite le soir en échange de visibilité. Envoyez un email court avec votre sujet, le nombre de participants prévu et ce que vous pouvez offrir (mention sur vos réseaux, par exemple).
+- **Bars et restaurants.** Réservez un espace en échange d'une consommation par personne. Idéalement, négociez un coin semi-privé. Précisez "pas de minimum de dépense" dans votre accord.
+- **Bureaux d'entreprise.** Des entreprises tech prêtent volontiers leurs locaux le soir. C'est du recrutement passif pour elles, une salle gratuite pour vous. Tout le monde y gagne.
+- **Bibliothèques municipales.** Salles gratuites, souvent méconnues. Il faut réserver tôt.
+- **Parcs et espaces publics.** Gratuit par définition. Parfait pour le printemps et l'été. Prévoyez un plan B en cas de pluie.
 
 Ne cherchez pas la salle parfaite pour votre premier meetup. Un endroit accessible, avec assez de chaises, suffit largement.
 
@@ -47,10 +47,10 @@ Vous avez besoin de trois choses : une **page d'inscription**, un moyen de **com
 
 Plusieurs plateformes existent, chacune avec ses compromis :
 
-- **Meetup.com** — La référence historique, grosse base d'utilisateurs, bon pour la découverte. Mais payant pour les organisateurs (abonnement mensuel). Si votre objectif est "gratuit", c'est éliminé.
-- **Luma** — Design soigné, inscription par magic link sans création de compte. Gratuit pour les événements gratuits. En revanche, pas de notion de communauté : chaque événement repart de zéro, sans rétention des participants.
-- **Eventbrite** — Puissant mais lourd. L'interface est pensée pour des conférences, pas pour des meetups informels. Gratuit pour les événements gratuits.
-- **The Playground** — Gratuit, avec des pages événement soignées et une couche communautaire (les inscrits à un événement rejoignent automatiquement votre communauté). Export CSV, ajout au calendrier (Google Calendar, Apple Calendar, ICS), authentification par magic link. C'est une plateforme récente, donc la base d'utilisateurs est plus petite que Meetup ou Eventbrite.
+- **Meetup.com.** La référence historique, grosse base d'utilisateurs, bon pour la découverte. Mais payant pour les organisateurs (abonnement mensuel). Si votre objectif est "gratuit", c'est éliminé.
+- **Luma.** Design soigné, inscription par magic link sans création de compte. Gratuit pour les événements gratuits. En revanche, pas de notion de communauté : chaque événement repart de zéro, sans rétention des participants.
+- **Eventbrite.** Puissant mais lourd. L'interface est pensée pour des conférences, pas pour des meetups informels. Gratuit pour les événements gratuits.
+- **The Playground.** Gratuit, avec des pages événement soignées et une couche communautaire (les inscrits à un événement rejoignent automatiquement votre communauté). Export CSV, ajout au calendrier (Google Calendar, Apple Calendar, ICS), authentification par magic link. C'est une plateforme récente, donc la base d'utilisateurs est plus petite que Meetup ou Eventbrite.
 
 Quel que soit l'outil, l'essentiel est d'avoir une page claire avec le titre, la date, le lieu et un bouton d'inscription visible.
 
@@ -68,10 +68,10 @@ La promotion est le nerf de la guerre. Voici ce qui fonctionne réellement, et c
 
 **Ce qui fonctionne :**
 
-- **Le bouche-à-oreille** — De loin le canal le plus efficace. Parlez-en à 5 personnes qui en parleront à 5 autres.
-- **Les groupes WhatsApp/Telegram thématiques** — Si vous organisez un meetup Python, le groupe WhatsApp des développeurs Python de votre ville est votre meilleur allié.
-- **LinkedIn** — Un post personnel (pas une page entreprise) avec un texte authentique. Les posts "je lance un meetup, voici pourquoi" fonctionnent bien.
-- **Les communautés Slack/Discord existantes** — Partagez-y votre événement, mais contribuez d'abord. Personne n'aime le spam.
+- **Le bouche-à-oreille.** De loin le canal le plus efficace. Parlez-en à 5 personnes qui en parleront à 5 autres.
+- **Les groupes WhatsApp/Telegram thématiques.** Si vous organisez un meetup Python, le groupe WhatsApp des développeurs Python de votre ville est votre meilleur allié.
+- **LinkedIn.** Un post personnel (pas une page entreprise) avec un texte authentique. Les posts "je lance un meetup, voici pourquoi" fonctionnent bien.
+- **Les communautés Slack/Discord existantes.** Partagez-y votre événement, mais contribuez d'abord. Personne n'aime le spam.
 
 **Ce qui ne fonctionne pas (ou très peu) :**
 
@@ -92,7 +92,7 @@ Quelques conseils pratiques qui font la différence :
 - **Respectez l'horaire.** Commencez à l'heure annoncée, terminez à l'heure annoncée. Les gens ont des vies.
 - **Gardez 15-20 minutes de networking libre** à la fin. C'est souvent là que les meilleures conversations ont lieu.
 
-## Après l'événement — l'étape que tout le monde oublie
+## Après l'événement, l'étape que tout le monde oublie
 
 C'est ici que se joue la différence entre "un événement ponctuel" et "une communauté". La plupart des organisateurs s'arrêtent au jour J. Ne faites pas cette erreur.
 


### PR DESCRIPTION
## Summary
- Supprime toutes les occurrences du caractère "—" (em dash) dans les 10 articles de blog (5 FR + 5 EN)
- Remplacé par des virgules, des points ou des reformulations selon le contexte
- Aucun changement de sens, uniquement de la ponctuation

## Test plan
- [ ] Vérifier le rendu des articles sur la preview Vercel (pages `/blog/*`)
- [ ] Confirmer qu'aucun em dash ne subsiste dans les articles

🤖 Generated with [Claude Code](https://claude.com/claude-code)