### PR TITLE
chore: réactiver Vercel Speed Insights

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -10,6 +10,7 @@ import { ThemeProvider } from "@/components/providers/theme-provider";
 import { PostHogProvider } from "@/components/providers/posthog-provider";
 import { PostHogIdentity } from "@/components/providers/posthog-identity";
 import { PostHogPageView } from "@/components/providers/posthog-pageview";
+import { SpeedInsights } from "@vercel/speed-insights/next";
 import { Toaster } from "sonner";
 import "../globals.css";
 
@@ -105,6 +106,7 @@ export default async function LocaleLayout({
             </PostHogProvider>
           </SessionProvider>
         </ThemeProvider>
+        <SpeedInsights />
         <Toaster richColors position="bottom-right" />
       </body>
     </html>


### PR DESCRIPTION
## Summary
- Réactive `<SpeedInsights />` dans le layout principal
- Retiré par erreur en mars (commit `fa17fc3`) lors d'une optimisation des coûts pré-Pro
- PostHog ne couvre pas le monitoring Web Vitals (LCP, CLS, FID, TTFB)
- Speed Insights est inclus dans le plan Pro Vercel (10K data points/mois)

## Test plan
- [ ] Vérifier que Speed Insights apparaît dans le dashboard Vercel après déploiement
- [ ] Vérifier que les Core Web Vitals sont collectés sur les pages publiques

🤖 Generated with [Claude Code](https://claude.com/claude-code)