### PR TITLE
perf(dashboard+moment): Phase 1 — 4 quick wins latence

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -7,8 +7,11 @@ const withNextIntl = createNextIntlPlugin("./src/i18n/request.ts");
 
 const withPWA = withPWAInit({
   dest: "public",
-  cacheOnFrontEndNav: true,
-  aggressiveFrontEndNavCaching: true,
+  // Désactivé : cachait le HTML personnalisé du dashboard côté service worker,
+  // provoquant des données obsolètes après mutations (inscriptions, création,
+  // suppression). Le precaching des assets statiques + offline fallback restent actifs.
+  cacheOnFrontEndNav: false,
+  aggressiveFrontEndNavCaching: false,
   reloadOnOnline: true,
   disable: process.env.NODE_ENV === "development",
 });

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -269,6 +269,10 @@ model Moment {
   @@index([status, startsAt])
   // Index sur (circleId, status) : utilisé dans findPublic (circles avec moments à venir)
   @@index([circleId, status])
+  // Index composite (circleId, status, startsAt) : optimise les correlated subqueries
+  // de findAllByUserIdWithStats (dashboard) et findUpcomingByCircleId (page événement).
+  // Permet un index seek par circleId + status, puis range scan sur startsAt.
+  @@index([circleId, status, startsAt])
   // Index sur explorerScore : utilisé dans ORDER BY explorer_score DESC (Explorer)
   @@index([explorerScore])
   @@map("moments")

--- a/src/app/[locale]/(routes)/dashboard/(app)/(main)/_components/dashboard-content.tsx
+++ b/src/app/[locale]/(routes)/dashboard/(app)/(main)/_components/dashboard-content.tsx
@@ -1,10 +1,6 @@
-import { after } from "next/server";
 import { getTranslations } from "next-intl/server";
 import { measureTime } from "@/lib/perf-logger";
-import {
-  prismaMomentRepository,
-  prismaRegistrationRepository,
-} from "@/infrastructure/repositories";
+import { prismaRegistrationRepository } from "@/infrastructure/repositories";
 import { getCachedDashboardCircles, getCachedHostMoments } from "@/lib/dashboard-cache";
 import { DashboardCircleCard } from "@/components/circles/dashboard-circle-card";
 import { DashboardMomentCard } from "@/components/moments/dashboard-moment-card";
@@ -31,8 +27,8 @@ export async function DashboardContent({
   activeTab: "moments" | "circles";
   hostOnly?: boolean;
 }) {
-  // Transition PUBLISHED → PAST pour les Moments terminés — fire-and-forget après la réponse
-  after(() => prismaMomentRepository.transitionPastMoments());
+  // La transition PUBLISHED → PAST est gérée par le cron /api/cron/transition-past-moments
+  // (toutes les 5 min) — plus fiable que `after()` sur Vercel serverless ("best effort").
 
   // Requêtes fusionnées : inscriptions + communautés + host moments en parallèle
   const [

--- a/src/app/[locale]/(routes)/m/[slug]/page.tsx
+++ b/src/app/[locale]/(routes)/m/[slug]/page.tsx
@@ -1,5 +1,4 @@
 import { cache } from "react";
-import { after } from "next/server";
 import { notFound } from "next/navigation";
 import { measureTime } from "@/lib/perf-logger";
 import { isValidSlug } from "@/lib/slug";
@@ -101,8 +100,8 @@ export default async function PublicMomentPage({
   const { slug, locale } = await params;
   if (!isValidSlug(slug)) notFound();
 
-  // Transition PUBLISHED → PAST for ended Moments — fire-and-forget après la réponse
-  after(() => prismaMomentRepository.transitionPastMoments());
+  // La transition PUBLISHED → PAST est gérée par le cron /api/cron/transition-past-moments
+  // (toutes les 5 min) — plus fiable que `after()` sur Vercel serverless ("best effort").
 
   const moment = await measureTime("moment-page:moment", () => getMoment(slug));
   if (!moment) notFound();

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -4,7 +4,7 @@ import { NextIntlClientProvider, hasLocale } from "next-intl";
 import { getTranslations } from "next-intl/server";
 import { notFound } from "next/navigation";
 import { routing } from "@/i18n/routing";
-import { auth } from "@/infrastructure/auth/auth.config";
+import { getCachedSession } from "@/lib/auth-cache";
 import { SessionProvider } from "@/components/providers/session-provider";
 import { ThemeProvider } from "@/components/providers/theme-provider";
 import { PostHogProvider } from "@/components/providers/posthog-provider";
@@ -71,7 +71,7 @@ export default async function LocaleLayout({
   children: React.ReactNode;
   params: Promise<{ locale: string }>;
 }) {
-  const [{ locale }, session] = await Promise.all([params, auth()]);
+  const [{ locale }, session] = await Promise.all([params, getCachedSession()]);
 
   if (!hasLocale(routing.locales, locale)) {
     notFound();

--- a/src/app/api/cron/transition-past-moments/route.ts
+++ b/src/app/api/cron/transition-past-moments/route.ts
@@ -1,0 +1,64 @@
+import * as Sentry from "@sentry/nextjs";
+import { NextRequest, NextResponse } from "next/server";
+import { prismaMomentRepository } from "@/infrastructure/repositories";
+
+/**
+ * GET /api/cron/transition-past-moments
+ *
+ * Fait transitionner tout Moment PUBLISHED terminé vers le statut PAST.
+ * Logique : status = PUBLISHED AND (endsAt <= now OR (endsAt IS NULL AND startsAt <= now)).
+ * Idempotente : un moment déjà PAST n'est pas affecté.
+ *
+ * Remplace l'appel `after(() => transitionPastMoments())` qui tournait sur
+ * chaque chargement du dashboard et de la page événement. Problèmes résolus :
+ *  - after() sur Vercel serverless est "best effort" et peut être coupé
+ *  - chaque page view consommait une connexion pool et du compute
+ *  - exécution redondante alors que la transition dépend uniquement du temps
+ *
+ * Déclenché toutes les 5 minutes via Vercel Cron. Staleness max = 5 min,
+ * acceptable UX (bandeau "Terminé", grayscale, catégorisation upcoming/past).
+ *
+ * Protection : header Authorization: Bearer CRON_SECRET.
+ */
+
+async function handler(request: NextRequest) {
+  const authHeader = request.headers.get("authorization");
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    Sentry.captureMessage(
+      "[cron] transition-past-moments: unauthorized request",
+      "warning"
+    );
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const startedAt = Date.now();
+
+  try {
+    const count = await prismaMomentRepository.transitionPastMoments();
+    const durationMs = Date.now() - startedAt;
+
+    if (count > 0) {
+      console.log(
+        `[transition-past-moments] ${count} événement(s) basculé(s) en PAST en ${durationMs}ms`
+      );
+    }
+
+    return NextResponse.json({ success: true, transitioned: count, durationMs });
+  } catch (error) {
+    const durationMs = Date.now() - startedAt;
+    console.error(
+      `[transition-past-moments] Erreur après ${durationMs}ms :`,
+      error
+    );
+    Sentry.captureException(error, {
+      tags: { cron: "transition-past-moments" },
+      extra: { durationMs },
+    });
+    return NextResponse.json(
+      { error: "Transition failed" },
+      { status: 500 }
+    );
+  }
+}
+
+export { handler as GET, handler as POST };

--- a/vercel.json
+++ b/vercel.json
@@ -20,6 +20,10 @@
     {
       "path": "/api/cron/send-onboarding-welcome",
       "schedule": "0 6 * * *"
+    },
+    {
+      "path": "/api/cron/transition-past-moments",
+      "schedule": "*/5 * * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Phase 1 d'optimisations perf pour le dashboard (~1008ms) et la page événement (~1035ms). 4 fixes à faible risque, issus d'un audit croisé (code + logs `slow_query` prod + vérification par 8 sous-agents).

- **perf(auth)** — root layout `auth()` → `getCachedSession()` : élimine 1 `Session.findUnique` redondant (~100ms sur toutes pages protégées)
- **fix(pwa)** — désactive `aggressiveFrontEndNavCaching` + `cacheOnFrontEndNav` : le SW cachait le HTML personnalisé du dashboard, provoquant des données obsolètes après mutations
- **perf(db)** — index composite `(circleId, status, startsAt)` sur `moments` : optimise les correlated subqueries de `findAllByUserIdWithStats` (dashboard) et `findUpcomingByCircleId` (page événement)
- **perf(cron)** — `transitionPastMoments()` déplacé de `after()` (page view) vers cron toutes les 5 min : libère le pool Neon et garantit l'exécution (au lieu du "best effort" de `after()` sur Vercel serverless)

## Gain attendu cumulé

| Page | Avant | Après Phase 1 |
|---|---|---|
| Dashboard | ~1008ms | ~700-800ms |
| Page événement | ~1035ms | ~700-800ms |

S'ajoute au gain déjà déployé du passage Vercel Functions `iad1` → `fra1` (~80-100ms par query DB).

## Action requise AVANT merge

- [ ] `pnpm db:push:prod` pour créer le nouvel index en production (sinon l'app tournera sans l'index au build Vercel)

## Test plan

- [ ] CI vert (typecheck + tests unitaires)
- [ ] Après merge : monitorer `/api/cron/transition-past-moments` dans les logs Vercel (exécution toutes les 5 min, status 200, durée < 1s)
- [ ] Après merge : vérifier dans Vercel Function Logs la baisse des `slow_query` `Session.findUnique` (une seule occurrence au lieu de deux)
- [ ] Vérifier qu'après une inscription/désinscription, le dashboard reflète bien la mutation sans cache SW obsolète
- [ ] Vérifier qu'un événement terminé bascule bien en `PAST` dans les 5 min qui suivent

## Notes de suivi (non bloquant)

Après ajout du 3-col composite `(circleId, status, startsAt)`, les index `@@index([circleId])` et `@@index([circleId, status])` sont techniquement couverts par son préfixe (PostgreSQL utilise le préfixe d'un index composite). Retrait envisageable après 24-48h de stabilisation pour réduire l'overhead d'écriture + l'espace disque.

🤖 Generated with [Claude Code](https://claude.com/claude-code)