### PR TITLE
feat(slack): notifier inscriptions et commentaires sur Slack

### DIFF
--- a/src/app/actions/comment.ts
+++ b/src/app/actions/comment.ts
@@ -13,6 +13,7 @@ import {
 import { createResendEmailService } from "@/infrastructure/services";
 import { addComment } from "@/domain/usecases/add-comment";
 import { deleteComment } from "@/domain/usecases/delete-comment";
+import { notifySlackNewComment } from "@/infrastructure/services/slack/slack-notification-service";
 import type { Comment } from "@/domain/models/comment";
 import type { ActionResult } from "./types";
 import { toActionResult } from "./helpers/to-action-result";
@@ -172,4 +173,12 @@ async function sendCommentNotifications(
       });
     })
   );
+
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
+  await notifySlackNewComment({
+    playerName,
+    momentTitle: moment.title,
+    commentPreview,
+    momentUrl: `${baseUrl}/m/${moment.slug}`,
+  });
 }

--- a/src/app/actions/registration.ts
+++ b/src/app/actions/registration.ts
@@ -25,6 +25,7 @@ import { rejectMomentRegistration } from "@/domain/usecases/reject-moment-regist
 import { toActionResult } from "./helpers/to-action-result";
 import { getDisplayName } from "@/lib/display-name";
 import { formatPrice } from "@/lib/format-price";
+import { notifySlackNewRegistration } from "@/infrastructure/services/slack/slack-notification-service";
 import type { Registration } from "@/domain/models/registration";
 import type { ActionResult } from "./types";
 
@@ -335,6 +336,14 @@ export async function sendRegistrationEmails(
       });
     })
   );
+
+  await notifySlackNewRegistration({
+    playerName,
+    momentTitle: moment.title,
+    circleName: circle.name,
+    registrationInfo,
+    momentUrl: `${baseUrl}/m/${moment.slug}`,
+  });
 }
 
 async function sendPromotionEmail(

--- a/src/infrastructure/services/slack/slack-notification-service.ts
+++ b/src/infrastructure/services/slack/slack-notification-service.ts
@@ -92,6 +92,44 @@ export async function notifySlackTrafficReport(params: {
   });
 }
 
+export async function notifySlackNewRegistration(params: {
+  playerName: string;
+  momentTitle: string;
+  circleName: string;
+  registrationInfo: string;
+  momentUrl: string;
+}): Promise<void> {
+  await sendSlack({
+    text: `🎟️ Nouvelle inscription — ${params.playerName} → ${params.momentTitle}`,
+    blocks: [
+      { type: "header", text: { type: "plain_text", text: "🎟️ Nouvelle inscription", emoji: true } },
+      { type: "section", text: { type: "mrkdwn", text: `*${params.playerName}* s'est inscrit a *${params.momentTitle}*` } },
+      { type: "section", fields: [
+        { type: "mrkdwn", text: `*Communaute*\n${params.circleName}` },
+        { type: "mrkdwn", text: `*Inscriptions*\n${params.registrationInfo}` },
+      ]},
+      { type: "actions", elements: [{ type: "button", text: { type: "plain_text", text: "Voir l'evenement" }, url: params.momentUrl }] },
+    ],
+  });
+}
+
+export async function notifySlackNewComment(params: {
+  playerName: string;
+  momentTitle: string;
+  commentPreview: string;
+  momentUrl: string;
+}): Promise<void> {
+  await sendSlack({
+    text: `💬 Nouveau commentaire — ${params.playerName} sur ${params.momentTitle}`,
+    blocks: [
+      { type: "header", text: { type: "plain_text", text: "💬 Nouveau commentaire", emoji: true } },
+      { type: "section", text: { type: "mrkdwn", text: `*${params.playerName}* a commente sur *${params.momentTitle}*` } },
+      { type: "section", text: { type: "mrkdwn", text: `> ${params.commentPreview}` } },
+      { type: "actions", elements: [{ type: "button", text: { type: "plain_text", text: "Voir l'evenement" }, url: params.momentUrl }] },
+    ],
+  });
+}
+
 export async function notifySlackSentryIssue(params: {
   issueShortId: string;
   issueTitle: string;


### PR DESCRIPTION
## Summary

- Ajoute `notifySlackNewRegistration` — notifie le canal Slack admin quand un Participant s'inscrit à un événement (nom, événement, communauté, compteur inscriptions)
- Ajoute `notifySlackNewComment` — notifie quand un commentaire est posté (auteur, événement, aperçu du contenu)
- Même pattern best-effort que les notifications existantes (silent failure, timeout 5s)

## Test plan

- [ ] S'inscrire à un événement → vérifier le message Slack
- [ ] Poster un commentaire → vérifier le message Slack
- [ ] Vérifier que l'app fonctionne sans `SLACK_ADMIN_WEBHOOK_URL` (silent skip)
- [ ] TypeScript typecheck passe

🤖 Generated with [Claude Code](https://claude.com/claude-code)