### PR TITLE
feat: photos dans les commentaires

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -123,7 +123,9 @@
     "you": "You",
     "demo": "Demo",
     "copyLink": "Copy link",
-    "copied": "Copied!"
+    "copied": "Copied!",
+    "close": "Close",
+    "openInNewTab": "Open in new tab"
   },
   "Auth": {
     "signIn": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -1526,7 +1526,11 @@
       },
       "comments": {
         "title": "Comments",
-        "intro": "Each event has a <strong>comment thread</strong>. You can ask questions, share your excitement, or chat with other attendees. Comments are visible to all registered members and the organizer."
+        "intro": "Each event has a <strong>comment thread</strong>. You can ask questions, share your excitement, or chat with other attendees. Comments are visible to all registered members and the organizer.",
+        "photosLabel": "Photos in comments:",
+        "photos1": "You can <strong>add up to 3 photos</strong> to each comment (JPG, PNG, WebP)",
+        "photos2": "Large photos are <strong>automatically compressed</strong> for fast upload, even from a phone",
+        "photos3": "Click a photo to enlarge it"
       },
       "mySpace": {
         "title": "My Dashboard",

--- a/messages/en.json
+++ b/messages/en.json
@@ -499,6 +499,7 @@
       "rateLimitReached": "Daily limit reached — {limit} analyses maximum per day. Come back tomorrow.",
       "sources": "Sources: Luma · Eventbrite · Meetup",
       "close": "Close",
+      "openInNewTab": "Open in new tab",
       "cityLabel": "in {city}",
       "badgeNew": "NEW",
       "analyzeShort": "Analyze",

--- a/messages/en.json
+++ b/messages/en.json
@@ -639,7 +639,14 @@
       "justNow": "Just now",
       "minutesAgo": "{count}m ago",
       "hoursAgo": "{count}h ago",
-      "daysAgo": "{count}d ago"
+      "daysAgo": "{count}d ago",
+      "addPhotos": "Add photos",
+      "addPhotosDisabled": "3 photos limit reached",
+      "removePhoto": "Remove this photo",
+      "photoTypeError": "Unsupported format. JPG, PNG or WebP only.",
+      "photoTooLargeError": "Photo too large, even after compression.",
+      "photoUploadError": "Failed to send. Try again.",
+      "photoCount": "{count}/3 photos"
     },
     "empty": {
       "description": "No Events yet. Create your first event."

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -499,6 +499,7 @@
       "rateLimitReached": "Limite atteinte — {limit} analyses par jour maximum. Revenez demain.",
       "sources": "Sources : Luma · Eventbrite · Meetup",
       "close": "Fermer",
+      "openInNewTab": "Ouvrir dans un nouvel onglet",
       "cityLabel": "dans {city}",
       "badgeNew": "NOUVEAU",
       "analyzeShort": "Analyser",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -639,7 +639,14 @@
       "justNow": "À l'instant",
       "minutesAgo": "Il y a {count}min",
       "hoursAgo": "Il y a {count}h",
-      "daysAgo": "Il y a {count}j"
+      "daysAgo": "Il y a {count}j",
+      "addPhotos": "Ajouter des photos",
+      "addPhotosDisabled": "Limite de 3 photos atteinte",
+      "removePhoto": "Retirer cette photo",
+      "photoTypeError": "Format non supporté. JPG, PNG ou WebP uniquement.",
+      "photoTooLargeError": "Photo trop volumineuse, même après compression.",
+      "photoUploadError": "Erreur lors de l'envoi. Réessayez.",
+      "photoCount": "{count}/3 photos"
     },
     "empty": {
       "description": "Aucun événement pour le moment. Créez votre premier événement."

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -123,7 +123,9 @@
     "you": "Vous",
     "demo": "Démo",
     "copyLink": "Copier le lien",
-    "copied": "Copié !"
+    "copied": "Copié !",
+    "close": "Fermer",
+    "openInNewTab": "Ouvrir dans un nouvel onglet"
   },
   "Auth": {
     "signIn": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1526,7 +1526,11 @@
       },
       "comments": {
         "title": "Les commentaires",
-        "intro": "Chaque événement dispose d'un <strong>fil de commentaires</strong>. Vous pouvez poser des questions, partager votre enthousiasme, ou échanger avec d'autres participants. Les commentaires sont visibles par tous les inscrits et par l'organisateur."
+        "intro": "Chaque événement dispose d'un <strong>fil de commentaires</strong>. Vous pouvez poser des questions, partager votre enthousiasme, ou échanger avec d'autres participants. Les commentaires sont visibles par tous les inscrits et par l'organisateur.",
+        "photosLabel": "Photos dans les commentaires :",
+        "photos1": "Vous pouvez <strong>ajouter jusqu'à 3 photos</strong> à chaque commentaire (JPG, PNG, WebP)",
+        "photos2": "Les photos volumineuses sont <strong>automatiquement compressées</strong> pour un envoi rapide, même depuis un téléphone",
+        "photos3": "Cliquez sur une photo pour l'agrandir"
       },
       "mySpace": {
         "title": "Mon espace",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -324,12 +324,29 @@ model Comment {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  moment Moment @relation(fields: [momentId], references: [id], onDelete: Cascade)
-  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  moment      Moment              @relation(fields: [momentId], references: [id], onDelete: Cascade)
+  user        User                @relation(fields: [userId], references: [id], onDelete: Cascade)
+  attachments CommentAttachment[]
 
   // Index sur momentId : utilisé dans findByMomentIdWithUser, countByMomentId
   @@index([momentId])
   @@map("comments")
+}
+
+model CommentAttachment {
+  id          String   @id @default(cuid())
+  commentId   String
+  url         String
+  filename    String
+  contentType String
+  sizeBytes   Int
+  createdAt   DateTime @default(now())
+
+  comment Comment @relation(fields: [commentId], references: [id], onDelete: Cascade)
+
+  // Index sur commentId : utilisé dans findByComment
+  @@index([commentId])
+  @@map("comment_attachments")
 }
 
 model RadarUsage {

--- a/spec/BACKLOG.md
+++ b/spec/BACKLOG.md
@@ -267,6 +267,7 @@
 | P-06 | **Export données Organisateur étendu** | CSV membres Communauté, historique événements, inscrits cumulés. L'export CSV inscrits par événement existe déjà. | — |
 | P-07 | **Assistant IA basique** | Description événement, email invitation, suggestions Communauté. SDK Anthropic (Claude). | — |
 | P-08 | **Stats Communauté basiques** | Métriques sur la page Communauté Organisateur (tendance membres, taux de remplissage, etc.). | — |
+| P-09 | **Notification désinscription (opt-in Organisateur)** | Option dans le profil Organisateur pour recevoir (ou non) une notification quand un Participant se désinscrit d'un événement gratuit. Actuellement seuls les événements payants notifient l'Organisateur. Alignement Meetup (qui notifie systématiquement). | — |
 
 ---
 
@@ -305,6 +306,7 @@
 - [ ] **Check-in** — Marquer présent sur place (retiré du MVP v1)
 - [ ] **Galerie photos post-événement** — Upload par Participants et Organisateur après un événement PAST. Galerie sur `/m/[slug]` et page Communauté. Modération par l'Organisateur. CTA "Voir les photos" dans l'email post-événement. Infrastructure `StorageService` (Vercel Blob) déjà en place.
 - [ ] **Dupliquer un événement** — Bouton "Dupliquer" sur un événement existant pour pré-remplir le formulaire de création avec les mêmes infos (titre, lieu, description, capacité, prix). Gain de temps pour les événements récurrents similaires.
+- [ ] **API publique v1** — Permettre aux organisateurs de créer/gérer des événements et récupérer les données via API REST + webhooks sortants. Débloque les intégrations avec des systèmes internes (automatisation, CRM, bots). Spec : `spec/features/public-api-v1.md`
 - [ ] **Plan Pro** — Analytics avancés, branding personnalisé, IA avancée, API, notifications multi-canal
 - [ ] **Suppression lien d'invitation** — Remplacer le système de token par email uniquement — `spec/features/remove-invite-token.md`
 - [ ] **White-label / mono-community** — `spec/product/white-label-mono-community.md`

--- a/spec/features/comment-photos.md
+++ b/spec/features/comment-photos.md
@@ -1,0 +1,751 @@
+# Photos dans les commentaires — Spec
+
+> Permettre à tout inscrit de joindre jusqu'à 3 photos à un commentaire sur un événement. Les photos lourdes sont automatiquement redimensionnées côté client pour une friction zéro, y compris depuis un téléphone.
+
+---
+
+## Vision produit
+
+Le fil de commentaires est aujourd'hui en texte pur. C'est suffisant pour les échanges simples, mais limitant pour les événements communautaires où les participants veulent :
+
+- **Partager des photos de l'événement** (ambiance, groupe, lieu)
+- **Poser une question visuelle** ("c'est bien ici ?" + photo de l'entrée)
+- **Montrer un résultat** (atelier cuisine, hackathon, sport)
+- **Remercier l'organisateur** avec une photo souvenir
+
+Ces photos sont les meilleures preuves sociales possibles. Elles transforment un fil de commentaires en mémoire collective de l'événement, et donnent envie aux futurs participants de rejoindre la Communauté.
+
+### Positionnement
+
+- **Simple comme un message** : joindre une photo doit être aussi naturel que dans WhatsApp ou iMessage. Pas de formulaire d'upload, pas de galerie dédiée, juste un bouton photo à côté du textarea.
+- **Mobile-first** : le parcours Participant passe par mobile (lien partagé via WhatsApp/Instagram). Les photos viennent de la galerie du téléphone, elles sont souvent lourdes (5 à 15 Mo sur un iPhone). Le redimensionnement automatique élimine cette friction.
+- **Le texte reste central** : un commentaire nécessite toujours du texte. Les photos enrichissent le message, elles ne le remplacent pas.
+- **Intégré, pas séparé** : les photos font partie du commentaire. Pas de galerie photos dédiée, pas d'album. La suppression d'un commentaire supprime ses photos.
+
+---
+
+## Règles produit
+
+| Règle | Valeur |
+| --- | --- |
+| **Nombre maximum** | 3 photos par commentaire |
+| **Texte obligatoire** | Oui (min 1 caractère après trim, max 2000 comme aujourd'hui) |
+| **Types acceptés** | JPEG, PNG, WebP (images uniquement, pas de PDF) |
+| **Redimensionnement automatique** | Côté client, si le fichier dépasse 3 Mo |
+| **Taille maximum serveur** | 5 Mo par photo (filet de sécurité post-resize) |
+| **Qui peut poster** | Tout utilisateur inscrit (identique aux commentaires texte) |
+| **Qui peut supprimer** | L'auteur du commentaire ou un Organisateur (HOST) du Circle |
+| **Granularité de suppression** | Le commentaire entier uniquement (pas de suppression photo individuelle) |
+| **Ordre d'affichage** | Par date d'ajout du commentaire (inchangé) |
+| **Visibilité** | Publique (même visibilité que les commentaires texte) |
+| **Upload** | Atomique avec le commentaire (texte + photos envoyés ensemble) |
+
+### Redimensionnement automatique côté client
+
+La fonction `resizeImage()` existante (`src/lib/image-resize.ts`) est réutilisée mais doit être étendue pour supporter un mode **non carré** (les photos de commentaires ne sont pas des avatars ni des covers).
+
+**Nouvelle fonction ****`compressCommentPhoto()`** :
+
+| Paramètre | Valeur |
+| --- | --- |
+| **Déclencheur** | Le fichier source dépasse 3 Mo |
+| **Si fichier ≤ 3 Mo** | Aucune transformation, envoi tel quel |
+| **Dimension max** | 1920px (le côté le plus long est ramené à 1920px, ratio préservé) |
+| **Qualité** | 0.8 (80%) |
+| **Format de sortie** | WebP (fallback JPEG si non supporté) |
+| **Crop** | Aucun (ratio d'origine conservé, contrairement aux covers) |
+| **Résultat typique** | Photo iPhone 12 Mo → ~200-400 Ko en WebP 1920px |
+
+La différence clé avec `resizeImage()` : pas de crop carré, ratio préservé, et déclenchement conditionnel (seulement si > 3 Mo). L'utilitaire existant fait un centre-crop carré adapté aux avatars/covers mais inadapté aux photos libres.
+
+### Validation côté serveur
+
+- Type MIME vérifié par magic bytes (`fileTypeFromBuffer` de `file-type`), pas le header déclaré
+- Taille re-vérifiée après upload (max 5 Mo)
+- Nombre total par commentaire vérifié (max 3)
+- Même contrôle d'accès que pour poster un commentaire texte (authentifié + non PENDING_APPROVAL)
+
+### Validation côté client
+
+- Feedback immédiat sur type/taille avant envoi
+- Redimensionnement transparent si > 3 Mo (pas de message d'erreur, juste une compression silencieuse)
+- Messages d'erreur inline si type non supporté ou si > 5 Mo après compression
+
+---
+
+## UX — Formulaire de commentaire (saisie)
+
+### État actuel
+
+```
+┌─────────────────────────────────────────────────┐
+│ [textarea placeholder]                          │
+│                                                 │
+│                                                 │
+├─────────────────────────────────────────────────┤
+│ 0 / 2000                          [Commenter]  │
+└─────────────────────────────────────────────────┘
+```
+
+### Nouvel état avec bouton photo
+
+```
+┌─────────────────────────────────────────────────┐
+│ [textarea placeholder]                          │
+│                                                 │
+│                                                 │
+├─────────────────────────────────────────────────┤
+│ 📷  0 / 2000                      [Commenter]  │
+└─────────────────────────────────────────────────┘
+```
+
+Le bouton photo (`ImagePlus` icon de Lucide, `size-5`, `text-muted-foreground hover:text-foreground`) est placé à gauche du compteur de caractères. Il déclenche un `<input type="file" accept="image/*" multiple>` caché.
+
+### État avec photos sélectionnées (avant envoi)
+
+```
+┌─────────────────────────────────────────────────┐
+│ Super soirée, merci pour l'organisation !       │
+│                                                 │
+│                                                 │
+├─────────────────────────────────────────────────┤
+│ ┌──────┐ ┌──────┐ ┌──────┐                     │
+│ │ img1 │ │ img2 │ │ img3 │   (miniatures)      │
+│ │  [×]  │ │  [×]  │ │  [×]  │                     │
+│ └──────┘ └──────┘ └──────┘                     │
+├─────────────────────────────────────────────────┤
+│ 📷  42 / 2000                     [Commenter]  │
+└─────────────────────────────────────────────────┘
+```
+
+### Détails des miniatures (previews)
+
+| Élément | Valeur |
+| --- | --- |
+| Taille miniature | `w-16 h-16` (64x64px) sur mobile, `w-20 h-20` (80x80px) sur desktop |
+| Style | `rounded-lg object-cover` (les photos sont croppées visuellement en carré pour la preview, mais stockées en ratio original) |
+| Bouton supprimer | Icône `X` en `absolute top-0 right-0`, `size-4`, cercle `bg-black/60 text-white hover:bg-black/80`, supprime la photo de la sélection (avant envoi) |
+| Conteneur | `flex gap-2 px-3 py-2` entre le textarea et la barre d'action |
+| Limite atteinte | Si 3 photos, le bouton photo (`ImagePlus`) passe en `opacity-50 cursor-not-allowed` et ne déclenche plus l'input file |
+| Animation | Les miniatures apparaissent avec un léger `animate-in fade-in` |
+
+### État pendant l'envoi
+
+Le bouton "Commenter" est disabled et affiche le loader. Les miniatures restent visibles. Pas de progress bar individuelle par photo (l'envoi est atomique).
+
+### Messages d'erreur inline
+
+| Cas | Message |
+| --- | --- |
+| Type non supporté | "Format non supporté. JPG, PNG ou WebP uniquement." |
+| Photo > 5 Mo après compression | "Photo trop volumineuse, même après compression." |
+| Limite 3 photos atteinte | (pas de message, bouton grisé suffit) |
+| Erreur réseau | "Erreur lors de l'envoi. Réessayez." |
+
+### Accessibilité
+
+- Le bouton photo a un `aria-label` : "Ajouter des photos" / "Add photos"
+- Le bouton photo grisé a un `aria-disabled="true"`
+- Les miniatures sont dans un `role="list"` avec `role="listitem"`
+- Chaque bouton supprimer a un `aria-label` : "Retirer cette photo" / "Remove this photo"
+- `accept="image/*"` sur l'input file (filtre natif du sélecteur de fichiers)
+
+---
+
+## UX — Affichage des photos dans un commentaire posté
+
+### Commentaire avec photos
+
+```
+┌─ Avatar ─── Nom · il y a 5 min · Supprimer ────┐
+│                                                  │
+│  Super soirée, merci pour l'organisation !       │
+│                                                  │
+│  ┌──────────┐ ┌──────────┐ ┌──────────┐        │
+│  │          │ │          │ │          │         │
+│  │  photo1  │ │  photo2  │ │  photo3  │         │
+│  │          │ │          │ │          │         │
+│  └──────────┘ └──────────┘ └──────────┘        │
+│                                                  │
+└──────────────────────────────────────────────────┘
+```
+
+### Détails de l'affichage — plusieurs photos (2 ou 3)
+
+Les vignettes sont **toujours carrées** (`object-cover` crop visuel), quelle que soit la forme de la photo originale. Cela garantit un alignement propre dans le fil de commentaires.
+
+| Élément | Valeur |
+| --- | --- |
+| Position | Sous le texte du commentaire, avec `mt-2` |
+| Conteneur | `flex gap-2 flex-wrap` |
+| Taille | `w-24 h-24` (96x96px) mobile, `w-32 h-32` (128x128px) desktop |
+| Style image | `rounded-lg object-cover cursor-pointer` — le `object-cover` + dimensions carrées forcent un crop visuel centré, la photo originale est stockée en ratio libre |
+| Hover desktop | `hover:opacity-90 transition-opacity ring-2 ring-transparent hover:ring-primary/30` |
+| Click | Ouvre la photo en lightbox (plein écran, ratio original) |
+| Alt text | Le filename original (sans extension), ex: "IMG_2847" |
+
+### Détails de l'affichage — une seule photo (exception)
+
+Quand un commentaire n'a qu'**une seule photo**, elle est affichée en **ratio libre** (pas de crop carré). Cela donne plus de place à la photo et un rendu plus naturel quand il n'y a pas besoin d'aligner plusieurs vignettes.
+
+| Élément | Valeur |
+| --- | --- |
+| Taille | `max-w-xs` (~320px de large), hauteur auto (ratio préservé) |
+| Style image | `rounded-lg object-cover cursor-pointer` — mais **sans dimensions carrées forcées**, le ratio original est visible |
+| Hover / Click / Alt | Identiques aux vignettes multiples |
+
+### Lightbox (viewer plein écran)
+
+Réutiliser le composant `AttachmentViewerDialog` existant (`src/components/moments/attachment-viewer-dialog.tsx`) en mode image. La lightbox affiche **toujours** la photo en ratio original, que la vignette soit carrée ou non. Comportements :
+
+- Overlay sombre, photo centrée en `max-w-full max-h-[90vh] object-contain`
+- Bouton fermer (`X`) en haut à droite
+- Fermeture via Escape, clic sur l'overlay, ou bouton `X`
+- **Pas de navigation entre photos** (V1). L'utilisateur ferme et clique sur la suivante.
+- **Pas de bouton télécharger** (V1). Les photos de commentaires sont de la social proof, pas des livrables.
+
+### Commentaire texte seul (inchangé)
+
+Aucun changement visuel pour les commentaires sans photo. Pas de placeholder "Aucune photo" ni d'espace réservé.
+
+---
+
+## Architecture technique
+
+### Modèle de données
+
+Nouvelle table `comment_attachments` :
+
+```prisma
+model CommentAttachment {
+  id          String   @id @default(cuid())
+  commentId   String
+  url         String                          // URL Vercel Blob
+  filename    String                          // Nom original
+  contentType String                          // image/jpeg, image/png, image/webp
+  sizeBytes   Int
+  createdAt   DateTime @default(now())
+
+  comment Comment @relation(fields: [commentId], references: [id], onDelete: Cascade)
+
+  @@index([commentId])
+  @@map("comment_attachments")
+}
+```
+
+Relation inverse sur Comment :
+
+```prisma
+// Ajout dans model Comment
+attachments CommentAttachment[]
+```
+
+**Pas de backfill** : table nouvelle, les commentaires existants n'ont simplement pas d'attachments.
+
+### Architecture hexagonale
+
+| Couche | Fichier | Responsabilité |
+| --- | --- | --- |
+| **Domain model** | `domain/models/comment-attachment.ts` | Type `CommentAttachment`, constantes (`MAX_COMMENT_PHOTOS`, `MAX_COMMENT_PHOTO_SIZE_BYTES`, `ALLOWED_COMMENT_PHOTO_TYPES`) |
+| **Domain model** | `domain/models/comment.ts` | Enrichir `CommentWithUser` avec `attachments: CommentAttachment[]` |
+| **Domain errors** | `domain/errors/comment-attachment-errors.ts` | `CommentPhotoLimitReachedError`, `CommentPhotoTooLargeError`, `CommentPhotoTypeNotAllowedError` |
+| **Domain port** | `domain/ports/repositories/comment-attachment-repository.ts` | Interface `CommentAttachmentRepository` |
+| **Domain usecase** | `domain/usecases/add-comment.ts` | Modifier pour accepter des photos en entrée (upload atomique) |
+| **Domain usecase** | `domain/usecases/delete-comment.ts` | Modifier pour supprimer les blobs associés |
+| **Infra repository** | `infrastructure/repositories/prisma-comment-attachment-repository.ts` | Implémentation Prisma |
+| **Infra repository** | `infrastructure/repositories/prisma-comment-repository.ts` | Modifier `findByMomentIdWithUser` pour inclure les attachments |
+| **App action** | `app/actions/comment.ts` | Modifier `addCommentAction` pour accepter `FormData`, modifier `deleteCommentAction` pour nettoyer les blobs |
+| **Lib (refactor)** | `lib/sanitize-filename.ts` | Extraire `sanitizeFilename()` depuis `add-moment-attachment.ts` vers un utilitaire partagé. Mettre à jour l'import dans `add-moment-attachment.ts`. |
+| **UI utility** | `lib/image-compress.ts` | Nouvelle fonction `compressCommentPhoto()` (compression conditionnelle, ratio préservé) |
+| **UI component** | `components/moments/comment-thread.tsx` | Enrichir avec bouton photo, previews, affichage photos, enrichir PostHog `comment_posted` avec `photo_count` |
+
+### Flux d'upload atomique
+
+```
+1. Participant sélectionne des photos dans le CommentThread
+   → Client : compressCommentPhoto() si > 3 Mo (Canvas API, ratio préservé, max 1920px, WebP)
+   → Client : preview miniature locale (URL.createObjectURL)
+
+2. Participant clique "Commenter"
+   → Client : construit un FormData { content: string, photo-0: File, photo-1: File, ... }
+   → Client : appelle addCommentAction(momentId, formData)
+
+3. Server action addCommentAction
+   → Auth check
+   → Rate limit (même pool que les commentaires texte, pas un rate limit séparé)
+   → Pour chaque photo : fileTypeFromBuffer() → validation MIME + taille
+   → Appelle addComment() usecase avec les fichiers validés
+   → Le usecase crée le commentaire ET les attachments en séquence :
+     a. Crée le Comment en DB
+     b. Pour chaque photo : upload Vercel Blob → crée CommentAttachment en DB
+   → revalidatePath
+
+4. Si une photo échoue à l'upload :
+   → Le commentaire est déjà créé (avec les photos précédentes)
+   → Log l'erreur dans Sentry
+   → Le commentaire apparaît avec les photos qui ont réussi
+   → Pas de rollback (cohérence : mieux vaut un commentaire partiel qu'aucun commentaire)
+```
+
+### Modification du usecase `addComment`
+
+Le usecase `addComment` est enrichi pour accepter des fichiers optionnels :
+
+```typescript
+type AddCommentInput = {
+  momentId: string;
+  userId: string;
+  content: string;
+  photos?: {
+    buffer: Buffer;
+    filename: string;
+    contentType: string;
+    sizeBytes: number;
+  }[];
+};
+
+type AddCommentDeps = {
+  commentRepository: CommentRepository;
+  momentRepository: MomentRepository;
+  registrationRepository?: RegistrationRepository;
+  // Nouveaux deps optionnels (absents = pas de photos)
+  commentAttachmentRepository?: CommentAttachmentRepository;
+  storage?: StorageService;
+};
+```
+
+La logique ajoutée (en deux phases : **validation avant création, upload après**) :
+
+```typescript
+// ── Phase 1 : validation de TOUTES les photos AVANT de créer le commentaire ──
+// On échoue vite et proprement, sans side-effect en DB ni en storage.
+if (input.photos?.length && commentAttachmentRepository && storage) {
+  if (input.photos.length > MAX_COMMENT_PHOTOS) {
+    throw new CommentPhotoLimitReachedError(MAX_COMMENT_PHOTOS);
+  }
+  for (const photo of input.photos) {
+    if (!ALLOWED_COMMENT_PHOTO_TYPES.has(photo.contentType)) {
+      throw new CommentPhotoTypeNotAllowedError(photo.contentType);
+    }
+    if (photo.sizeBytes > MAX_COMMENT_PHOTO_SIZE_BYTES) {
+      throw new CommentPhotoTooLargeError(MAX_COMMENT_PHOTO_SIZE_BYTES);
+    }
+  }
+}
+
+// Création du commentaire (existant, inchangé)
+const comment = await commentRepository.create({ ... });
+
+// ── Phase 2 : upload des photos (toutes validées, commentaire créé) ──
+// Les erreurs ici sont des erreurs réseau/blob, pas des erreurs de validation.
+// En cas d'échec partiel : le commentaire existe avec les photos déjà uploadées.
+// Mieux vaut un commentaire partiel qu'aucun commentaire.
+if (input.photos?.length && commentAttachmentRepository && storage) {
+  for (const photo of input.photos) {
+    const safeName = sanitizeFilename(photo.filename);
+    const path = `comment-photos/${comment.id}-${Date.now()}-${safeName}`;
+    const url = await storage.upload(path, photo.buffer, photo.contentType);
+
+    await commentAttachmentRepository.create({
+      commentId: comment.id,
+      url,
+      filename: photo.filename,
+      contentType: photo.contentType,
+      sizeBytes: photo.sizeBytes,
+    });
+  }
+}
+```
+
+Les nouvelles dépendances sont optionnelles : les tests existants de `addComment` continuent de fonctionner sans modification (pas de photos = ancien comportement).
+
+### Modification du usecase `deleteComment`
+
+Le usecase `deleteComment` doit nettoyer les blobs des photos :
+
+```typescript
+type DeleteCommentDeps = {
+  commentRepository: CommentRepository;
+  momentRepository: MomentRepository;
+  circleRepository: CircleRepository;
+  // Nouveaux deps optionnels
+  commentAttachmentRepository?: CommentAttachmentRepository;
+  storage?: StorageService;
+};
+```
+
+Avant la suppression du commentaire en DB :
+
+```typescript
+// Supprimer les blobs des photos (best-effort, log les erreurs)
+if (commentAttachmentRepository && storage) {
+  const attachments = await commentAttachmentRepository.findByComment(comment.id);
+  for (const att of attachments) {
+    try {
+      await storage.delete(att.url);
+    } catch (err) {
+      // Log mais ne bloque pas la suppression
+      console.error(`Failed to delete blob for comment attachment ${att.id}`, err);
+    }
+  }
+}
+// La suppression du commentaire en DB cascade sur comment_attachments
+await commentRepository.delete(input.commentId);
+```
+
+### Modification de `addCommentAction` (server action)
+
+La signature passe de `(momentId, content)` à `(momentId, formData)` :
+
+```typescript
+export async function addCommentAction(
+  momentId: string,
+  formData: FormData
+): Promise<ActionResult<Comment>> {
+  const session = await auth();
+  if (!session?.user?.id) { ... }
+
+  const content = formData.get("content") as string;
+  const photoFiles: File[] = [];
+  for (let i = 0; i < 3; i++) {
+    const f = formData.get(`photo-${i}`) as File | null;
+    if (f && f.size > 0) photoFiles.push(f);
+  }
+
+  // Validation et détection MIME pour chaque photo
+  const photos = await Promise.all(
+    photoFiles.map(async (file) => {
+      const buffer = Buffer.from(await file.arrayBuffer());
+      const detected = await fileTypeFromBuffer(buffer);
+      if (!detected || !ALLOWED_COMMENT_PHOTO_TYPES.has(detected.mime)) {
+        throw new CommentPhotoTypeNotAllowedError(detected?.mime ?? "unknown");
+      }
+      if (buffer.length > MAX_COMMENT_PHOTO_SIZE_BYTES) {
+        throw new CommentPhotoTooLargeError(MAX_COMMENT_PHOTO_SIZE_BYTES);
+      }
+      return {
+        buffer,
+        filename: file.name,
+        contentType: detected.mime,
+        sizeBytes: buffer.length,
+      };
+    })
+  );
+
+  return toActionResult(async () => {
+    const result = await addComment(
+      { momentId, userId, content, photos },
+      {
+        commentRepository: prismaCommentRepository,
+        momentRepository: prismaMomentRepository,
+        registrationRepository: prismaRegistrationRepository,
+        commentAttachmentRepository: prismaCommentAttachmentRepository,
+        storage: vercelBlobStorageService,
+      }
+    );
+    // Notifications (inchangées)
+    // ...
+    return result.comment;
+  });
+}
+```
+
+### Port `CommentAttachmentRepository`
+
+```typescript
+// src/domain/ports/repositories/comment-attachment-repository.ts
+
+export type CreateCommentAttachmentInput = {
+  commentId: string;
+  url: string;
+  filename: string;
+  contentType: string;
+  sizeBytes: number;
+};
+
+export interface CommentAttachmentRepository {
+  create(input: CreateCommentAttachmentInput): Promise<CommentAttachment>;
+  findByComment(commentId: string): Promise<CommentAttachment[]>;
+  deleteByComment(commentId: string): Promise<void>;
+}
+```
+
+### Constantes du domaine
+
+```typescript
+// src/domain/models/comment-attachment.ts
+
+export type CommentAttachment = {
+  id: string;
+  commentId: string;
+  url: string;
+  filename: string;
+  contentType: string;
+  sizeBytes: number;
+  createdAt: Date;
+};
+
+export const MAX_COMMENT_PHOTOS = 3;
+export const MAX_COMMENT_PHOTO_SIZE_BYTES = 5 * 1024 * 1024; // 5 Mo
+export const CLIENT_COMPRESS_THRESHOLD_BYTES = 3 * 1024 * 1024; // 3 Mo
+
+export const ALLOWED_COMMENT_PHOTO_TYPES: ReadonlySet<string> = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+]);
+```
+
+### Utilitaire client `compressCommentPhoto()`
+
+```typescript
+// src/lib/image-compress.ts
+
+/**
+ * Compresse une photo de commentaire si elle dépasse le seuil de 3 Mo.
+ * Contrairement à resizeImage() (crop carré pour avatars/covers),
+ * cette fonction préserve le ratio d'origine.
+ *
+ * - Si le fichier ≤ 3 Mo → retourné tel quel
+ * - Si > 3 Mo → redimensionné (max 1920px côté long), qualité 0.8, WebP
+ * - Le ratio d'origine est TOUJOURS préservé (pas de crop)
+ */
+export async function compressCommentPhoto(file: File): Promise<Blob> {
+  if (file.size <= CLIENT_COMPRESS_THRESHOLD_BYTES) {
+    return file;
+  }
+
+  const maxDimension = 1920;
+  const quality = 0.8;
+  const format = "image/webp";
+
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    const objectUrl = URL.createObjectURL(file);
+
+    img.onload = () => {
+      URL.revokeObjectURL(objectUrl);
+      const { naturalWidth: w, naturalHeight: h } = img;
+
+      // Scale down: le côté le plus long → maxDimension, ratio préservé
+      let targetW = w;
+      let targetH = h;
+      if (w > maxDimension || h > maxDimension) {
+        if (w >= h) {
+          targetW = maxDimension;
+          targetH = Math.round(h * (maxDimension / w));
+        } else {
+          targetH = maxDimension;
+          targetW = Math.round(w * (maxDimension / h));
+        }
+      }
+
+      const canvas = document.createElement("canvas");
+      canvas.width = targetW;
+      canvas.height = targetH;
+      const ctx = canvas.getContext("2d");
+      if (!ctx) { reject(new Error("Canvas 2D context unavailable")); return; }
+
+      ctx.drawImage(img, 0, 0, targetW, targetH);
+
+      canvas.toBlob(
+        (blob) => {
+          if (blob) { resolve(blob); }
+          else {
+            // Fallback JPEG
+            canvas.toBlob(
+              (fb) => fb ? resolve(fb) : reject(new Error("Export failed")),
+              "image/jpeg",
+              quality
+            );
+          }
+        },
+        format,
+        quality
+      );
+    };
+
+    img.onerror = () => { URL.revokeObjectURL(objectUrl); reject(new Error("Image load failed")); };
+    img.src = objectUrl;
+  });
+}
+```
+
+### Réutilisation des briques existantes
+
+| Brique | Source | Usage |
+| --- | --- | --- |
+| `StorageService` (port) | `domain/ports/services/storage-service.ts` | Tel quel, même interface `upload()`/`delete()` |
+| `VercelBlobStorageService` (adapter) | `infrastructure/services/storage/vercel-blob-storage-service.ts` | Tel quel |
+| `isUploadedUrl()` | `lib/blob.ts` | Pour le cleanup des blobs dans `deleteComment` |
+| `fileTypeFromBuffer` | `file-type` (dépendance existante) | Validation MIME serveur |
+| `sanitizeFilename()` | Pattern de `add-moment-attachment.ts` | Copier la même logique pour les noms de fichiers photos |
+| `AttachmentViewerDialog` | `components/moments/attachment-viewer-dialog.tsx` | Lightbox plein écran pour agrandir les photos |
+| `isImageAttachment()` | `components/moments/attachment-format.ts` | Détection image pour le rendu |
+| `formatAttachmentSize()` | `components/moments/attachment-format.ts` | Affichage taille si nécessaire |
+| `toActionResult()` | `app/actions/helpers/to-action-result.ts` | Pattern de gestion d'erreur des server actions |
+
+### Convention de stockage Vercel Blob
+
+Les photos sont stockées avec le préfixe `comment-photos/` :
+
+```
+comment-photos/{commentId}-{timestamp}-{sanitized-filename}
+```
+
+Exemples :
+- `comment-photos/cm1abc-1713024000000-img-2847.webp`
+- `comment-photos/cm1abc-1713024000001-photo-soiree.jpeg`
+
+### Sécurité
+
+- **MIME par magic bytes** : le type réel est détecté par `fileTypeFromBuffer()`, le content-type déclaré par le client est ignoré
+- **Taille re-vérifiée** : côté serveur après lecture du buffer (le client peut mentir ou la compression peut échouer)
+- **Pas de XSS** : les filenames sont affichés via React (échappement natif), jamais via `dangerouslySetInnerHTML`
+- **Rate limiting** : même pool que le commentaire texte (pas de rate limit séparé pour les photos), via le rate limiter existant si ajouté aux commentaires à l'avenir
+- **Accès PENDING\_APPROVAL bloqué** : le check existant dans `addComment` bloque aussi l'envoi de photos (même code path)
+- **Cleanup blobs** : les blobs sont supprimés best-effort à la suppression du commentaire. Le `onDelete: Cascade` en Prisma supprime les lignes DB automatiquement.
+- **Pas d'exécution de code** : seuls les types image sont acceptés (JPEG, PNG, WebP). Pas de SVG (vecteur d'attaque XSS), pas de PDF, pas de format exécutable.
+
+### Analytics (PostHog)
+
+L'event `comment_posted` existant est enrichi avec le nombre de photos :
+
+```typescript
+posthog.capture("comment_posted", {
+  moment_id: momentId,
+  photo_count: photoFiles.length,  // 0 si commentaire texte seul
+});
+```
+
+Cela permet de mesurer l'adoption de la feature (% de commentaires avec photos, distribution du nombre de photos).
+
+---
+
+## i18n — Clés à ajouter
+
+Dans le namespace `Moment.comments` existant (FR et EN) :
+
+### Français
+
+```json
+{
+  "comments": {
+    "addPhotos": "Ajouter des photos",
+    "addPhotosDisabled": "Limite de 3 photos atteinte",
+    "removePhoto": "Retirer cette photo",
+    "photoTypeError": "Format non supporté. JPG, PNG ou WebP uniquement.",
+    "photoTooLargeError": "Photo trop volumineuse, même après compression.",
+    "photoUploadError": "Erreur lors de l'envoi. Réessayez.",
+    "photoCount": "{count}/3 photos"
+  }
+}
+```
+
+### Anglais
+
+```json
+{
+  "comments": {
+    "addPhotos": "Add photos",
+    "addPhotosDisabled": "3 photos limit reached",
+    "removePhoto": "Remove this photo",
+    "photoTypeError": "Unsupported format. JPG, PNG or WebP only.",
+    "photoTooLargeError": "Photo too large, even after compression.",
+    "photoUploadError": "Failed to send. Try again.",
+    "photoCount": "{count}/3 photos"
+  }
+}
+```
+
+---
+
+## Stratégie de tests
+
+### Tests unitaires (Vitest, domain/)
+
+**`add-comment.test.ts`** (enrichir les tests existants) :
+
+- Given valid content + 2 valid photos → should create comment + 2 attachments
+- Given valid content + 0 photos → should create comment only (rétro-compatible)
+- Given 4 photos → should throw `CommentPhotoLimitReachedError`
+- Given photo with `image/gif` type → should throw `CommentPhotoTypeNotAllowedError`
+- Given photo > 5 Mo → should throw `CommentPhotoTooLargeError`
+- Given valid photos but empty content → should throw `CommentContentEmptyError` (texte obligatoire)
+- `test.each` sur les types autorisés/refusés : JPEG oui, PNG oui, WebP oui, GIF non, PDF non, SVG non
+- `test.each` sur les tailles limites : 5 Mo exact oui, 5 Mo + 1 byte non
+- Given valid photos + valid content but 4 photos → should throw BEFORE creating the comment (aucun side-effect en DB)
+- Given user with PENDING_APPROVAL registration + valid photos → should throw `MomentNotFoundError` (même blocage que pour le texte seul, vérifie que les photos ne contournent pas le check)
+
+**`delete-comment.test.ts`** (enrichir) :
+
+- Given comment with photos + user is author → should delete blobs then comment
+- Given comment with photos + user is host → should delete blobs then comment
+- Given blob delete fails → should still delete comment (best-effort cleanup)
+
+### Tests d'intégration (Vitest, infrastructure/)
+
+**`prisma-comment-attachment-repository.test.ts`** (nouveau) :
+
+- `create` : insère et retourne un `CommentAttachment`
+- `findByComment` : retourne les attachments d'un commentaire, ordonnés par `createdAt`
+- `deleteByComment` : supprime tous les attachments d'un commentaire
+- Cascade : supprimer un Comment supprime ses CommentAttachments
+
+**`prisma-comment-repository.test.ts`** (enrichir) :
+
+- `findByMomentIdWithUser` : les commentaires incluent leurs attachments
+
+### Tests E2E (Playwright)
+
+**Dans le fichier de tests des commentaires existant** (enrichir) :
+
+- **Parcours poster un commentaire avec photo** :
+  - Se connecter → page événement → saisir texte → ajouter une photo → commenter
+  - Vérifier que le commentaire apparaît avec la photo
+
+- **Parcours limite photos** :
+  - Ajouter 3 photos → vérifier que le bouton photo est grisé
+  - Retirer une photo → vérifier que le bouton redevient actif
+
+- **Parcours suppression** :
+  - Poster un commentaire avec photo → supprimer le commentaire
+  - Vérifier que le commentaire et ses photos disparaissent
+
+- **Parcours format refusé** :
+  - Tenter d'ajouter un .txt ou .pdf → vérifier le message d'erreur
+
+---
+
+## Plan d'implémentation
+
+| Phase | Contenu | Dépendances |
+| --- | --- | --- |
+| **1. Schema** | Modèle Prisma `CommentAttachment` + relation sur `Comment` + `db:push` dev/prod | Aucune |
+| **2. Domain** | `comment-attachment.ts` (modèle + constantes), `comment-attachment-errors.ts`, port `CommentAttachmentRepository`, enrichir `CommentWithUser` avec `attachments` | Phase 1 |
+| **3. Refactor** | Extraire `sanitizeFilename()` de `add-moment-attachment.ts` vers `lib/sanitize-filename.ts`, mettre à jour l'import dans `add-moment-attachment.ts` | Aucune |
+| **4. Infrastructure** | `PrismaCommentAttachmentRepository`, modifier `PrismaCommentRepository.findByMomentIdWithUser` pour inclure attachments | Phase 2 |
+| **5. Utilitaire client** | `lib/image-compress.ts` : `compressCommentPhoto()` (ratio préservé, seuil 3 Mo) | Aucune |
+| **6. Usecases** | Modifier `addComment` (validation photos avant création, upload après) + `deleteComment` (cleanup blobs) + tests unitaires (inclut test PENDING_APPROVAL + photos) | Phases 2-4 |
+| **7. Server action** | Modifier `addCommentAction` (FormData) + `deleteCommentAction` (cleanup blobs) | Phase 6 |
+| **8. UI** | Enrichir `CommentThread` : bouton photo, previews, affichage photos, lightbox, enrichir PostHog `comment_posted` avec `photo_count` | Phases 5, 7 |
+| **9. i18n + tests** | Clés FR/EN + tests E2E Playwright | Phase 8 |
+| **10. Page Aide** | Mettre à jour la page Aide (Help dans fr.json + en.json) pour mentionner les photos dans les commentaires | Phase 9 |
+
+---
+
+## Hors scope V1 (évolutions futures)
+
+- **Navigation entre photos** dans la lightbox (flèches prev/next)
+- **Galerie de photos de l'événement** : vue agrégée de toutes les photos postées dans les commentaires
+- **Suppression individuelle d'une photo** dans un commentaire existant (sans supprimer le commentaire)
+- **Drag-and-drop** de photos dans le textarea (en V1, uniquement via le bouton/input file)
+- **Pasting** d'images depuis le presse-papier (Ctrl+V)
+- **GIF animés** (type `image/gif` non autorisé en V1)
+- **Vidéos** courtes
+- **Mentions** (@utilisateur) dans les commentaires
+- **Réactions** (like/emoji) sur les commentaires
+- **Notifications enrichies** : inclure une miniature de la photo dans l'email de notification
+- **Compression serveur** : re-compression côté serveur pour les navigateurs qui ne supportent pas le Canvas API
+- **Quotas** : limite globale de stockage par Communauté
+- **Garbage collection** des blobs orphelins

--- a/spec/mockups/comment-photos.mockup.html
+++ b/spec/mockups/comment-photos.mockup.html
@@ -1,0 +1,992 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=1440">
+<title>Mockup — Photos dans les commentaires (dark, desktop)</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<style>
+:root {
+  /* Dark mode tokens — globals.css oklch → hex */
+  --background: #17152a;
+  --foreground: #ecebf3;
+  --card: #282238;
+  --card-foreground: #ecebf3;
+  --muted: #201c33;
+  --muted-foreground: #918ea5;
+  --border: #382f52;
+  --primary: #e8457a;
+  --primary-foreground: #ffffff;
+  --primary-10: rgba(232, 69, 122, 0.10);
+  --primary-20: rgba(232, 69, 122, 0.20);
+  --primary-30: rgba(232, 69, 122, 0.30);
+  --destructive: #e8457a;
+  --radius-sm: 0.5rem;
+  --radius-md: 0.75rem;
+  --radius-lg: 1rem;
+  --radius-xl: 1rem;
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.25);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.35);
+  --shadow-lg: 0 20px 40px rgba(0, 0, 0, 0.55);
+}
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+body {
+  font-family: 'Inter', sans-serif;
+  font-size: 15px;
+  line-height: 1.6;
+  color: var(--foreground);
+  background: var(--background);
+  -webkit-font-smoothing: antialiased;
+  padding: 2.5rem 0 5rem;
+}
+
+/* ── Layout ── */
+.screen {
+  max-width: 1180px;
+  margin: 0 auto 4rem;
+  padding: 0 2rem;
+}
+.screen-label {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--muted-foreground);
+  margin-bottom: 1rem;
+  padding-left: 0.25rem;
+}
+.screen-note {
+  font-size: 0.75rem;
+  color: var(--muted-foreground);
+  margin-bottom: 1.5rem;
+  padding-left: 0.25rem;
+  line-height: 1.5;
+  max-width: 680px;
+}
+.divider {
+  border: none;
+  border-top: 1px dashed var(--border);
+  margin: 3rem 0;
+}
+
+/* ═══════════════════════════════════════════════════════════════ */
+/* Event page — two columns                                       */
+/* ═══════════════════════════════════════════════════════════════ */
+.event-page {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  gap: 2rem;
+}
+
+/* ─── LEFT column ─── */
+.left-col {
+  width: 340px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+.cover-block {
+  aspect-ratio: 1 / 1;
+  border-radius: var(--radius-xl);
+  overflow: hidden;
+  background: linear-gradient(135deg, #e8457a 0%, #a855f7 50%, #6366f1 100%);
+  position: relative;
+  display: flex;
+  align-items: flex-end;
+  padding: 1.25rem;
+  box-shadow: 0 20px 60px rgba(232, 69, 122, 0.15);
+}
+.cover-block::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(ellipse at top right, rgba(255,255,255,0.12) 0%, transparent 60%),
+              radial-gradient(ellipse at bottom left, rgba(0,0,0,0.2) 0%, transparent 60%);
+}
+.cover-block .cover-label {
+  position: relative;
+  font-family: Georgia, serif;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: white;
+  line-height: 1.1;
+  text-shadow: 0 2px 20px rgba(0,0,0,0.3);
+}
+.circle-info-block {
+  border: 1px solid var(--border);
+  background: var(--card);
+  border-radius: var(--radius-xl);
+  padding: 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+.circle-avatar {
+  width: 40px;
+  height: 40px;
+  flex-shrink: 0;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #a855f7, #6366f1);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: white;
+  font-weight: 700;
+  font-size: 0.875rem;
+}
+.circle-info-meta { flex: 1; min-width: 0; }
+.circle-info-label { font-size: 0.7rem; color: var(--muted-foreground); }
+.circle-info-name {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--foreground);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ─── RIGHT column ─── */
+.right-col {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+.hosted-by { font-size: 0.875rem; color: var(--muted-foreground); }
+.hosted-by strong { color: var(--foreground); font-weight: 500; }
+.event-title {
+  font-size: 2.25rem;
+  font-weight: 700;
+  letter-spacing: -0.025em;
+  line-height: 1.15;
+  color: var(--foreground);
+}
+.meta-row { display: flex; align-items: center; gap: 0.75rem; }
+.meta-icon {
+  width: 32px; height: 32px; flex-shrink: 0;
+  border-radius: var(--radius-sm);
+  background: var(--primary-10); color: var(--primary);
+  display: flex; align-items: center; justify-content: center;
+}
+.meta-icon svg { width: 16px; height: 16px; }
+.meta-label { font-size: 0.75rem; color: var(--muted-foreground); line-height: 1.4; }
+.meta-value { font-size: 0.875rem; font-weight: 500; color: var(--foreground); line-height: 1.4; }
+.description-block { font-size: 0.9375rem; line-height: 1.7; color: var(--foreground); }
+.description-block p + p { margin-top: 0.75rem; }
+
+/* ─── Collapsed content indicator ─── */
+.collapsed-placeholder {
+  font-size: 0.8125rem;
+  color: var(--muted-foreground);
+  font-style: italic;
+  padding: 0.75rem 0;
+}
+
+/* ═══════════════════════════════════════════════════════════════ */
+/* Comment thread — card                                          */
+/* ═══════════════════════════════════════════════════════════════ */
+.comment-card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  padding: 1.5rem;
+}
+.comment-card-title {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--foreground);
+  margin-bottom: 1rem;
+}
+.comment-card-title .count {
+  font-size: 1rem;
+  font-weight: 400;
+  color: var(--muted-foreground);
+}
+.comments-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+/* ─── Single comment ─── */
+.comment {
+  display: flex;
+  gap: 0.75rem;
+}
+.comment-avatar {
+  width: 28px;
+  height: 28px;
+  flex-shrink: 0;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 500;
+  font-size: 0.6875rem;
+  color: var(--primary);
+  background: var(--primary-10);
+}
+.comment-avatar.green  { background: rgba(34,197,94,0.12); color: #22c55e; }
+.comment-avatar.purple { background: rgba(168,85,247,0.12); color: #a855f7; }
+.comment-avatar.blue   { background: rgba(59,130,246,0.12); color: #3b82f6; }
+.comment-avatar.orange { background: rgba(249,115,22,0.12); color: #f97316; }
+.comment-avatar.teal   { background: rgba(20,184,166,0.12); color: #14b8a6; }
+.comment-avatar img {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  object-fit: cover;
+}
+.comment-body { flex: 1; min-width: 0; }
+.comment-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+.comment-name { font-size: 0.875rem; font-weight: 500; color: var(--foreground); }
+.comment-time { font-size: 0.75rem; color: var(--muted-foreground); }
+.comment-delete {
+  font-size: 0.75rem;
+  color: var(--muted-foreground);
+  cursor: pointer;
+  background: none;
+  border: none;
+  font-family: inherit;
+  transition: color 0.15s;
+}
+.comment-delete:hover { color: var(--destructive); }
+.comment-text {
+  margin-top: 0.125rem;
+  font-size: 0.875rem;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--foreground);
+}
+
+/* ─── Photos in a posted comment ─── */
+.comment-photos {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-top: 0.5rem;
+}
+.comment-photo {
+  width: 128px;
+  height: 128px;
+  border-radius: 0.5rem;
+  object-fit: cover;
+  cursor: pointer;
+  transition: opacity 0.15s, box-shadow 0.15s;
+  border: 1px solid var(--border);
+}
+.comment-photo:hover {
+  opacity: 0.9;
+  box-shadow: 0 0 0 2px var(--primary-30);
+}
+
+/* Single photo — larger display */
+.comment-photos.single .comment-photo {
+  width: auto;
+  max-width: 320px;
+  height: auto;
+  max-height: 240px;
+  object-fit: cover;
+}
+
+/* ═══════════════════════════════════════════════════════════════ */
+/* Comment form — input area                                      */
+/* ═══════════════════════════════════════════════════════════════ */
+.comment-form {
+  margin-top: 1rem;
+  padding-top: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.comment-textarea {
+  width: 100%;
+  resize: none;
+  border: 1px solid var(--border);
+  background: var(--background);
+  color: var(--foreground);
+  border-radius: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  font-family: 'Inter', sans-serif;
+  font-size: 0.875rem;
+  line-height: 1.6;
+  outline: none;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+.comment-textarea::placeholder { color: var(--muted-foreground); }
+.comment-textarea:focus {
+  border-color: var(--primary);
+  box-shadow: 0 0 0 2px var(--primary-20);
+}
+
+/* ─── Photo previews (before posting) ─── */
+.photo-previews {
+  display: flex;
+  gap: 0.5rem;
+  padding: 0 0.125rem;
+}
+.photo-preview-item {
+  position: relative;
+  width: 64px;
+  height: 64px;
+  border-radius: 0.5rem;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+.photo-preview-item img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+.photo-preview-remove {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: rgba(0,0,0,0.6);
+  color: white;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 10px;
+  line-height: 1;
+  transition: background 0.15s;
+}
+.photo-preview-remove:hover { background: rgba(0,0,0,0.85); }
+
+/* ─── Form footer (photo btn + counter + submit) ─── */
+.comment-form-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+.comment-form-left {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+.photo-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 0.375rem;
+  background: none;
+  border: none;
+  color: var(--muted-foreground);
+  cursor: pointer;
+  transition: color 0.15s, background 0.15s;
+}
+.photo-btn:hover {
+  color: var(--foreground);
+  background: var(--muted);
+}
+.photo-btn.disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+.photo-btn.disabled:hover {
+  color: var(--muted-foreground);
+  background: none;
+}
+.photo-btn svg { width: 18px; height: 18px; }
+.char-count { font-size: 0.75rem; color: var(--muted-foreground); }
+.btn-sm {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 2rem;
+  padding: 0 0.75rem;
+  border-radius: 0.375rem;
+  background: var(--primary);
+  color: var(--primary-foreground);
+  font-family: inherit;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  border: none;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.btn-sm:hover { background: #d63a6c; }
+.btn-sm:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* ═══════════════════════════════════════════════════════════════ */
+/* Lightbox overlay                                               */
+/* ═══════════════════════════════════════════════════════════════ */
+.lightbox-overlay {
+  position: relative;
+  background: rgba(0, 0, 0, 0.85);
+  border-radius: var(--radius-xl);
+  overflow: hidden;
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow-lg);
+  max-width: 800px;
+  margin: 0 auto;
+}
+.lightbox-header {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid rgba(255,255,255,0.08);
+}
+.lightbox-close {
+  width: 36px;
+  height: 36px;
+  border-radius: 0.5rem;
+  border: 1px solid rgba(255,255,255,0.12);
+  background: rgba(255,255,255,0.06);
+  color: #ccc;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+}
+.lightbox-close:hover {
+  background: rgba(255,255,255,0.12);
+  border-color: rgba(255,255,255,0.2);
+  color: white;
+}
+.lightbox-close svg { width: 16px; height: 16px; }
+.lightbox-body {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  min-height: 400px;
+}
+.lightbox-body img {
+  max-width: 100%;
+  max-height: 60vh;
+  object-fit: contain;
+  border-radius: 0.375rem;
+}
+
+/* ═══════════════════════════════════════════════════════════════ */
+/* Annotations                                                    */
+/* ═══════════════════════════════════════════════════════════════ */
+.annotation {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
+  background: var(--primary-10);
+  color: var(--primary);
+  margin-left: 0.5rem;
+  vertical-align: middle;
+}
+.annotation.new {
+  background: rgba(34, 197, 94, 0.12);
+  color: #22c55e;
+}
+.annotation.changed {
+  background: rgba(249, 115, 22, 0.12);
+  color: #f97316;
+}
+
+/* ── Placeholder images ── */
+.placeholder-photo {
+  background: linear-gradient(135deg, #352c47 0%, #282238 100%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--muted-foreground);
+  font-size: 0.6875rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+</style>
+</head>
+<body>
+
+<!-- ═══════════════════════════════════════════════════════════ -->
+<!--  SCREEN 1 : Page complete avec commentaires + photos       -->
+<!-- ═══════════════════════════════════════════════════════════ -->
+<div class="screen">
+  <div class="screen-label">Screen 1 — Page publique avec commentaires et photos</div>
+  <div class="screen-note">
+    Vue d'ensemble : la section commentaires sur la page publique d'un événement.
+    Les photos sont intégrées dans les commentaires existants, sous le texte.
+  </div>
+
+  <div class="event-page">
+    <!-- LEFT COL -->
+    <div class="left-col">
+      <div class="cover-block">
+        <div class="cover-label">Soirée Networking<br>Tech Bordeaux</div>
+      </div>
+      <div class="circle-info-block">
+        <div class="circle-avatar">TB</div>
+        <div class="circle-info-meta">
+          <div class="circle-info-label">Communauté</div>
+          <div class="circle-info-name">Tech Bordeaux</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- RIGHT COL -->
+    <div class="right-col">
+      <div class="hosted-by">Organisé par <strong>Marie Dupont</strong></div>
+      <h1 class="event-title">Soirée Networking Tech Bordeaux</h1>
+
+      <!-- Meta rows -->
+      <div class="meta-row">
+        <div class="meta-icon">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="4" rx="2"/><path d="M16 2v4"/><path d="M8 2v4"/><path d="M3 10h18"/></svg>
+        </div>
+        <div>
+          <div class="meta-label">Date</div>
+          <div class="meta-value">Vendredi 11 avril 2026, 19h00</div>
+        </div>
+      </div>
+      <div class="meta-row">
+        <div class="meta-icon">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0Z"/><circle cx="12" cy="10" r="3"/></svg>
+        </div>
+        <div>
+          <div class="meta-label">Lieu</div>
+          <div class="meta-value">Le Node, 12 rue Sainte-Catherine, Bordeaux</div>
+        </div>
+      </div>
+
+      <!-- Description (collapsed) -->
+      <div class="collapsed-placeholder">... description, inscription, participants ...</div>
+
+      <!-- ═══════════════════════════════════════════════════ -->
+      <!--  COMMENT THREAD                                    -->
+      <!-- ═══════════════════════════════════════════════════ -->
+      <div class="comment-card">
+        <div class="comment-card-title">
+          Commentaires <span class="count">(4)</span>
+        </div>
+
+        <div class="comments-list">
+
+          <!-- Comment 1 : texte seul (inchangé) -->
+          <div class="comment">
+            <div class="comment-avatar green">ML</div>
+            <div class="comment-body">
+              <div class="comment-header">
+                <span class="comment-name">Marc Lefèvre</span>
+                <span class="comment-time">il y a 2 heures</span>
+              </div>
+              <p class="comment-text">Super soirée en perspective ! Quelqu'un sait si le parking du Node est ouvert le soir ?</p>
+            </div>
+          </div>
+
+          <!-- Comment 2 : texte + 1 photo (single = larger display) -->
+          <div class="comment">
+            <div class="comment-avatar purple">SD</div>
+            <div class="comment-body">
+              <div class="comment-header">
+                <span class="comment-name">Sophie Durand</span>
+                <span class="comment-time">il y a 45 min</span>
+              </div>
+              <p class="comment-text">L'entrée c'est bien ici ? Je suis passée devant tout à l'heure.</p>
+              <div class="comment-photos single">
+                <div class="comment-photo placeholder-photo" style="width:320px;height:200px;border-radius:0.5rem;border:1px solid var(--border);">
+                  Photo de l'entrée du Node
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Comment 3 : texte + 3 photos -->
+          <div class="comment">
+            <div class="comment-avatar">MD</div>
+            <div class="comment-body">
+              <div class="comment-header">
+                <span class="comment-name">Marie Dupont</span>
+                <span class="comment-time">il y a 20 min</span>
+                <button class="comment-delete">Supprimer</button>
+              </div>
+              <p class="comment-text">Merci à tous pour cette soirée incroyable ! Voici quelques photos de l'ambiance.</p>
+              <div class="comment-photos">
+                <div class="comment-photo placeholder-photo" style="border:1px solid var(--border);">
+                  Photo 1
+                </div>
+                <div class="comment-photo placeholder-photo" style="border:1px solid var(--border);">
+                  Photo 2
+                </div>
+                <div class="comment-photo placeholder-photo" style="border:1px solid var(--border);">
+                  Photo 3
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Comment 4 : texte + 2 photos -->
+          <div class="comment">
+            <div class="comment-avatar blue">TM</div>
+            <div class="comment-body">
+              <div class="comment-header">
+                <span class="comment-name">Thomas Martin</span>
+                <span class="comment-time">il y a 5 min</span>
+              </div>
+              <p class="comment-text">Top ambiance ! Hâte de revenir au prochain.</p>
+              <div class="comment-photos">
+                <div class="comment-photo placeholder-photo" style="border:1px solid var(--border);">
+                  Photo 1
+                </div>
+                <div class="comment-photo placeholder-photo" style="border:1px solid var(--border);">
+                  Photo 2
+                </div>
+              </div>
+            </div>
+          </div>
+
+        </div>
+
+        <!-- ─── Comment form : empty state ─── -->
+        <div class="comment-form">
+          <textarea class="comment-textarea" rows="3" placeholder="Partagez votre expérience, posez une question..."></textarea>
+          <div class="comment-form-footer">
+            <div class="comment-form-left">
+              <button class="photo-btn" title="Ajouter des photos">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h7"/><line x1="16" x2="22" y1="5" y2="5"/><line x1="19" x2="19" y1="2" y2="8"/><circle cx="9" cy="9" r="2"/><path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"/></svg>
+              </button>
+              <span class="char-count">0 / 2000</span>
+            </div>
+            <button class="btn-sm" disabled>Commenter</button>
+          </div>
+        </div>
+
+      </div><!-- /comment-card -->
+    </div><!-- /right-col -->
+  </div><!-- /event-page -->
+</div>
+
+
+<hr class="divider">
+
+
+<!-- ═══════════════════════════════════════════════════════════ -->
+<!--  SCREEN 2 : Formulaire avec photos sélectionnées          -->
+<!-- ═══════════════════════════════════════════════════════════ -->
+<div class="screen">
+  <div class="screen-label">Screen 2 — Saisie d'un commentaire avec 2 photos sélectionnées <span class="annotation new">nouveau</span></div>
+  <div class="screen-note">
+    L'utilisateur a saisi du texte et sélectionné 2 photos. Les miniatures apparaissent entre le textarea et la barre d'action.
+    Chaque miniature a un bouton [x] pour retirer la photo avant l'envoi. Le bouton photo reste actif (2/3 photos).
+  </div>
+
+  <div style="max-width:680px;">
+    <div class="comment-card">
+      <div class="comment-card-title">
+        Commentaires <span class="count">(3)</span>
+      </div>
+
+      <div class="comments-list">
+        <div class="comment">
+          <div class="comment-avatar green">ML</div>
+          <div class="comment-body">
+            <div class="comment-header">
+              <span class="comment-name">Marc Lefèvre</span>
+              <span class="comment-time">il y a 2 heures</span>
+            </div>
+            <p class="comment-text">Super soirée en perspective !</p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Form with photos selected -->
+      <div class="comment-form">
+        <textarea class="comment-textarea" rows="3" style="border-color:var(--primary);box-shadow:0 0 0 2px var(--primary-20);">Merci à tous pour cette soirée incroyable ! Voici quelques photos de l'ambiance.</textarea>
+
+        <!-- Photo previews -->
+        <div class="photo-previews">
+          <div class="photo-preview-item">
+            <div class="placeholder-photo" style="width:100%;height:100%;font-size:9px;">IMG_2847</div>
+            <button class="photo-preview-remove" title="Retirer cette photo">
+              <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+            </button>
+          </div>
+          <div class="photo-preview-item">
+            <div class="placeholder-photo" style="width:100%;height:100%;font-size:9px;">IMG_2850</div>
+            <button class="photo-preview-remove" title="Retirer cette photo">
+              <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+            </button>
+          </div>
+        </div>
+
+        <div class="comment-form-footer">
+          <div class="comment-form-left">
+            <button class="photo-btn" title="Ajouter des photos">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h7"/><line x1="16" x2="22" y1="5" y2="5"/><line x1="19" x2="19" y1="2" y2="8"/><circle cx="9" cy="9" r="2"/><path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"/></svg>
+            </button>
+            <span class="char-count">72 / 2000</span>
+          </div>
+          <button class="btn-sm">Commenter</button>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</div>
+
+
+<hr class="divider">
+
+
+<!-- ═══════════════════════════════════════════════════════════ -->
+<!--  SCREEN 3 : Limite de 3 photos atteinte                   -->
+<!-- ═══════════════════════════════════════════════════════════ -->
+<div class="screen">
+  <div class="screen-label">Screen 3 — Limite de 3 photos atteinte <span class="annotation changed">limite</span></div>
+  <div class="screen-note">
+    3 photos sélectionnées. Le bouton photo passe en grisé (opacity 40%, cursor not-allowed). Pas de message d'erreur, le bouton suffit.
+  </div>
+
+  <div style="max-width:680px;">
+    <div class="comment-card" style="padding-top:0.75rem;">
+
+      <!-- Form with 3 photos -->
+      <div class="comment-form" style="margin-top:0;">
+        <textarea class="comment-textarea" rows="3" style="border-color:var(--primary);box-shadow:0 0 0 2px var(--primary-20);">Quelques souvenirs de la soirée !</textarea>
+
+        <!-- 3 photo previews -->
+        <div class="photo-previews">
+          <div class="photo-preview-item">
+            <div class="placeholder-photo" style="width:100%;height:100%;font-size:9px;">IMG_2847</div>
+            <button class="photo-preview-remove" title="Retirer cette photo">
+              <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+            </button>
+          </div>
+          <div class="photo-preview-item">
+            <div class="placeholder-photo" style="width:100%;height:100%;font-size:9px;">IMG_2850</div>
+            <button class="photo-preview-remove" title="Retirer cette photo">
+              <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+            </button>
+          </div>
+          <div class="photo-preview-item">
+            <div class="placeholder-photo" style="width:100%;height:100%;font-size:9px;">IMG_2853</div>
+            <button class="photo-preview-remove" title="Retirer cette photo">
+              <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+            </button>
+          </div>
+        </div>
+
+        <div class="comment-form-footer">
+          <div class="comment-form-left">
+            <!-- Disabled photo button -->
+            <button class="photo-btn disabled" title="Limite de 3 photos atteinte" aria-disabled="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h7"/><line x1="16" x2="22" y1="5" y2="5"/><line x1="19" x2="19" y1="2" y2="8"/><circle cx="9" cy="9" r="2"/><path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"/></svg>
+            </button>
+            <span class="char-count">33 / 2000</span>
+          </div>
+          <button class="btn-sm">Commenter</button>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</div>
+
+
+<hr class="divider">
+
+
+<!-- ═══════════════════════════════════════════════════════════ -->
+<!--  SCREEN 4 : Formulaire vide (état initial)                -->
+<!-- ═══════════════════════════════════════════════════════════ -->
+<div class="screen">
+  <div class="screen-label">Screen 4 — Formulaire vide, état initial <span class="annotation changed">modifié</span></div>
+  <div class="screen-note">
+    L'unique changement par rapport à l'existant : le bouton photo (ImagePlus) apparaît à gauche du compteur de caractères.
+    Le bouton "Commenter" est disabled tant que le textarea est vide.
+  </div>
+
+  <div style="max-width:680px;">
+    <div class="comment-card" style="padding-top:0.75rem;">
+
+      <div class="comment-form" style="margin-top:0;">
+        <textarea class="comment-textarea" rows="3" placeholder="Partagez votre expérience, posez une question..."></textarea>
+        <div class="comment-form-footer">
+          <div class="comment-form-left">
+            <button class="photo-btn" title="Ajouter des photos">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h7"/><line x1="16" x2="22" y1="5" y2="5"/><line x1="19" x2="19" y1="2" y2="8"/><circle cx="9" cy="9" r="2"/><path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"/></svg>
+            </button>
+            <span class="char-count">0 / 2000</span>
+          </div>
+          <button class="btn-sm" disabled>Commenter</button>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</div>
+
+
+<hr class="divider">
+
+
+<!-- ═══════════════════════════════════════════════════════════ -->
+<!--  SCREEN 5 : Commentaire posté — 1 photo (affichage large) -->
+<!-- ═══════════════════════════════════════════════════════════ -->
+<div class="screen">
+  <div class="screen-label">Screen 5 — Commentaire avec une seule photo (affichage large) <span class="annotation new">nouveau</span></div>
+  <div class="screen-note">
+    Quand un commentaire n'a qu'une seule photo, elle est affichée plus grande (max-width 320px, ratio préservé).
+    Le clic ouvre la lightbox.
+  </div>
+
+  <div style="max-width:680px;">
+    <div class="comment-card" style="padding-top:0.75rem;">
+      <div class="comments-list">
+        <div class="comment">
+          <div class="comment-avatar purple">SD</div>
+          <div class="comment-body">
+            <div class="comment-header">
+              <span class="comment-name">Sophie Durand</span>
+              <span class="comment-time">il y a 45 min</span>
+            </div>
+            <p class="comment-text">L'entrée c'est bien ici ? Je suis passée devant tout à l'heure.</p>
+            <div class="comment-photos single">
+              <div class="comment-photo placeholder-photo" style="width:320px;height:200px;border-radius:0.5rem;border:1px solid var(--border);cursor:pointer;">
+                Photo de l'entrée du lieu
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+
+<hr class="divider">
+
+
+<!-- ═══════════════════════════════════════════════════════════ -->
+<!--  SCREEN 6 : Commentaire posté — 3 photos (grille)         -->
+<!-- ═══════════════════════════════════════════════════════════ -->
+<div class="screen">
+  <div class="screen-label">Screen 6 — Commentaire avec 3 photos (grille compacte) <span class="annotation new">nouveau</span></div>
+  <div class="screen-note">
+    Les photos multiples sont affichées en 128x128px, croppées visuellement en carré (object-fit: cover).
+    Au hover, un léger anneau rose apparaît. Le clic ouvre la lightbox.
+  </div>
+
+  <div style="max-width:680px;">
+    <div class="comment-card" style="padding-top:0.75rem;">
+      <div class="comments-list">
+        <div class="comment">
+          <div class="comment-avatar">MD</div>
+          <div class="comment-body">
+            <div class="comment-header">
+              <span class="comment-name">Marie Dupont</span>
+              <span class="comment-time">il y a 20 min</span>
+              <button class="comment-delete">Supprimer</button>
+            </div>
+            <p class="comment-text">Merci à tous pour cette soirée incroyable ! Voici quelques photos.</p>
+            <div class="comment-photos">
+              <div class="comment-photo placeholder-photo" style="border:1px solid var(--border);">
+                Photo 1
+              </div>
+              <div class="comment-photo placeholder-photo" style="border:1px solid var(--border);box-shadow:0 0 0 2px var(--primary-30);">
+                Photo 2 (hover)
+              </div>
+              <div class="comment-photo placeholder-photo" style="border:1px solid var(--border);">
+                Photo 3
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+
+<hr class="divider">
+
+
+<!-- ═══════════════════════════════════════════════════════════ -->
+<!--  SCREEN 7 : Lightbox (photo agrandie)                     -->
+<!-- ═══════════════════════════════════════════════════════════ -->
+<div class="screen">
+  <div class="screen-label">Screen 7 — Lightbox (photo agrandie au clic) <span class="annotation new">nouveau</span></div>
+  <div class="screen-note">
+    Overlay sombre (bg-black/85), photo centrée en taille originale (max 90vh). Bouton fermer en haut à droite.
+    Fermeture via Escape, clic sur l'overlay, ou bouton X. Réutilise le composant AttachmentViewerDialog.
+  </div>
+
+  <div class="lightbox-overlay">
+    <div class="lightbox-header">
+      <button class="lightbox-close" title="Fermer">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+          <path d="M18 6 6 18"/><path d="m6 6 12 12"/>
+        </svg>
+      </button>
+    </div>
+    <div class="lightbox-body">
+      <div class="placeholder-photo" style="width:600px;height:400px;border-radius:0.375rem;font-size:1rem;">
+        Photo agrandie (600 x 400)
+      </div>
+    </div>
+  </div>
+</div>
+
+
+<hr class="divider">
+
+
+<!-- ═══════════════════════════════════════════════════════════ -->
+<!--  SCREEN 8 : Erreur format non supporté                    -->
+<!-- ═══════════════════════════════════════════════════════════ -->
+<div class="screen">
+  <div class="screen-label">Screen 8 — Erreur : format non supporté</div>
+  <div class="screen-note">
+    L'utilisateur a tenté d'ajouter un fichier non supporté (ex: .pdf ou .gif). Le message d'erreur apparaît sous le formulaire.
+  </div>
+
+  <div style="max-width:680px;">
+    <div class="comment-card" style="padding-top:0.75rem;">
+
+      <div class="comment-form" style="margin-top:0;">
+        <textarea class="comment-textarea" rows="3">Je partage le programme de la soirée</textarea>
+        <div class="comment-form-footer">
+          <div class="comment-form-left">
+            <button class="photo-btn" title="Ajouter des photos">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h7"/><line x1="16" x2="22" y1="5" y2="5"/><line x1="19" x2="19" y1="2" y2="8"/><circle cx="9" cy="9" r="2"/><path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"/></svg>
+            </button>
+            <span class="char-count">38 / 2000</span>
+          </div>
+          <button class="btn-sm">Commenter</button>
+        </div>
+        <p style="font-size:0.75rem;color:var(--destructive);margin-top:0.125rem;">Format non supporté. JPG, PNG ou WebP uniquement.</p>
+      </div>
+
+    </div>
+  </div>
+</div>
+
+
+</body>
+</html>

--- a/src/app/[locale]/(routes)/(static)/help/page.tsx
+++ b/src/app/[locale]/(routes)/(static)/help/page.tsx
@@ -288,6 +288,14 @@ export default async function HelpPage() {
               <p className="text-sm leading-relaxed text-muted-foreground">
                 {t.rich("participant.comments.intro", rich)}
               </p>
+              <p className="text-sm font-medium text-muted-foreground">
+                {t("participant.comments.photosLabel")}
+              </p>
+              <ul className="list-inside list-disc space-y-1.5 text-sm leading-relaxed text-muted-foreground">
+                <li>{t.rich("participant.comments.photos1", rich)}</li>
+                <li>{t.rich("participant.comments.photos2", rich)}</li>
+                <li>{t("participant.comments.photos3")}</li>
+              </ul>
             </div>
 
             <hr className="border-border" />

--- a/src/app/actions/comment.ts
+++ b/src/app/actions/comment.ts
@@ -38,16 +38,17 @@ export async function addCommentAction(
   }
   const userId = session.user.id;
 
-  const content = formData.get("content") as string | null;
-  if (!content) {
+  const rawContent = formData.get("content");
+  if (typeof rawContent !== "string" || !rawContent) {
     return { success: false, error: "Content missing", code: "MISSING_CONTENT" };
   }
+  const content = rawContent;
 
   // Extract photo files from FormData (photo-0, photo-1, photo-2)
   const photoFiles: File[] = [];
   for (let i = 0; i < 3; i++) {
-    const f = formData.get(`photo-${i}`) as File | null;
-    if (f && f.size > 0) photoFiles.push(f);
+    const f = formData.get(`photo-${i}`);
+    if (f instanceof File && f.size > 0) photoFiles.push(f);
   }
 
   // Validate and detect MIME for each photo

--- a/src/app/actions/comment.ts
+++ b/src/app/actions/comment.ts
@@ -2,6 +2,7 @@
 
 import * as Sentry from "@sentry/nextjs";
 import { getLocale, getTranslations } from "next-intl/server";
+import { fileTypeFromBuffer } from "file-type";
 import { auth } from "@/infrastructure/auth/auth.config";
 import {
   prismaCommentRepository,
@@ -9,11 +10,18 @@ import {
   prismaCircleRepository,
   prismaUserRepository,
   prismaRegistrationRepository,
+  prismaCommentAttachmentRepository,
 } from "@/infrastructure/repositories";
+import { vercelBlobStorageService } from "@/infrastructure/services/storage/vercel-blob-storage-service";
 import { createResendEmailService } from "@/infrastructure/services";
 import { addComment } from "@/domain/usecases/add-comment";
+import type { CommentPhotoInput } from "@/domain/usecases/add-comment";
 import { deleteComment } from "@/domain/usecases/delete-comment";
 import { notifySlackNewComment } from "@/infrastructure/services/slack/slack-notification-service";
+import {
+  ALLOWED_COMMENT_PHOTO_TYPES,
+  MAX_COMMENT_PHOTO_SIZE_BYTES,
+} from "@/domain/models/comment-attachment";
 import type { Comment } from "@/domain/models/comment";
 import type { ActionResult } from "./types";
 import { toActionResult } from "./helpers/to-action-result";
@@ -22,7 +30,7 @@ const emailService = createResendEmailService();
 
 export async function addCommentAction(
   momentId: string,
-  content: string
+  formData: FormData
 ): Promise<ActionResult<Comment>> {
   const session = await auth();
   if (!session?.user?.id) {
@@ -30,13 +38,86 @@ export async function addCommentAction(
   }
   const userId = session.user.id;
 
+  const content = formData.get("content") as string | null;
+  if (!content) {
+    return { success: false, error: "Content missing", code: "MISSING_CONTENT" };
+  }
+
+  // Extract photo files from FormData (photo-0, photo-1, photo-2)
+  const photoFiles: File[] = [];
+  for (let i = 0; i < 3; i++) {
+    const f = formData.get(`photo-${i}`) as File | null;
+    if (f && f.size > 0) photoFiles.push(f);
+  }
+
+  // Validate and detect MIME for each photo
+  let photos: CommentPhotoInput[] = [];
+  if (photoFiles.length > 0) {
+    try {
+      photos = await Promise.all(
+        photoFiles.map(async (file) => {
+          const buffer = Buffer.from(await file.arrayBuffer());
+          const detected = await fileTypeFromBuffer(buffer);
+          if (
+            !detected ||
+            !ALLOWED_COMMENT_PHOTO_TYPES.has(detected.mime)
+          ) {
+            return {
+              buffer,
+              filename: file.name,
+              contentType: "invalid",
+              sizeBytes: buffer.length,
+            };
+          }
+          return {
+            buffer,
+            filename: file.name,
+            contentType: detected.mime,
+            sizeBytes: buffer.length,
+          };
+        })
+      );
+
+      // Check for invalid types (detected in parallel above)
+      const invalid = photos.find((p) => p.contentType === "invalid");
+      if (invalid) {
+        return {
+          success: false,
+          error: "Format non supporté",
+          code: "COMMENT_PHOTO_TYPE_NOT_ALLOWED",
+        };
+      }
+
+      // Check sizes
+      const tooLarge = photos.find(
+        (p) => p.sizeBytes > MAX_COMMENT_PHOTO_SIZE_BYTES
+      );
+      if (tooLarge) {
+        return {
+          success: false,
+          error: "Photo trop volumineuse",
+          code: "COMMENT_PHOTO_TOO_LARGE",
+        };
+      }
+    } catch (err) {
+      Sentry.captureException(err);
+      return {
+        success: false,
+        error: "Erreur de lecture des photos",
+        code: "READ_ERROR",
+      };
+    }
+  }
+
   return toActionResult(async () => {
     const result = await addComment(
-      { momentId, userId, content },
+      { momentId, userId, content, photos },
       {
         commentRepository: prismaCommentRepository,
         momentRepository: prismaMomentRepository,
         registrationRepository: prismaRegistrationRepository,
+        commentAttachmentRepository: prismaCommentAttachmentRepository,
+        storage: vercelBlobStorageService,
       }
     );
 
@@ -71,6 +152,8 @@ export async function deleteCommentAction(
         commentRepository: prismaCommentRepository,
         momentRepository: prismaMomentRepository,
         circleRepository: prismaCircleRepository,
+        commentAttachmentRepository: prismaCommentAttachmentRepository,
+        storage: vercelBlobStorageService,
       }
     );
   });

--- a/src/components/moments/comment-photo-lightbox.tsx
+++ b/src/components/moments/comment-photo-lightbox.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { X } from "lucide-react";
+import { ExternalLink, X } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { Dialog as DialogPrimitive } from "radix-ui";
 import { cn } from "@/lib/utils";
@@ -40,13 +40,29 @@ export function CommentPhotoLightbox({
             {alt}
           </DialogPrimitive.Description>
 
-          {/* Close button */}
-          <DialogPrimitive.Close
-            className="absolute top-0 right-0 z-10 flex size-9 items-center justify-center rounded-lg border border-white/12 bg-white/6 text-gray-300 transition-colors hover:border-white/20 hover:bg-white/12 hover:text-white"
-            aria-label={t("close")}
-          >
-            <X className="size-4" />
-          </DialogPrimitive.Close>
+          {/* Action buttons — top right */}
+          <div className="absolute top-0 right-0 z-10 flex gap-1.5">
+            {/* Open in new tab — pinch-to-zoom works natively in
+                the browser's full-screen image viewer, unlike inside
+                a modal where touch events are intercepted. */}
+            {url && (
+              <a
+                href={url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex size-9 items-center justify-center rounded-lg border border-white/12 bg-white/6 text-gray-300 transition-colors hover:border-white/20 hover:bg-white/12 hover:text-white"
+                aria-label={t("openInNewTab")}
+              >
+                <ExternalLink className="size-4" />
+              </a>
+            )}
+            <DialogPrimitive.Close
+              className="flex size-9 items-center justify-center rounded-lg border border-white/12 bg-white/6 text-gray-300 transition-colors hover:border-white/20 hover:bg-white/12 hover:text-white"
+              aria-label={t("close")}
+            >
+              <X className="size-4" />
+            </DialogPrimitive.Close>
+          </div>
 
           {/* Image */}
           {url && (

--- a/src/components/moments/comment-photo-lightbox.tsx
+++ b/src/components/moments/comment-photo-lightbox.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { X } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { Dialog as DialogPrimitive } from "radix-ui";
+import { cn } from "@/lib/utils";
+
+type CommentPhotoLightboxProps = {
+  url: string | null;
+  alt: string;
+  onClose: () => void;
+};
+
+export function CommentPhotoLightbox({
+  url,
+  alt,
+  onClose,
+}: CommentPhotoLightboxProps) {
+  const t = useTranslations("Common");
+
+  return (
+    <DialogPrimitive.Root
+      open={url !== null}
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay className="data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/85" />
+        <DialogPrimitive.Content
+          className={cn(
+            "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+            "fixed top-1/2 left-1/2 z-50 flex w-[calc(100vw-2rem)] -translate-x-1/2 -translate-y-1/2 flex-col items-center justify-center",
+            "h-[calc(100vh-4rem)] max-h-[900px] max-w-4xl",
+            "outline-none"
+          )}
+        >
+          <DialogPrimitive.Title className="sr-only">{alt}</DialogPrimitive.Title>
+          <DialogPrimitive.Description className="sr-only">
+            {alt}
+          </DialogPrimitive.Description>
+
+          {/* Close button */}
+          <DialogPrimitive.Close
+            className="absolute top-0 right-0 z-10 flex size-9 items-center justify-center rounded-lg border border-white/12 bg-white/6 text-gray-300 transition-colors hover:border-white/20 hover:bg-white/12 hover:text-white"
+            aria-label={t("close")}
+          >
+            <X className="size-4" />
+          </DialogPrimitive.Close>
+
+          {/* Image */}
+          {url && (
+            <img
+              src={url}
+              alt={alt}
+              className="max-h-full max-w-full rounded-md object-contain"
+            />
+          )}
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  );
+}

--- a/src/components/moments/comment-thread.tsx
+++ b/src/components/moments/comment-thread.tsx
@@ -396,7 +396,7 @@ export function CommentThread({
               <input
                 ref={fileInputRef}
                 type="file"
-                accept="image/jpeg,image/png,image/webp"
+                accept="image/*"
                 multiple
                 className="hidden"
                 onChange={handlePhotoSelect}
@@ -415,7 +415,7 @@ export function CommentThread({
                 className="text-muted-foreground gap-1.5"
               >
                 <ImagePlus className="size-4" />
-                {t("comments.addPhotos")}
+                <span className="hidden sm:inline">{t("comments.addPhotos")}</span>
               </Button>
               <Button
                 size="sm"

--- a/src/components/moments/comment-thread.tsx
+++ b/src/components/moments/comment-thread.tsx
@@ -120,6 +120,16 @@ function DeleteCommentButton({
 
 // --- Comment photos display ---
 
+/**
+ * Touch-first device detection (phones, tablets).
+ * On coarse pointers, photos open directly in a new tab where
+ * pinch-to-zoom works natively — no modal needed.
+ */
+function isCoarsePointer(): boolean {
+  if (typeof window === "undefined") return false;
+  return window.matchMedia("(pointer: coarse)").matches;
+}
+
 function CommentPhotos({
   attachments,
   onPhotoClick,
@@ -131,6 +141,14 @@ function CommentPhotos({
 
   const isSingle = attachments.length === 1;
 
+  function handleClick(url: string, altText: string) {
+    if (isCoarsePointer()) {
+      window.open(url, "_blank", "noopener,noreferrer");
+      return;
+    }
+    onPhotoClick(url, altText);
+  }
+
   return (
     <div className={isSingle ? "mt-2" : "mt-2 flex flex-wrap gap-2"}>
       {attachments.map((att) => {
@@ -139,7 +157,7 @@ function CommentPhotos({
           <button
             key={att.id}
             type="button"
-            onClick={() => onPhotoClick(att.url, alt)}
+            onClick={() => handleClick(att.url, alt)}
             className={
               isSingle
                 ? "block max-w-xs cursor-pointer overflow-hidden rounded-lg ring-2 ring-transparent transition-all hover:opacity-90 hover:ring-primary/30"

--- a/src/components/moments/comment-thread.tsx
+++ b/src/components/moments/comment-thread.tsx
@@ -347,16 +347,24 @@ export function CommentThread({
         {/* Form or sign-in prompt */}
         {isAuthenticated ? (
           <div className="space-y-2 pt-2">
-            <textarea
-              ref={textareaRef}
-              value={content}
-              onChange={(e) => setContent(e.target.value)}
-              placeholder={isPastMoment ? t("comments.placeholderPast") : t("comments.placeholder")}
-              rows={3}
-              maxLength={MAX_CONTENT_LENGTH}
-              className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring w-full resize-none rounded-xl border px-3 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:opacity-50"
-              disabled={isPending}
-            />
+            {/* Textarea + char count in a single bordered container */}
+            <div className="border-input bg-background focus-within:ring-ring focus-within:border-ring rounded-xl border focus-within:ring-2 focus-within:ring-offset-2">
+              <textarea
+                ref={textareaRef}
+                value={content}
+                onChange={(e) => setContent(e.target.value)}
+                placeholder={isPastMoment ? t("comments.placeholderPast") : t("comments.placeholder")}
+                rows={3}
+                maxLength={MAX_CONTENT_LENGTH}
+                className="placeholder:text-muted-foreground w-full resize-none border-none bg-transparent px-3 pt-2 pb-0 text-sm outline-none disabled:opacity-50"
+                disabled={isPending}
+              />
+              <div className="flex justify-end px-3 pb-1.5">
+                <span className="text-muted-foreground text-[11px]">
+                  {content.length} / {MAX_CONTENT_LENGTH}
+                </span>
+              </div>
+            </div>
 
             {/* Photo previews */}
             {stagedPhotos.length > 0 && (
@@ -384,38 +392,31 @@ export function CommentThread({
               </div>
             )}
 
-            <div className="flex items-center justify-between gap-2">
-              <div className="flex items-center gap-3">
-                {/* Photo button */}
-                <button
-                  type="button"
-                  onClick={() => !photosAtLimit && fileInputRef.current?.click()}
-                  className={
-                    photosAtLimit
-                      ? "text-muted-foreground flex size-7 cursor-not-allowed items-center justify-center rounded-md opacity-40"
-                      : "text-muted-foreground hover:text-foreground hover:bg-muted flex size-7 cursor-pointer items-center justify-center rounded-md transition-colors"
-                  }
-                  aria-label={
-                    photosAtLimit
-                      ? t("comments.addPhotosDisabled")
-                      : t("comments.addPhotos")
-                  }
-                  aria-disabled={photosAtLimit}
-                >
-                  <ImagePlus className="size-[18px]" />
-                </button>
-                <input
-                  ref={fileInputRef}
-                  type="file"
-                  accept="image/jpeg,image/png,image/webp"
-                  multiple
-                  className="hidden"
-                  onChange={handlePhotoSelect}
-                />
-                <span className="text-muted-foreground text-xs">
-                  {content.length} / {MAX_CONTENT_LENGTH}
-                </span>
-              </div>
+            <div className="flex items-center justify-end gap-2">
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/jpeg,image/png,image/webp"
+                multiple
+                className="hidden"
+                onChange={handlePhotoSelect}
+              />
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => !photosAtLimit && fileInputRef.current?.click()}
+                disabled={photosAtLimit}
+                aria-label={
+                  photosAtLimit
+                    ? t("comments.addPhotosDisabled")
+                    : t("comments.addPhotos")
+                }
+                className="text-muted-foreground gap-1.5"
+              >
+                <ImagePlus className="size-4" />
+                {t("comments.addPhotos")}
+              </Button>
               <Button
                 size="sm"
                 onClick={handleSubmit}

--- a/src/components/moments/comment-thread.tsx
+++ b/src/components/moments/comment-thread.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useTransition, useRef, useCallback } from "react";
+import { useState, useTransition, useRef, useCallback, useEffect } from "react";
 import posthog from "posthog-js";
 import { useTranslations } from "next-intl";
 import { ImagePlus, X } from "lucide-react";
@@ -21,6 +21,7 @@ import { UserAvatar } from "@/components/user-avatar";
 import { CommentPhotoLightbox } from "@/components/moments/comment-photo-lightbox";
 import { addCommentAction, deleteCommentAction } from "@/app/actions/comment";
 import { compressCommentPhoto } from "@/lib/image-compress";
+import { isCoarsePointer } from "@/lib/coarse-pointer";
 import { getDisplayName } from "@/lib/display-name";
 import { linkifyText } from "@/lib/linkify";
 import {
@@ -120,16 +121,6 @@ function DeleteCommentButton({
 
 // --- Comment photos display ---
 
-/**
- * Touch-first device detection (phones, tablets).
- * On coarse pointers, photos open directly in a new tab where
- * pinch-to-zoom works natively — no modal needed.
- */
-function isCoarsePointer(): boolean {
-  if (typeof window === "undefined") return false;
-  return window.matchMedia("(pointer: coarse)").matches;
-}
-
 function CommentPhotos({
   attachments,
   onPhotoClick,
@@ -169,7 +160,7 @@ function CommentPhotos({
               alt={alt}
               className={
                 isSingle
-                  ? "max-h-60 w-auto rounded-lg object-cover"
+                  ? "max-h-60 max-w-xs rounded-lg object-cover"
                   : "size-full object-cover"
               }
             />
@@ -207,6 +198,15 @@ export function CommentThread({
   // Lightbox state
   const [lightboxUrl, setLightboxUrl] = useState<string | null>(null);
   const [lightboxAlt, setLightboxAlt] = useState("");
+
+  // Cleanup preview URLs on unmount to avoid memory leaks
+  const stagedPhotosRef = useRef(stagedPhotos);
+  stagedPhotosRef.current = stagedPhotos;
+  useEffect(() => {
+    return () => {
+      stagedPhotosRef.current.forEach((p) => URL.revokeObjectURL(p.previewUrl));
+    };
+  }, []);
 
   const isAuthenticated = currentUserId !== null;
   const photosAtLimit = stagedPhotos.length >= MAX_COMMENT_PHOTOS;

--- a/src/components/moments/comment-thread.tsx
+++ b/src/components/moments/comment-thread.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useState, useTransition, useRef } from "react";
+import { useState, useTransition, useRef, useCallback } from "react";
 import posthog from "posthog-js";
 import { useTranslations } from "next-intl";
+import { ImagePlus, X } from "lucide-react";
 import { useRouter } from "@/i18n/navigation";
 import {
   AlertDialog,
@@ -17,12 +18,24 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { UserAvatar } from "@/components/user-avatar";
+import { CommentPhotoLightbox } from "@/components/moments/comment-photo-lightbox";
 import { addCommentAction, deleteCommentAction } from "@/app/actions/comment";
+import { compressCommentPhoto } from "@/lib/image-compress";
 import { getDisplayName } from "@/lib/display-name";
 import { linkifyText } from "@/lib/linkify";
+import {
+  MAX_COMMENT_PHOTOS,
+  ALLOWED_COMMENT_PHOTO_TYPES,
+} from "@/domain/models/comment-attachment";
 import type { CommentWithUser } from "@/domain/models/comment";
 
 const MAX_CONTENT_LENGTH = 2000;
+
+type StagedPhoto = {
+  file: File;
+  previewUrl: string;
+  compressed: Blob | null; // null = not yet compressed
+};
 
 type CommentThreadProps = {
   momentId: string;
@@ -105,6 +118,52 @@ function DeleteCommentButton({
   );
 }
 
+// --- Comment photos display ---
+
+function CommentPhotos({
+  attachments,
+  onPhotoClick,
+}: {
+  attachments: CommentWithUser["attachments"];
+  onPhotoClick: (url: string, alt: string) => void;
+}) {
+  if (attachments.length === 0) return null;
+
+  const isSingle = attachments.length === 1;
+
+  return (
+    <div className={isSingle ? "mt-2" : "mt-2 flex flex-wrap gap-2"}>
+      {attachments.map((att) => {
+        const alt = att.filename.replace(/\.[^.]+$/, "");
+        return (
+          <button
+            key={att.id}
+            type="button"
+            onClick={() => onPhotoClick(att.url, alt)}
+            className={
+              isSingle
+                ? "block max-w-xs cursor-pointer overflow-hidden rounded-lg ring-2 ring-transparent transition-all hover:opacity-90 hover:ring-primary/30"
+                : "size-24 cursor-pointer overflow-hidden rounded-lg ring-2 ring-transparent transition-all hover:opacity-90 hover:ring-primary/30 sm:size-32"
+            }
+          >
+            <img
+              src={att.url}
+              alt={alt}
+              className={
+                isSingle
+                  ? "max-h-60 w-auto rounded-lg object-cover"
+                  : "size-full object-cover"
+              }
+            />
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+// --- Main component ---
+
 export function CommentThread({
   momentId,
   comments,
@@ -120,19 +179,89 @@ export function CommentThread({
   const [error, setError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const formatRelativeTime = useRelativeTime(t);
 
+  // Photo state
+  const [stagedPhotos, setStagedPhotos] = useState<StagedPhoto[]>([]);
+  const [photoError, setPhotoError] = useState<string | null>(null);
+
+  // Lightbox state
+  const [lightboxUrl, setLightboxUrl] = useState<string | null>(null);
+  const [lightboxAlt, setLightboxAlt] = useState("");
+
   const isAuthenticated = currentUserId !== null;
-  const canComment = isAuthenticated;
+  const photosAtLimit = stagedPhotos.length >= MAX_COMMENT_PHOTOS;
+
+  const handlePhotoSelect = useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      setPhotoError(null);
+      const files = e.target.files;
+      if (!files) return;
+
+      const remaining = MAX_COMMENT_PHOTOS - stagedPhotos.length;
+      const filesToAdd = Array.from(files).slice(0, remaining);
+
+      for (const file of filesToAdd) {
+        // Client-side type check
+        if (!ALLOWED_COMMENT_PHOTO_TYPES.has(file.type)) {
+          setPhotoError(t("comments.photoTypeError"));
+          continue;
+        }
+
+        // Compress if needed, create preview
+        const previewUrl = URL.createObjectURL(file);
+        try {
+          const compressed = await compressCommentPhoto(file);
+          setStagedPhotos((prev) => [
+            ...prev,
+            { file, previewUrl, compressed },
+          ]);
+        } catch {
+          URL.revokeObjectURL(previewUrl);
+          setPhotoError(t("comments.photoUploadError"));
+        }
+      }
+
+      // Reset input so the same file can be re-selected
+      e.target.value = "";
+    },
+    [stagedPhotos.length, t]
+  );
+
+  const removePhoto = useCallback((index: number) => {
+    setStagedPhotos((prev) => {
+      const removed = prev[index];
+      if (removed) URL.revokeObjectURL(removed.previewUrl);
+      return prev.filter((_, i) => i !== index);
+    });
+  }, []);
 
   function handleSubmit() {
     if (!content.trim()) return;
     setError(null);
+    setPhotoError(null);
     startTransition(async () => {
-      const result = await addCommentAction(momentId, content);
+      const formData = new FormData();
+      formData.set("content", content);
+
+      // Attach compressed photos
+      for (let i = 0; i < stagedPhotos.length; i++) {
+        const staged = stagedPhotos[i];
+        const blob = staged.compressed ?? staged.file;
+        formData.set(`photo-${i}`, blob, staged.file.name);
+      }
+
+      const result = await addCommentAction(momentId, formData);
       if (result.success) {
-        posthog.capture("comment_posted", { moment_id: momentId });
+        posthog.capture("comment_posted", {
+          moment_id: momentId,
+          photo_count: stagedPhotos.length,
+        });
         setContent("");
+        // Cleanup preview URLs
+        for (const p of stagedPhotos) URL.revokeObjectURL(p.previewUrl);
+        setStagedPhotos([]);
         router.refresh();
       } else {
         setError(result.error);
@@ -199,6 +328,15 @@ export function CommentThread({
                     <p className="mt-0.5 text-sm whitespace-pre-wrap break-words">
                       {linkifyText(comment.content)}
                     </p>
+
+                    {/* Photos */}
+                    <CommentPhotos
+                      attachments={comment.attachments}
+                      onPhotoClick={(url, alt) => {
+                        setLightboxUrl(url);
+                        setLightboxAlt(alt);
+                      }}
+                    />
                   </div>
                 </div>
               );
@@ -219,10 +357,65 @@ export function CommentThread({
               className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring w-full resize-none rounded-xl border px-3 py-2 text-sm focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:opacity-50"
               disabled={isPending}
             />
+
+            {/* Photo previews */}
+            {stagedPhotos.length > 0 && (
+              <div className="flex gap-2 px-0.5">
+                {stagedPhotos.map((staged, i) => (
+                  <div
+                    key={staged.previewUrl}
+                    className="relative size-16 shrink-0 overflow-hidden rounded-lg sm:size-20"
+                  >
+                    <img
+                      src={staged.previewUrl}
+                      alt=""
+                      className="size-full object-cover"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => removePhoto(i)}
+                      className="absolute top-0.5 right-0.5 flex size-[18px] cursor-pointer items-center justify-center rounded-full bg-black/60 text-white transition-colors hover:bg-black/85"
+                      aria-label={t("comments.removePhoto")}
+                    >
+                      <X className="size-2.5" />
+                    </button>
+                  </div>
+                ))}
+              </div>
+            )}
+
             <div className="flex items-center justify-between gap-2">
-              <span className="text-muted-foreground text-xs">
-                {content.length} / {MAX_CONTENT_LENGTH}
-              </span>
+              <div className="flex items-center gap-3">
+                {/* Photo button */}
+                <button
+                  type="button"
+                  onClick={() => !photosAtLimit && fileInputRef.current?.click()}
+                  className={
+                    photosAtLimit
+                      ? "text-muted-foreground flex size-7 cursor-not-allowed items-center justify-center rounded-md opacity-40"
+                      : "text-muted-foreground hover:text-foreground hover:bg-muted flex size-7 cursor-pointer items-center justify-center rounded-md transition-colors"
+                  }
+                  aria-label={
+                    photosAtLimit
+                      ? t("comments.addPhotosDisabled")
+                      : t("comments.addPhotos")
+                  }
+                  aria-disabled={photosAtLimit}
+                >
+                  <ImagePlus className="size-[18px]" />
+                </button>
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept="image/jpeg,image/png,image/webp"
+                  multiple
+                  className="hidden"
+                  onChange={handlePhotoSelect}
+                />
+                <span className="text-muted-foreground text-xs">
+                  {content.length} / {MAX_CONTENT_LENGTH}
+                </span>
+              </div>
               <Button
                 size="sm"
                 onClick={handleSubmit}
@@ -231,8 +424,8 @@ export function CommentThread({
                 {t("comments.submit")}
               </Button>
             </div>
-            {error && (
-              <p className="text-destructive text-xs">{error}</p>
+            {(error || photoError) && (
+              <p className="text-destructive text-xs">{error || photoError}</p>
             )}
           </div>
         ) : (
@@ -244,6 +437,13 @@ export function CommentThread({
           </a>
         )}
       </div>
+
+      {/* Lightbox */}
+      <CommentPhotoLightbox
+        url={lightboxUrl}
+        alt={lightboxAlt}
+        onClose={() => setLightboxUrl(null)}
+      />
     </div>
   );
 }

--- a/src/components/moments/moment-attachments-list.tsx
+++ b/src/components/moments/moment-attachments-list.tsx
@@ -4,6 +4,7 @@ import { useCallback, useState } from "react";
 import { ChevronRight, FileText, ImageIcon } from "lucide-react";
 import { useTranslations } from "next-intl";
 import type { MomentAttachment } from "@/domain/models/moment-attachment";
+import { isCoarsePointer } from "@/lib/coarse-pointer";
 import { AttachmentViewerDialog } from "./attachment-viewer-dialog";
 import {
   formatAttachmentName,
@@ -16,21 +17,6 @@ type MomentAttachmentsListProps = {
   attachments: MomentAttachment[];
   momentSlug: string;
 };
-
-/**
- * Detects touch-first devices (phones, tablets) at click time.
- * `(pointer: coarse)` is the standard media query for coarse pointers
- * like fingers (vs. `fine` for mouse/trackpad).
- *
- * Runs only in the browser — always returns false during SSR/first
- * render, avoiding hydration mismatch. This is fine because the only
- * place we call it is inside a click handler, which by definition runs
- * on the client.
- */
-function isCoarsePointer(): boolean {
-  if (typeof window === "undefined") return false;
-  return window.matchMedia("(pointer: coarse)").matches;
-}
 
 /**
  * Public-facing list of attachments on the Moment page.

--- a/src/components/moments/registration-button.tsx
+++ b/src/components/moments/registration-button.tsx
@@ -5,7 +5,7 @@ import { useTranslations, useLocale } from "next-intl";
 import { useRouter } from "@/i18n/navigation";
 import { Link } from "@/i18n/navigation";
 import { Button } from "@/components/ui/button";
-import { Check, Clock, Download } from "lucide-react";
+import { CalendarIcon, Check, Clock, Download, X } from "lucide-react";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -204,119 +204,144 @@ export function RegistrationButton({
     return (
       <div className="space-y-3">
 
-        {/* Banner de confirmation */}
-        <div className={`border-border bg-card flex items-center gap-3 rounded-2xl border p-4 ${!isRegistered ? "border-amber-500/30 bg-amber-500/[0.06]" : ""}`}>
-          <div className={`flex size-9 shrink-0 items-center justify-center rounded-full ${isRegistered ? "bg-emerald-500/15 text-emerald-400" : "bg-amber-500/15 text-amber-500"}`}>
-            {isRegistered ? <Check className="size-4" /> : <Clock className="size-4" />}
+        {/* Card unifiée inscription */}
+        <div className={`border-border bg-card overflow-hidden rounded-2xl border ${!isRegistered ? "border-amber-500/30 bg-amber-500/[0.06]" : ""}`}>
+
+          {/* Ligne 1 — Statut */}
+          <div className="flex items-center gap-3 p-4">
+            <div className={`flex size-8 shrink-0 items-center justify-center rounded-lg ${isRegistered ? "bg-emerald-500/15 text-emerald-400" : "bg-amber-500/15 text-amber-500"}`}>
+              {isRegistered ? <Check className="size-4" strokeWidth={3} /> : <Clock className="size-4" />}
+            </div>
+            <div className="min-w-0 flex-1">
+              <p className="text-sm font-semibold">
+                {isRegistered ? t("public.registeredBannerTitle") : t("public.waitlistedBannerTitle")}
+              </p>
+              <p className="text-muted-foreground text-xs">
+                {t("public.registrantsCount", { count: registrationCount })}
+                {!isRegistered && waitlistPosition != null && waitlistPosition > 0
+                  ? ` · ${t("public.waitlistPosition", { position: waitlistPosition })}`
+                  : !isFull && spotsRemaining !== null
+                    ? ` · ${t("public.spotsRemaining", { count: spotsRemaining })}`
+                    : isFull
+                      ? ` · ${t("public.eventFull")}`
+                      : ""}
+              </p>
+            </div>
           </div>
-          <div className="min-w-0 flex-1">
-            <p className="text-sm font-semibold">
-              {isRegistered ? t("public.registeredBannerTitle") : t("public.waitlistedBannerTitle")}
-            </p>
-            <p className="text-muted-foreground text-xs">
-              {t("public.registrantsCount", { count: registrationCount })}
-              {!isRegistered && waitlistPosition != null && waitlistPosition > 0
-                ? ` · ${t("public.waitlistPosition", { position: waitlistPosition })}`
-                : !isFull && spotsRemaining !== null
-                  ? ` · ${t("public.spotsRemaining", { count: spotsRemaining })}`
-                  : isFull
-                    ? ` · ${t("public.eventFull")}`
-                    : ""}
-            </p>
-          </div>
-          {isRegistered && (
-            <Button variant="outline" className="h-[34px] shrink-0 rounded-xl text-xs" asChild>
-              <Link href="/dashboard?tab=moments">
-                {t("public.viewInDashboard")}
-              </Link>
-            </Button>
+
+          {/* Ligne 2 — Calendrier (inscrits confirmés uniquement) */}
+          {isRegistered && calendarData && appUrl && (
+            <>
+              <div className="border-border ml-[3.25rem] border-t" />
+              <div className="flex items-center gap-3 px-4 py-3">
+                <div className="bg-primary/10 text-primary flex size-8 shrink-0 items-center justify-center rounded-lg">
+                  <CalendarIcon className="size-4" />
+                </div>
+                <p className="min-w-0 flex-1 text-sm font-medium">{t("public.addToCalendar.label")}</p>
+                <div className="flex shrink-0 gap-1.5">
+                  <Button variant="outline" size="sm" asChild>
+                    <a href={buildGoogleCalendarUrl(calendarData, appUrl, { join: t("public.addToCalendar.calendarJoin"), organizedBy: t("public.addToCalendar.calendarOrganizedBy") })} target="_blank" rel="noopener noreferrer">
+                      <svg width="14" height="14" viewBox="0 0 48 48" aria-hidden="true">
+                        <path fill="#EA4335" d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"/>
+                        <path fill="#4285F4" d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"/>
+                        <path fill="#FBBC05" d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"/>
+                        <path fill="#34A853" d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"/>
+                      </svg>
+                      Google
+                    </a>
+                  </Button>
+                  <Button variant="outline" size="sm" asChild>
+                    <a href={`/api/moments/${calendarData.slug}/calendar`} download={`${calendarData.slug}.ics`}>
+                      <Download className="size-3.5" />
+                      .ics
+                    </a>
+                  </Button>
+                </div>
+              </div>
+            </>
           )}
+
+          {/* Ligne 3 — Actions */}
+          {(isRegistered || !isHost) && (
+            <>
+              <div className="border-border ml-[3.25rem] border-t" />
+              <div className="flex items-center justify-end gap-1.5 px-4 py-3">
+                {!isHost && (
+                  <AlertDialog>
+                    <AlertDialogTrigger asChild>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="text-muted-foreground"
+                      >
+                        {t("public.cancelRegistration")}
+                      </Button>
+                    </AlertDialogTrigger>
+                    <AlertDialogContent>
+                      <AlertDialogHeader>
+                        <AlertDialogTitle>
+                          {t("public.cancelConfirmTitle")}
+                        </AlertDialogTitle>
+                        <AlertDialogDescription>
+                          {t("public.cancelConfirmDescription")}
+                        </AlertDialogDescription>
+                      </AlertDialogHeader>
+                      {price > 0 && existingRegistration?.paymentStatus === "PAID" && (
+                        <div className={`rounded-md p-3 text-sm ${refundable ? "bg-green-500/10 text-green-500" : "bg-amber-500/10 text-amber-500"}`}>
+                          {refundable
+                            ? t("public.cancelRefundableInfo")
+                            : t("public.cancelNonRefundableWarning")}
+                        </div>
+                      )}
+                      {error && (
+                        <div className="bg-destructive/10 text-destructive rounded-md p-3 text-sm">
+                          {error}
+                        </div>
+                      )}
+                      <AlertDialogFooter>
+                        <AlertDialogCancel>{tCommon("cancel")}</AlertDialogCancel>
+                        <AlertDialogAction
+                          variant="destructive"
+                          disabled={isPending}
+                          onClick={() => {
+                            if (!localRegistrationId) return;
+                            startTransition(async () => {
+                              setError(null);
+                              const result = await cancelRegistrationAction(
+                                localRegistrationId
+                              );
+                              if (result.success) {
+                                posthog.capture("registration_cancelled", {
+                                  moment_id: momentId,
+                                  circle_id: circleId,
+                                });
+                                setLocalStatus(null);
+                                setLocalRegistrationId(null);
+                                router.refresh();
+                              } else {
+                                setError(result.error);
+                              }
+                            });
+                          }}
+                        >
+                          {isPending ? tCommon("loading") : t("public.confirmCancel")}
+                        </AlertDialogAction>
+                      </AlertDialogFooter>
+                    </AlertDialogContent>
+                  </AlertDialog>
+                )}
+                {isRegistered && (
+                  <Button size="sm" asChild>
+                    <Link href="/dashboard?tab=moments">
+                      {t("public.viewInDashboard")}
+                    </Link>
+                  </Button>
+                )}
+              </div>
+            </>
+          )}
+
         </div>
-
-        {/* Boutons calendrier — inscrits confirmés uniquement */}
-        {isRegistered && calendarData && appUrl && (
-          <div className="flex gap-2">
-            <Button variant="outline" className="h-[34px] flex-1 gap-1.5 rounded-xl text-xs" asChild>
-              <a href={buildGoogleCalendarUrl(calendarData, appUrl, { join: t("public.addToCalendar.calendarJoin"), organizedBy: t("public.addToCalendar.calendarOrganizedBy") })} target="_blank" rel="noopener noreferrer">
-                <svg width="13" height="13" viewBox="0 0 48 48" aria-hidden="true">
-                  <path fill="#EA4335" d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"/>
-                  <path fill="#4285F4" d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"/>
-                  <path fill="#FBBC05" d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"/>
-                  <path fill="#34A853" d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"/>
-                </svg>
-                {t("public.addToCalendar.google")}
-              </a>
-            </Button>
-            <Button variant="outline" className="h-[34px] flex-1 gap-1.5 rounded-xl text-xs" asChild>
-              <a href={`/api/moments/${calendarData.slug}/calendar`} download={`${calendarData.slug}.ics`}>
-                <Download className="size-3" />
-                {t("public.addToCalendar.ics")}
-              </a>
-            </Button>
-          </div>
-        )}
-
-        {/* Annuler — lien texte discret */}
-        {!isHost && (
-          <AlertDialog>
-            <AlertDialogTrigger asChild>
-              <button className="text-muted-foreground hover:text-destructive w-full text-center text-xs underline underline-offset-2 transition-colors">
-                {t("public.cancelRegistration")}
-              </button>
-            </AlertDialogTrigger>
-            <AlertDialogContent>
-              <AlertDialogHeader>
-                <AlertDialogTitle>
-                  {t("public.cancelConfirmTitle")}
-                </AlertDialogTitle>
-                <AlertDialogDescription>
-                  {t("public.cancelConfirmDescription")}
-                </AlertDialogDescription>
-              </AlertDialogHeader>
-              {price > 0 && existingRegistration?.paymentStatus === "PAID" && (
-                <div className={`rounded-md p-3 text-sm ${refundable ? "bg-green-500/10 text-green-500" : "bg-amber-500/10 text-amber-500"}`}>
-                  {refundable
-                    ? t("public.cancelRefundableInfo")
-                    : t("public.cancelNonRefundableWarning")}
-                </div>
-              )}
-              {error && (
-                <div className="bg-destructive/10 text-destructive rounded-md p-3 text-sm">
-                  {error}
-                </div>
-              )}
-              <AlertDialogFooter>
-                <AlertDialogCancel>{tCommon("cancel")}</AlertDialogCancel>
-                <AlertDialogAction
-                  variant="destructive"
-                  disabled={isPending}
-                  onClick={() => {
-                    if (!localRegistrationId) return;
-                    startTransition(async () => {
-                      setError(null);
-                      const result = await cancelRegistrationAction(
-                        localRegistrationId
-                      );
-                      if (result.success) {
-                        posthog.capture("registration_cancelled", {
-                          moment_id: momentId,
-                          circle_id: circleId,
-                        });
-                        setLocalStatus(null);
-                        setLocalRegistrationId(null);
-                        router.refresh();
-                      } else {
-                        setError(result.error);
-                      }
-                    });
-                  }}
-                >
-                  {isPending ? tCommon("loading") : t("public.confirmCancel")}
-                </AlertDialogAction>
-              </AlertDialogFooter>
-            </AlertDialogContent>
-          </AlertDialog>
-        )}
       </div>
     );
   }

--- a/src/domain/errors/comment-attachment-errors.ts
+++ b/src/domain/errors/comment-attachment-errors.ts
@@ -1,0 +1,25 @@
+import { DomainError } from "./domain-error";
+
+export class CommentPhotoLimitReachedError extends DomainError {
+  readonly code = "COMMENT_PHOTO_LIMIT_REACHED";
+
+  constructor(limit: number) {
+    super(`Comment photo limit reached (${limit} per comment)`);
+  }
+}
+
+export class CommentPhotoTooLargeError extends DomainError {
+  readonly code = "COMMENT_PHOTO_TOO_LARGE";
+
+  constructor(maxBytes: number) {
+    super(`Comment photo too large (max ${maxBytes} bytes)`);
+  }
+}
+
+export class CommentPhotoTypeNotAllowedError extends DomainError {
+  readonly code = "COMMENT_PHOTO_TYPE_NOT_ALLOWED";
+
+  constructor(contentType: string) {
+    super(`Comment photo type not allowed: ${contentType}`);
+  }
+}

--- a/src/domain/errors/index.ts
+++ b/src/domain/errors/index.ts
@@ -50,3 +50,8 @@ export {
   StripeConnectNotActiveError,
   StripeConnectAlreadyActiveError,
 } from "./stripe-errors";
+export {
+  CommentPhotoLimitReachedError,
+  CommentPhotoTooLargeError,
+  CommentPhotoTypeNotAllowedError,
+} from "./comment-attachment-errors";

--- a/src/domain/models/comment-attachment.ts
+++ b/src/domain/models/comment-attachment.ts
@@ -1,0 +1,19 @@
+export type CommentAttachment = {
+  id: string;
+  commentId: string;
+  url: string;
+  filename: string;
+  contentType: string;
+  sizeBytes: number;
+  createdAt: Date;
+};
+
+export const MAX_COMMENT_PHOTOS = 3;
+export const MAX_COMMENT_PHOTO_SIZE_BYTES = 5 * 1024 * 1024; // 5 MB
+export const CLIENT_COMPRESS_THRESHOLD_BYTES = 3 * 1024 * 1024; // 3 MB
+
+export const ALLOWED_COMMENT_PHOTO_TYPES: ReadonlySet<string> = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+]);

--- a/src/domain/models/comment.ts
+++ b/src/domain/models/comment.ts
@@ -1,3 +1,5 @@
+import type { CommentAttachment } from "./comment-attachment";
+
 export type Comment = {
   id: string;
   momentId: string;
@@ -15,4 +17,5 @@ export type CommentWithUser = Comment & {
     email: string;
     image: string | null;
   };
+  attachments: CommentAttachment[];
 };

--- a/src/domain/ports/repositories/comment-attachment-repository.ts
+++ b/src/domain/ports/repositories/comment-attachment-repository.ts
@@ -1,0 +1,15 @@
+import type { CommentAttachment } from "@/domain/models/comment-attachment";
+
+export type CreateCommentAttachmentInput = {
+  commentId: string;
+  url: string;
+  filename: string;
+  contentType: string;
+  sizeBytes: number;
+};
+
+export interface CommentAttachmentRepository {
+  create(input: CreateCommentAttachmentInput): Promise<CommentAttachment>;
+  findByComment(commentId: string): Promise<CommentAttachment[]>;
+  deleteByComment(commentId: string): Promise<void>;
+}

--- a/src/domain/usecases/__tests__/add-comment.test.ts
+++ b/src/domain/usecases/__tests__/add-comment.test.ts
@@ -1,23 +1,55 @@
 import { describe, it, expect, vi } from "vitest";
 import { addComment } from "@/domain/usecases/add-comment";
+import type { CommentPhotoInput } from "@/domain/usecases/add-comment";
 import { createMockCommentRepository, makeComment } from "./helpers/mock-comment-repository";
 import { createMockMomentRepository, makeMoment } from "./helpers/mock-moment-repository";
+import { createMockCommentAttachmentRepository } from "./helpers/mock-comment-attachment-repository";
+import { createMockStorageService } from "./helpers/mock-storage-service";
 import {
   CommentContentEmptyError,
   CommentContentTooLongError,
+  CommentPhotoLimitReachedError,
+  CommentPhotoTooLargeError,
+  CommentPhotoTypeNotAllowedError,
   MomentNotFoundError,
 } from "@/domain/errors";
+import {
+  MAX_COMMENT_PHOTO_SIZE_BYTES,
+} from "@/domain/models/comment-attachment";
+
+function makePhoto(overrides: Partial<CommentPhotoInput> = {}): CommentPhotoInput {
+  return {
+    buffer: Buffer.from("fake-image-content"),
+    filename: "photo.jpg",
+    contentType: "image/jpeg",
+    sizeBytes: 100_000,
+    ...overrides,
+  };
+}
 
 describe("AddComment", () => {
   function makeDeps(overrides: {
     commentRepository?: Partial<ReturnType<typeof createMockCommentRepository>>;
     momentRepository?: Partial<ReturnType<typeof createMockMomentRepository>>;
+    commentAttachmentRepository?: Partial<ReturnType<typeof createMockCommentAttachmentRepository>>;
+    storage?: Partial<ReturnType<typeof createMockStorageService>>;
   } = {}) {
     return {
       commentRepository: createMockCommentRepository(overrides.commentRepository),
       momentRepository: createMockMomentRepository(overrides.momentRepository),
+      commentAttachmentRepository: createMockCommentAttachmentRepository(overrides.commentAttachmentRepository),
+      storage: createMockStorageService(overrides.storage),
     };
   }
+
+  function depsWithMoment(overrides: Parameters<typeof makeDeps>[0] = {}) {
+    return makeDeps({
+      momentRepository: { findById: vi.fn().mockResolvedValue(makeMoment()) },
+      ...overrides,
+    });
+  }
+
+  // --- Text-only comments (existing behavior) ---
 
   describe("given a valid Moment and non-empty content", () => {
     it("should create and return the comment", async () => {
@@ -38,6 +70,7 @@ describe("AddComment", () => {
       );
 
       expect(result.comment).toEqual(comment);
+      expect(result.photoCount).toBe(0);
       expect(deps.commentRepository.create).toHaveBeenCalledWith({
         momentId: "moment-1",
         userId: "user-1",
@@ -119,6 +152,240 @@ describe("AddComment", () => {
       await expect(
         addComment(
           { momentId: "moment-999", userId: "user-1", content: "Hello" },
+          deps
+        )
+      ).rejects.toThrow(MomentNotFoundError);
+    });
+  });
+
+  // --- Comments with photos ---
+
+  describe("given valid content and valid photos", () => {
+    it("should create comment and upload photos", async () => {
+      const comment = makeComment();
+      const deps = depsWithMoment({
+        commentRepository: { create: vi.fn().mockResolvedValue(comment) },
+      });
+
+      const result = await addComment(
+        {
+          momentId: "moment-1",
+          userId: "user-1",
+          content: "Great event!",
+          photos: [makePhoto(), makePhoto({ filename: "photo2.png", contentType: "image/png" })],
+        },
+        deps
+      );
+
+      expect(result.comment).toEqual(comment);
+      expect(result.photoCount).toBe(2);
+      expect(deps.storage.upload).toHaveBeenCalledTimes(2);
+      expect(deps.commentAttachmentRepository.create).toHaveBeenCalledTimes(2);
+    });
+
+    it("should upload photos in parallel", async () => {
+      const callOrder: string[] = [];
+      const deps = depsWithMoment({
+        storage: {
+          upload: vi.fn().mockImplementation(async () => {
+            callOrder.push("upload-start");
+            await new Promise((r) => setTimeout(r, 10));
+            callOrder.push("upload-end");
+            return "https://blob.test/photo.jpg";
+          }),
+        },
+      });
+
+      await addComment(
+        {
+          momentId: "moment-1",
+          userId: "user-1",
+          content: "Parallel test",
+          photos: [makePhoto(), makePhoto()],
+        },
+        deps
+      );
+
+      // Both uploads should start before either finishes
+      expect(callOrder[0]).toBe("upload-start");
+      expect(callOrder[1]).toBe("upload-start");
+    });
+  });
+
+  describe("given valid content and 0 photos", () => {
+    it("should create comment only (retro-compatible)", async () => {
+      const deps = depsWithMoment();
+
+      const result = await addComment(
+        { momentId: "moment-1", userId: "user-1", content: "No photos" },
+        deps
+      );
+
+      expect(result.photoCount).toBe(0);
+      expect(deps.storage.upload).not.toHaveBeenCalled();
+      expect(deps.commentAttachmentRepository.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("given too many photos", () => {
+    it("should throw CommentPhotoLimitReachedError for 4 photos", async () => {
+      const deps = depsWithMoment();
+
+      await expect(
+        addComment(
+          {
+            momentId: "moment-1",
+            userId: "user-1",
+            content: "Too many photos",
+            photos: [makePhoto(), makePhoto(), makePhoto(), makePhoto()],
+          },
+          deps
+        )
+      ).rejects.toThrow(CommentPhotoLimitReachedError);
+
+      // No side-effect: comment should NOT be created
+      expect(deps.commentRepository.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("given photos with invalid types", () => {
+    it.each([
+      ["image/gif", "GIF"],
+      ["application/pdf", "PDF"],
+      ["image/svg+xml", "SVG"],
+      ["text/plain", "text"],
+    ])("should throw CommentPhotoTypeNotAllowedError for %s (%s)", async (contentType) => {
+      const deps = depsWithMoment();
+
+      await expect(
+        addComment(
+          {
+            momentId: "moment-1",
+            userId: "user-1",
+            content: "Bad type",
+            photos: [makePhoto({ contentType })],
+          },
+          deps
+        )
+      ).rejects.toThrow(CommentPhotoTypeNotAllowedError);
+
+      expect(deps.commentRepository.create).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      ["image/jpeg", "JPEG"],
+      ["image/png", "PNG"],
+      ["image/webp", "WebP"],
+    ])("should accept %s (%s)", async (contentType) => {
+      const deps = depsWithMoment();
+
+      await expect(
+        addComment(
+          {
+            momentId: "moment-1",
+            userId: "user-1",
+            content: "Good type",
+            photos: [makePhoto({ contentType })],
+          },
+          deps
+        )
+      ).resolves.toBeDefined();
+    });
+  });
+
+  describe("given photos that exceed size limit", () => {
+    it("should throw CommentPhotoTooLargeError for photo > 5 MB", async () => {
+      const deps = depsWithMoment();
+
+      await expect(
+        addComment(
+          {
+            momentId: "moment-1",
+            userId: "user-1",
+            content: "Too large",
+            photos: [makePhoto({ sizeBytes: MAX_COMMENT_PHOTO_SIZE_BYTES + 1 })],
+          },
+          deps
+        )
+      ).rejects.toThrow(CommentPhotoTooLargeError);
+
+      expect(deps.commentRepository.create).not.toHaveBeenCalled();
+    });
+
+    it("should accept photo at exactly 5 MB", async () => {
+      const deps = depsWithMoment();
+
+      await expect(
+        addComment(
+          {
+            momentId: "moment-1",
+            userId: "user-1",
+            content: "Exact limit",
+            photos: [makePhoto({ sizeBytes: MAX_COMMENT_PHOTO_SIZE_BYTES })],
+          },
+          deps
+        )
+      ).resolves.toBeDefined();
+    });
+  });
+
+  describe("given valid photos but empty content", () => {
+    it("should throw CommentContentEmptyError (text is mandatory)", async () => {
+      const deps = depsWithMoment();
+
+      await expect(
+        addComment(
+          {
+            momentId: "moment-1",
+            userId: "user-1",
+            content: "",
+            photos: [makePhoto()],
+          },
+          deps
+        )
+      ).rejects.toThrow(CommentContentEmptyError);
+    });
+  });
+
+  describe("given photo validation fails", () => {
+    it("should not create the comment (no side-effect before validation)", async () => {
+      const deps = depsWithMoment();
+
+      await expect(
+        addComment(
+          {
+            momentId: "moment-1",
+            userId: "user-1",
+            content: "Valid text",
+            photos: [makePhoto({ contentType: "image/gif" })],
+          },
+          deps
+        )
+      ).rejects.toThrow(CommentPhotoTypeNotAllowedError);
+
+      expect(deps.commentRepository.create).not.toHaveBeenCalled();
+      expect(deps.storage.upload).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("given user with PENDING_APPROVAL registration and photos", () => {
+    it("should throw MomentNotFoundError (same block as text-only)", async () => {
+      const mockRegistrationRepo = {
+        findByMomentAndUser: vi.fn().mockResolvedValue({ status: "PENDING_APPROVAL" }),
+      };
+      const deps = {
+        ...depsWithMoment(),
+        registrationRepository: mockRegistrationRepo as never,
+      };
+
+      await expect(
+        addComment(
+          {
+            momentId: "moment-1",
+            userId: "user-1",
+            content: "With photos",
+            photos: [makePhoto()],
+          },
           deps
         )
       ).rejects.toThrow(MomentNotFoundError);

--- a/src/domain/usecases/__tests__/delete-comment.test.ts
+++ b/src/domain/usecases/__tests__/delete-comment.test.ts
@@ -3,6 +3,8 @@ import { deleteComment } from "@/domain/usecases/delete-comment";
 import { createMockCommentRepository, makeComment } from "./helpers/mock-comment-repository";
 import { createMockMomentRepository, makeMoment } from "./helpers/mock-moment-repository";
 import { createMockCircleRepository, makeMembership } from "./helpers/mock-circle-repository";
+import { createMockCommentAttachmentRepository, makeCommentAttachment } from "./helpers/mock-comment-attachment-repository";
+import { createMockStorageService } from "./helpers/mock-storage-service";
 import {
   CommentNotFoundError,
   UnauthorizedCommentDeletionError,
@@ -13,11 +15,15 @@ describe("DeleteComment", () => {
     commentRepository?: Partial<ReturnType<typeof createMockCommentRepository>>;
     momentRepository?: Partial<ReturnType<typeof createMockMomentRepository>>;
     circleRepository?: Partial<ReturnType<typeof createMockCircleRepository>>;
+    commentAttachmentRepository?: Partial<ReturnType<typeof createMockCommentAttachmentRepository>>;
+    storage?: Partial<ReturnType<typeof createMockStorageService>>;
   } = {}) {
     return {
       commentRepository: createMockCommentRepository(overrides.commentRepository),
       momentRepository: createMockMomentRepository(overrides.momentRepository),
       circleRepository: createMockCircleRepository(overrides.circleRepository),
+      commentAttachmentRepository: createMockCommentAttachmentRepository(overrides.commentAttachmentRepository),
+      storage: createMockStorageService(overrides.storage),
     };
   }
 
@@ -110,18 +116,116 @@ describe("DeleteComment", () => {
     it("should throw UnauthorizedCommentDeletionError", async () => {
       const comment = makeComment({ userId: "user-2", momentId: "moment-1" });
       const moment = makeMoment({ id: "moment-1", circleId: "circle-1" });
-      // Host of circle-2, not circle-1
-      const otherHostMembership = makeMembership({ userId: "other-host", circleId: "circle-2", role: "HOST" });
       const deps = makeDeps({
         commentRepository: { findById: vi.fn().mockResolvedValue(comment) },
         momentRepository: { findById: vi.fn().mockResolvedValue(moment) },
-        // findMembership for circle-1 returns null (not a member of circle-1)
         circleRepository: { findMembership: vi.fn().mockResolvedValue(null) },
       });
 
       await expect(
         deleteComment({ commentId: "comment-1", userId: "other-host" }, deps)
       ).rejects.toThrow(UnauthorizedCommentDeletionError);
+    });
+  });
+
+  // --- Blob cleanup on deletion ---
+
+  describe("given a comment with photo attachments", () => {
+    it("should delete blobs before deleting the comment", async () => {
+      const comment = makeComment({ userId: "user-1" });
+      const attachments = [
+        makeCommentAttachment({ id: "att-1", url: "https://public.blob.vercel-storage.com/photo1.jpg" }),
+        makeCommentAttachment({ id: "att-2", url: "https://public.blob.vercel-storage.com/photo2.jpg" }),
+      ];
+      const deps = makeDeps({
+        commentRepository: {
+          findById: vi.fn().mockResolvedValue(comment),
+          delete: vi.fn().mockResolvedValue(undefined),
+        },
+        commentAttachmentRepository: {
+          findByComment: vi.fn().mockResolvedValue(attachments),
+        },
+      });
+
+      await deleteComment({ commentId: "comment-1", userId: "user-1" }, deps);
+
+      expect(deps.storage.delete).toHaveBeenCalledTimes(2);
+      expect(deps.storage.delete).toHaveBeenCalledWith(attachments[0].url);
+      expect(deps.storage.delete).toHaveBeenCalledWith(attachments[1].url);
+      expect(deps.commentRepository.delete).toHaveBeenCalledWith("comment-1");
+    });
+
+    it("should still delete comment even if blob deletion fails (best-effort)", async () => {
+      const comment = makeComment({ userId: "user-1" });
+      const attachments = [
+        makeCommentAttachment({ id: "att-1", url: "https://public.blob.vercel-storage.com/photo1.jpg" }),
+      ];
+      const deps = makeDeps({
+        commentRepository: {
+          findById: vi.fn().mockResolvedValue(comment),
+          delete: vi.fn().mockResolvedValue(undefined),
+        },
+        commentAttachmentRepository: {
+          findByComment: vi.fn().mockResolvedValue(attachments),
+        },
+        storage: {
+          delete: vi.fn().mockRejectedValue(new Error("Blob service down")),
+        },
+      });
+
+      await deleteComment({ commentId: "comment-1", userId: "user-1" }, deps);
+
+      expect(deps.commentRepository.delete).toHaveBeenCalledWith("comment-1");
+    });
+
+    it("should delete blobs in parallel", async () => {
+      const comment = makeComment({ userId: "user-1" });
+      const callOrder: string[] = [];
+      const attachments = [
+        makeCommentAttachment({ id: "att-1" }),
+        makeCommentAttachment({ id: "att-2" }),
+      ];
+      const deps = makeDeps({
+        commentRepository: {
+          findById: vi.fn().mockResolvedValue(comment),
+          delete: vi.fn().mockResolvedValue(undefined),
+        },
+        commentAttachmentRepository: {
+          findByComment: vi.fn().mockResolvedValue(attachments),
+        },
+        storage: {
+          delete: vi.fn().mockImplementation(async () => {
+            callOrder.push("delete-start");
+            await new Promise((r) => setTimeout(r, 10));
+            callOrder.push("delete-end");
+          }),
+        },
+      });
+
+      await deleteComment({ commentId: "comment-1", userId: "user-1" }, deps);
+
+      expect(callOrder[0]).toBe("delete-start");
+      expect(callOrder[1]).toBe("delete-start");
+    });
+  });
+
+  describe("given a comment without attachments", () => {
+    it("should skip blob cleanup and just delete the comment", async () => {
+      const comment = makeComment({ userId: "user-1" });
+      const deps = makeDeps({
+        commentRepository: {
+          findById: vi.fn().mockResolvedValue(comment),
+          delete: vi.fn().mockResolvedValue(undefined),
+        },
+        commentAttachmentRepository: {
+          findByComment: vi.fn().mockResolvedValue([]),
+        },
+      });
+
+      await deleteComment({ commentId: "comment-1", userId: "user-1" }, deps);
+
+      expect(deps.storage.delete).not.toHaveBeenCalled();
+      expect(deps.commentRepository.delete).toHaveBeenCalledWith("comment-1");
     });
   });
 });

--- a/src/domain/usecases/__tests__/helpers/mock-comment-attachment-repository.ts
+++ b/src/domain/usecases/__tests__/helpers/mock-comment-attachment-repository.ts
@@ -1,0 +1,39 @@
+import type { CommentAttachmentRepository } from "@/domain/ports/repositories/comment-attachment-repository";
+import type { CommentAttachment } from "@/domain/models/comment-attachment";
+import { vi } from "vitest";
+
+export function createMockCommentAttachmentRepository(
+  overrides: Partial<CommentAttachmentRepository> = {}
+): CommentAttachmentRepository {
+  return {
+    create: vi
+      .fn<CommentAttachmentRepository["create"]>()
+      .mockImplementation(async (input) => ({
+        id: `att-${Date.now()}`,
+        ...input,
+        createdAt: new Date("2026-01-01"),
+      })),
+    findByComment: vi
+      .fn<CommentAttachmentRepository["findByComment"]>()
+      .mockResolvedValue([]),
+    deleteByComment: vi
+      .fn<CommentAttachmentRepository["deleteByComment"]>()
+      .mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+export function makeCommentAttachment(
+  overrides: Partial<CommentAttachment> = {}
+): CommentAttachment {
+  return {
+    id: "att-1",
+    commentId: "comment-1",
+    url: "https://public.blob.vercel-storage.com/comment-photos/test.jpg",
+    filename: "photo.jpg",
+    contentType: "image/jpeg",
+    sizeBytes: 100_000,
+    createdAt: new Date("2026-01-01"),
+    ...overrides,
+  };
+}

--- a/src/domain/usecases/__tests__/helpers/mock-comment-repository.ts
+++ b/src/domain/usecases/__tests__/helpers/mock-comment-repository.ts
@@ -43,6 +43,7 @@ export function makeCommentWithUser(
       email: "alice@example.com",
       image: null,
     },
+    attachments: [],
     ...overrides,
   };
 }

--- a/src/domain/usecases/add-comment.ts
+++ b/src/domain/usecases/add-comment.ts
@@ -2,28 +2,50 @@ import type { Comment } from "@/domain/models/comment";
 import type { CommentRepository } from "@/domain/ports/repositories/comment-repository";
 import type { MomentRepository } from "@/domain/ports/repositories/moment-repository";
 import type { RegistrationRepository } from "@/domain/ports/repositories/registration-repository";
+import type { CommentAttachmentRepository } from "@/domain/ports/repositories/comment-attachment-repository";
+import type { StorageService } from "@/domain/ports/services/storage-service";
+import {
+  MAX_COMMENT_PHOTOS,
+  MAX_COMMENT_PHOTO_SIZE_BYTES,
+  ALLOWED_COMMENT_PHOTO_TYPES,
+} from "@/domain/models/comment-attachment";
 import {
   MomentNotFoundError,
   CommentContentEmptyError,
   CommentContentTooLongError,
+  CommentPhotoLimitReachedError,
+  CommentPhotoTooLargeError,
+  CommentPhotoTypeNotAllowedError,
 } from "@/domain/errors";
+import { sanitizeFilename } from "@/lib/sanitize-filename";
 
 const MAX_COMMENT_LENGTH = 2000;
+
+export type CommentPhotoInput = {
+  buffer: Buffer;
+  filename: string;
+  contentType: string;
+  sizeBytes: number;
+};
 
 type AddCommentInput = {
   momentId: string;
   userId: string;
   content: string;
+  photos?: CommentPhotoInput[];
 };
 
 type AddCommentDeps = {
   commentRepository: CommentRepository;
   momentRepository: MomentRepository;
   registrationRepository?: RegistrationRepository;
+  commentAttachmentRepository?: CommentAttachmentRepository;
+  storage?: StorageService;
 };
 
 type AddCommentResult = {
   comment: Comment;
+  photoCount: number;
 };
 
 export async function addComment(
@@ -42,12 +64,28 @@ export async function addComment(
     throw new CommentContentTooLongError(MAX_COMMENT_LENGTH);
   }
 
+  // Phase 1: validate ALL photos BEFORE any side-effect (DB/storage)
+  const photos = input.photos ?? [];
+  if (photos.length > 0) {
+    if (photos.length > MAX_COMMENT_PHOTOS) {
+      throw new CommentPhotoLimitReachedError(MAX_COMMENT_PHOTOS);
+    }
+    for (const photo of photos) {
+      if (!ALLOWED_COMMENT_PHOTO_TYPES.has(photo.contentType)) {
+        throw new CommentPhotoTypeNotAllowedError(photo.contentType);
+      }
+      if (photo.sizeBytes > MAX_COMMENT_PHOTO_SIZE_BYTES) {
+        throw new CommentPhotoTooLargeError(MAX_COMMENT_PHOTO_SIZE_BYTES);
+      }
+    }
+  }
+
   const moment = await momentRepository.findById(input.momentId);
   if (!moment) {
     throw new MomentNotFoundError(input.momentId);
   }
 
-  // D11: block comments from users with PENDING_APPROVAL registration
+  // Block comments from users with PENDING_APPROVAL registration
   if (deps.registrationRepository) {
     const registration = await deps.registrationRepository.findByMomentAndUser(
       input.momentId,
@@ -58,11 +96,38 @@ export async function addComment(
     }
   }
 
+  // Phase 2: create comment, then upload photos
   const comment = await commentRepository.create({
     momentId: input.momentId,
     userId: input.userId,
     content: trimmed,
   });
 
-  return { comment };
+  let uploadedCount = 0;
+  if (
+    photos.length > 0 &&
+    deps.commentAttachmentRepository &&
+    deps.storage
+  ) {
+    for (const photo of photos) {
+      const safeName = sanitizeFilename(photo.filename);
+      const path = `comment-photos/${comment.id}-${Date.now()}-${safeName}`;
+      const url = await deps.storage.upload(
+        path,
+        photo.buffer,
+        photo.contentType
+      );
+
+      await deps.commentAttachmentRepository.create({
+        commentId: comment.id,
+        url,
+        filename: photo.filename,
+        contentType: photo.contentType,
+        sizeBytes: photo.sizeBytes,
+      });
+      uploadedCount++;
+    }
+  }
+
+  return { comment, photoCount: uploadedCount };
 }

--- a/src/domain/usecases/add-comment.ts
+++ b/src/domain/usecases/add-comment.ts
@@ -109,24 +109,26 @@ export async function addComment(
     deps.commentAttachmentRepository &&
     deps.storage
   ) {
-    for (const photo of photos) {
-      const safeName = sanitizeFilename(photo.filename);
-      const path = `comment-photos/${comment.id}-${Date.now()}-${safeName}`;
-      const url = await deps.storage.upload(
-        path,
-        photo.buffer,
-        photo.contentType
-      );
-
-      await deps.commentAttachmentRepository.create({
-        commentId: comment.id,
-        url,
-        filename: photo.filename,
-        contentType: photo.contentType,
-        sizeBytes: photo.sizeBytes,
-      });
-      uploadedCount++;
-    }
+    const { commentAttachmentRepository, storage } = deps;
+    await Promise.all(
+      photos.map(async (photo, i) => {
+        const safeName = sanitizeFilename(photo.filename);
+        const path = `comment-photos/${comment.id}-${Date.now()}-${i}-${safeName}`;
+        const url = await storage.upload(
+          path,
+          photo.buffer,
+          photo.contentType
+        );
+        await commentAttachmentRepository.create({
+          commentId: comment.id,
+          url,
+          filename: photo.filename,
+          contentType: photo.contentType,
+          sizeBytes: photo.sizeBytes,
+        });
+      })
+    );
+    uploadedCount = photos.length;
   }
 
   return { comment, photoCount: uploadedCount };

--- a/src/domain/usecases/add-moment-attachment.ts
+++ b/src/domain/usecases/add-moment-attachment.ts
@@ -15,6 +15,7 @@ import {
   AttachmentTooLargeError,
   AttachmentTypeNotAllowedError,
 } from "@/domain/errors";
+import { sanitizeFilename } from "@/lib/sanitize-filename";
 
 type AddMomentAttachmentInput = {
   momentId: string;
@@ -79,13 +80,4 @@ export async function addMomentAttachment(
     contentType: input.file.contentType,
     sizeBytes: input.file.sizeBytes,
   });
-}
-
-function sanitizeFilename(filename: string): string {
-  const ascii = filename.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
-  const safe = ascii
-    .replace(/[^a-zA-Z0-9._-]+/g, "-")
-    .replace(/^-+|-+$/g, "")
-    .toLowerCase();
-  return safe.length > 0 ? safe : "file";
 }

--- a/src/domain/usecases/delete-comment.ts
+++ b/src/domain/usecases/delete-comment.ts
@@ -53,16 +53,15 @@ export async function deleteComment(
     const attachments = await deps.commentAttachmentRepository.findByComment(
       input.commentId
     );
-    for (const att of attachments) {
-      try {
-        await deps.storage.delete(att.url);
-      } catch {
-        // Log but don't block deletion — orphaned blobs are recoverable
-        console.error(
-          `Failed to delete blob for comment attachment ${att.id}`
-        );
-      }
-    }
+    await Promise.all(
+      attachments.map((att) =>
+        deps.storage!.delete(att.url).catch(() => {
+          console.error(
+            `Failed to delete blob for comment attachment ${att.id}`
+          );
+        })
+      )
+    );
   }
 
   // Cascade on Comment deletes CommentAttachment rows automatically

--- a/src/domain/usecases/delete-comment.ts
+++ b/src/domain/usecases/delete-comment.ts
@@ -1,6 +1,8 @@
 import type { CommentRepository } from "@/domain/ports/repositories/comment-repository";
 import type { MomentRepository } from "@/domain/ports/repositories/moment-repository";
 import type { CircleRepository } from "@/domain/ports/repositories/circle-repository";
+import type { CommentAttachmentRepository } from "@/domain/ports/repositories/comment-attachment-repository";
+import type { StorageService } from "@/domain/ports/services/storage-service";
 import {
   CommentNotFoundError,
   UnauthorizedCommentDeletionError,
@@ -15,6 +17,8 @@ type DeleteCommentDeps = {
   commentRepository: CommentRepository;
   momentRepository: MomentRepository;
   circleRepository: CircleRepository;
+  commentAttachmentRepository?: CommentAttachmentRepository;
+  storage?: StorageService;
 };
 
 export async function deleteComment(
@@ -28,24 +32,39 @@ export async function deleteComment(
     throw new CommentNotFoundError(input.commentId);
   }
 
-  // Author can always delete their own comment
-  if (comment.userId === input.userId) {
-    await commentRepository.delete(input.commentId);
-    return;
-  }
-
-  // A Host of the Circle that owns the Moment can delete any comment
-  const moment = await momentRepository.findById(comment.momentId);
-  if (moment) {
+  // Check authorization: author or host can delete
+  const isAuthor = comment.userId === input.userId;
+  if (!isAuthor) {
+    const moment = await momentRepository.findById(comment.momentId);
+    if (!moment) {
+      throw new UnauthorizedCommentDeletionError();
+    }
     const membership = await circleRepository.findMembership(
       moment.circleId,
       input.userId
     );
-    if (membership?.role === "HOST") {
-      await commentRepository.delete(input.commentId);
-      return;
+    if (membership?.role !== "HOST") {
+      throw new UnauthorizedCommentDeletionError();
     }
   }
 
-  throw new UnauthorizedCommentDeletionError();
+  // Best-effort blob cleanup before DB deletion
+  if (deps.commentAttachmentRepository && deps.storage) {
+    const attachments = await deps.commentAttachmentRepository.findByComment(
+      input.commentId
+    );
+    for (const att of attachments) {
+      try {
+        await deps.storage.delete(att.url);
+      } catch {
+        // Log but don't block deletion — orphaned blobs are recoverable
+        console.error(
+          `Failed to delete blob for comment attachment ${att.id}`
+        );
+      }
+    }
+  }
+
+  // Cascade on Comment deletes CommentAttachment rows automatically
+  await commentRepository.delete(input.commentId);
 }

--- a/src/infrastructure/repositories/index.ts
+++ b/src/infrastructure/repositories/index.ts
@@ -3,6 +3,7 @@ export { prismaMomentRepository } from "./prisma-moment-repository";
 export { prismaRegistrationRepository } from "./prisma-registration-repository";
 export { prismaUserRepository } from "./prisma-user-repository";
 export { prismaCommentRepository } from "./prisma-comment-repository";
+export { prismaCommentAttachmentRepository } from "./prisma-comment-attachment-repository";
 export { prismaMomentAttachmentRepository } from "./prisma-moment-attachment-repository";
 export { prismaAdminRepository } from "./prisma-admin-repository";
 export { prismaCircleNetworkRepository } from "./prisma-circle-network-repository";

--- a/src/infrastructure/repositories/prisma-comment-attachment-repository.ts
+++ b/src/infrastructure/repositories/prisma-comment-attachment-repository.ts
@@ -1,0 +1,46 @@
+import { prisma } from "@/infrastructure/db/prisma";
+import type {
+  CommentAttachmentRepository,
+  CreateCommentAttachmentInput,
+} from "@/domain/ports/repositories/comment-attachment-repository";
+import type { CommentAttachment } from "@/domain/models/comment-attachment";
+import type { CommentAttachment as PrismaCommentAttachment } from "@prisma/client";
+
+function toDomain(record: PrismaCommentAttachment): CommentAttachment {
+  return {
+    id: record.id,
+    commentId: record.commentId,
+    url: record.url,
+    filename: record.filename,
+    contentType: record.contentType,
+    sizeBytes: record.sizeBytes,
+    createdAt: record.createdAt,
+  };
+}
+
+export const prismaCommentAttachmentRepository: CommentAttachmentRepository = {
+  async create(input: CreateCommentAttachmentInput): Promise<CommentAttachment> {
+    const record = await prisma.commentAttachment.create({
+      data: {
+        commentId: input.commentId,
+        url: input.url,
+        filename: input.filename,
+        contentType: input.contentType,
+        sizeBytes: input.sizeBytes,
+      },
+    });
+    return toDomain(record);
+  },
+
+  async findByComment(commentId: string): Promise<CommentAttachment[]> {
+    const records = await prisma.commentAttachment.findMany({
+      where: { commentId },
+      orderBy: { createdAt: "asc" },
+    });
+    return records.map(toDomain);
+  },
+
+  async deleteByComment(commentId: string): Promise<void> {
+    await prisma.commentAttachment.deleteMany({ where: { commentId } });
+  },
+};

--- a/src/infrastructure/repositories/prisma-comment-repository.ts
+++ b/src/infrastructure/repositories/prisma-comment-repository.ts
@@ -4,7 +4,11 @@ import type {
   CreateCommentInput,
 } from "@/domain/ports/repositories/comment-repository";
 import type { Comment, CommentWithUser } from "@/domain/models/comment";
-import type { Comment as PrismaComment } from "@prisma/client";
+import type { CommentAttachment } from "@/domain/models/comment-attachment";
+import type {
+  Comment as PrismaComment,
+  CommentAttachment as PrismaCommentAttachment,
+} from "@prisma/client";
 
 function toDomainComment(record: PrismaComment): Comment {
   return {
@@ -17,6 +21,20 @@ function toDomainComment(record: PrismaComment): Comment {
   };
 }
 
+function toDomainCommentAttachment(
+  record: PrismaCommentAttachment
+): CommentAttachment {
+  return {
+    id: record.id,
+    commentId: record.commentId,
+    url: record.url,
+    filename: record.filename,
+    contentType: record.contentType,
+    sizeBytes: record.sizeBytes,
+    createdAt: record.createdAt,
+  };
+}
+
 type PrismaCommentWithUser = PrismaComment & {
   user: {
     id: string;
@@ -25,6 +43,7 @@ type PrismaCommentWithUser = PrismaComment & {
     email: string;
     image: string | null;
   };
+  attachments: PrismaCommentAttachment[];
 };
 
 function toDomainCommentWithUser(record: PrismaCommentWithUser): CommentWithUser {
@@ -37,6 +56,7 @@ function toDomainCommentWithUser(record: PrismaCommentWithUser): CommentWithUser
       email: record.user.email,
       image: record.user.image,
     },
+    attachments: record.attachments.map(toDomainCommentAttachment),
   };
 }
 
@@ -69,6 +89,9 @@ export const prismaCommentRepository: CommentRepository = {
             email: true,
             image: true,
           },
+        },
+        attachments: {
+          orderBy: { createdAt: "asc" },
         },
       },
       orderBy: { createdAt: "asc" },

--- a/src/lib/coarse-pointer.ts
+++ b/src/lib/coarse-pointer.ts
@@ -1,0 +1,9 @@
+/**
+ * Detects touch-first devices (phones, tablets) at call time.
+ * `(pointer: coarse)` matches fingers vs. `fine` for mouse/trackpad.
+ * Returns false during SSR — safe to call only in event handlers.
+ */
+export function isCoarsePointer(): boolean {
+  if (typeof window === "undefined") return false;
+  return window.matchMedia("(pointer: coarse)").matches;
+}

--- a/src/lib/image-compress.ts
+++ b/src/lib/image-compress.ts
@@ -51,14 +51,26 @@ export async function compressCommentPhoto(file: File): Promise<Blob> {
 
       ctx.drawImage(img, 0, 0, targetW, targetH);
 
+      function releaseCanvas() {
+        canvas.width = 0;
+        canvas.height = 0;
+      }
+
       canvas.toBlob(
         (blob) => {
+          releaseCanvas();
           if (blob) {
             resolve(blob);
           } else {
-            // Fallback to JPEG if WebP is not supported
-            canvas.toBlob(
+            const fallback = document.createElement("canvas");
+            fallback.width = targetW;
+            fallback.height = targetH;
+            const fbCtx = fallback.getContext("2d");
+            fbCtx?.drawImage(img, 0, 0, targetW, targetH);
+            fallback.toBlob(
               (fallbackBlob) => {
+                fallback.width = 0;
+                fallback.height = 0;
                 if (fallbackBlob) {
                   resolve(fallbackBlob);
                 } else {

--- a/src/lib/image-compress.ts
+++ b/src/lib/image-compress.ts
@@ -1,0 +1,85 @@
+import { CLIENT_COMPRESS_THRESHOLD_BYTES } from "@/domain/models/comment-attachment";
+
+/**
+ * Compresses a comment photo if it exceeds the 3 MB threshold.
+ * Unlike resizeImage() (square centre-crop for avatars/covers),
+ * this function preserves the original aspect ratio.
+ *
+ * - File <= 3 MB → returned as-is (no transformation)
+ * - File > 3 MB  → scaled down (longest side = 1920px), 0.8 quality, WebP
+ * - Aspect ratio is ALWAYS preserved (no crop)
+ * - Typical result: 12 MB iPhone photo → ~200-400 KB WebP at 1920px
+ */
+export async function compressCommentPhoto(file: File): Promise<Blob> {
+  if (file.size <= CLIENT_COMPRESS_THRESHOLD_BYTES) {
+    return file;
+  }
+
+  const maxDimension = 1920;
+  const quality = 0.8;
+  const format = "image/webp";
+
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    const objectUrl = URL.createObjectURL(file);
+
+    img.onload = () => {
+      URL.revokeObjectURL(objectUrl);
+      const { naturalWidth: w, naturalHeight: h } = img;
+
+      // Scale down: longest side → maxDimension, ratio preserved
+      let targetW = w;
+      let targetH = h;
+      if (w > maxDimension || h > maxDimension) {
+        if (w >= h) {
+          targetW = maxDimension;
+          targetH = Math.round(h * (maxDimension / w));
+        } else {
+          targetH = maxDimension;
+          targetW = Math.round(w * (maxDimension / h));
+        }
+      }
+
+      const canvas = document.createElement("canvas");
+      canvas.width = targetW;
+      canvas.height = targetH;
+      const ctx = canvas.getContext("2d");
+      if (!ctx) {
+        reject(new Error("Canvas 2D context unavailable"));
+        return;
+      }
+
+      ctx.drawImage(img, 0, 0, targetW, targetH);
+
+      canvas.toBlob(
+        (blob) => {
+          if (blob) {
+            resolve(blob);
+          } else {
+            // Fallback to JPEG if WebP is not supported
+            canvas.toBlob(
+              (fallbackBlob) => {
+                if (fallbackBlob) {
+                  resolve(fallbackBlob);
+                } else {
+                  reject(new Error("Image export failed"));
+                }
+              },
+              "image/jpeg",
+              quality
+            );
+          }
+        },
+        format,
+        quality
+      );
+    };
+
+    img.onerror = () => {
+      URL.revokeObjectURL(objectUrl);
+      reject(new Error("Image load failed"));
+    };
+
+    img.src = objectUrl;
+  });
+}

--- a/src/lib/sanitize-filename.ts
+++ b/src/lib/sanitize-filename.ts
@@ -1,0 +1,16 @@
+/**
+ * Sanitizes a filename for safe storage and URL usage.
+ * - Strips diacritics (NFD decomposition)
+ * - Replaces non-ASCII / special characters with hyphens
+ * - Trims leading/trailing hyphens
+ * - Lowercases the result
+ * - Falls back to "file" if nothing remains
+ */
+export function sanitizeFilename(filename: string): string {
+  const ascii = filename.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
+  const safe = ascii
+    .replace(/[^a-zA-Z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .toLowerCase();
+  return safe.length > 0 ? safe : "file";
+}


### PR DESCRIPTION
## Summary

- Permettre à tout inscrit de joindre jusqu'à 3 photos à un commentaire (JPEG, PNG, WebP)
- Compression automatique côté client si > 3 Mo (ratio préservé, max 1920px, WebP)
- Affichage : vignettes carrées pour 2-3 photos, ratio libre pour une seule photo
- Lightbox desktop, ouverture directe en nouvel onglet sur mobile (pinch-to-zoom natif)
- Upload atomique (texte + photos ensemble), validation MIME par magic bytes côté serveur
- Cleanup best-effort des blobs Vercel à la suppression d'un commentaire
- Redesign du bloc inscription sur la page événement

## Détails techniques

- Nouveau modèle Prisma `CommentAttachment` (cascade delete, index)
- Architecture hexagonale : modèle domaine, erreurs, port, repository, usecases modifiés
- `sanitizeFilename()` extrait dans `lib/` (partagé avec moment-attachments)
- `isCoarsePointer()` extrait dans `lib/` (partagé avec moment-attachments-list)
- Upload et blob deletions en parallèle (`Promise.all`)
- Type guards (`instanceof`/`typeof`) dans la server action (pas de `as` casts)
- PostHog `comment_posted` enrichi avec `photo_count`

## Test plan

- [x] Typecheck passe
- [x] 908 tests unitaires verts (+20 nouveaux tests photos)
- [ ] `pnpm db:push:prod` avant merge (nouvelle table `comment_attachments`)
- [ ] Tester visuellement : poster un commentaire avec 1, 2, 3 photos
- [ ] Tester le redimensionnement auto (photo > 3 Mo depuis mobile)
- [ ] Tester la lightbox desktop et l'ouverture nouvel onglet mobile
- [ ] Tester la suppression d'un commentaire avec photos
- [ ] Vérifier la page Aide (section commentaires mise à jour)
- [ ] Vérifier i18n FR et EN

🤖 Generated with [Claude Code](https://claude.com/claude-code)