### PR TITLE
fix(email): éviter le doublon de notif d'update pour un Organisateur inscrit

### DIFF
--- a/src/app/actions/helpers/__tests__/moment-update-recipients.test.ts
+++ b/src/app/actions/helpers/__tests__/moment-update-recipients.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from "vitest";
+import { partitionMomentUpdateRecipients } from "../moment-update-recipients";
+import type { RegistrationWithUser } from "@/domain/models/registration";
+import type { CircleMemberWithUser } from "@/domain/models/circle";
+
+function makeRegistration(overrides: {
+  userId: string;
+  email: string;
+  firstName?: string | null;
+  lastName?: string | null;
+}): RegistrationWithUser {
+  return {
+    id: `reg-${overrides.userId}`,
+    momentId: "moment-1",
+    userId: overrides.userId,
+    status: "REGISTERED",
+    paymentStatus: "NONE",
+    stripePaymentIntentId: null,
+    stripeReceiptUrl: null,
+    registeredAt: new Date("2026-04-01T10:00:00Z"),
+    cancelledAt: null,
+    checkedInAt: null,
+    user: {
+      id: overrides.userId,
+      firstName: overrides.firstName ?? null,
+      lastName: overrides.lastName ?? null,
+      email: overrides.email,
+      image: null,
+      publicId: null,
+    },
+  };
+}
+
+function makeHost(overrides: {
+  userId: string;
+  email: string;
+  firstName?: string | null;
+  lastName?: string | null;
+}): CircleMemberWithUser {
+  return {
+    id: `mem-${overrides.userId}`,
+    userId: overrides.userId,
+    circleId: "circle-1",
+    role: "HOST",
+    status: "ACTIVE",
+    joinedAt: new Date("2026-03-01T10:00:00Z"),
+    user: {
+      id: overrides.userId,
+      firstName: overrides.firstName ?? null,
+      lastName: overrides.lastName ?? null,
+      email: overrides.email,
+      image: null,
+      publicId: null,
+    },
+  };
+}
+
+describe("partitionMomentUpdateRecipients", () => {
+  describe("given a Host is also registered as a participant", () => {
+    it("should exclude the Host from the participants batch so they receive only the Host version", () => {
+      const host = makeHost({ userId: "user-host", email: "host@example.com" });
+      const registrations = [
+        makeRegistration({ userId: "user-host", email: "host@example.com" }),
+        makeRegistration({ userId: "user-alice", email: "alice@example.com" }),
+      ];
+
+      const { participants, hosts } = partitionMomentUpdateRecipients(
+        registrations,
+        [host]
+      );
+
+      expect(participants.map((p) => p.to)).toEqual(["alice@example.com"]);
+      expect(hosts.map((h) => h.to)).toEqual(["host@example.com"]);
+    });
+  });
+
+  describe("given participants who are not Hosts", () => {
+    it("should include all of them in the participants batch", () => {
+      const host = makeHost({ userId: "user-host", email: "host@example.com" });
+      const registrations = [
+        makeRegistration({ userId: "user-alice", email: "alice@example.com" }),
+        makeRegistration({ userId: "user-bob", email: "bob@example.com" }),
+      ];
+
+      const { participants, hosts } = partitionMomentUpdateRecipients(
+        registrations,
+        [host]
+      );
+
+      expect(participants.map((p) => p.to).sort()).toEqual([
+        "alice@example.com",
+        "bob@example.com",
+      ]);
+      expect(hosts.map((h) => h.to)).toEqual(["host@example.com"]);
+    });
+  });
+
+  describe("given multiple Hosts in the Circle", () => {
+    it("should exclude every Host userId from the participants batch", () => {
+      const hostA = makeHost({ userId: "user-host-a", email: "a@example.com" });
+      const hostB = makeHost({ userId: "user-host-b", email: "b@example.com" });
+      const registrations = [
+        makeRegistration({ userId: "user-host-a", email: "a@example.com" }),
+        makeRegistration({ userId: "user-host-b", email: "b@example.com" }),
+        makeRegistration({ userId: "user-alice", email: "alice@example.com" }),
+      ];
+
+      const { participants, hosts } = partitionMomentUpdateRecipients(
+        registrations,
+        [hostA, hostB]
+      );
+
+      expect(participants.map((p) => p.to)).toEqual(["alice@example.com"]);
+      expect(hosts.map((h) => h.to).sort()).toEqual([
+        "a@example.com",
+        "b@example.com",
+      ]);
+    });
+  });
+
+  describe("given no registered participants", () => {
+    it("should return empty participants and still expose Hosts", () => {
+      const host = makeHost({ userId: "user-host", email: "host@example.com" });
+
+      const { participants, hosts } = partitionMomentUpdateRecipients([], [host]);
+
+      expect(participants).toEqual([]);
+      expect(hosts.map((h) => h.to)).toEqual(["host@example.com"]);
+    });
+  });
+});

--- a/src/app/actions/helpers/moment-update-recipients.ts
+++ b/src/app/actions/helpers/moment-update-recipients.ts
@@ -1,0 +1,39 @@
+import type { RegistrationWithUser } from "@/domain/models/registration";
+import type { CircleMemberWithUser } from "@/domain/models/circle";
+import { getDisplayName } from "@/lib/display-name";
+
+export type MomentUpdateRecipient = {
+  to: string;
+  playerName: string;
+};
+
+/**
+ * Sépare les destinataires d'une notif de mise à jour d'événement en deux groupes :
+ * - `participants` : inscrits REGISTERED qui ne sont PAS Organisateurs du Circle
+ * - `hosts` : Organisateurs du Circle (reçoivent la version « Organisateur » du mail)
+ *
+ * Un Organisateur inscrit à son propre événement ne reçoit donc qu'un seul email
+ * (la version Organisateur), jamais la version Participant en plus.
+ */
+export function partitionMomentUpdateRecipients(
+  confirmedRegistrations: RegistrationWithUser[],
+  hosts: CircleMemberWithUser[]
+): { participants: MomentUpdateRecipient[]; hosts: MomentUpdateRecipient[] } {
+  const hostUserIds = new Set(hosts.map((h) => h.userId));
+
+  const participants = confirmedRegistrations
+    .filter((r) => r.user?.email && !hostUserIds.has(r.userId))
+    .map((r) => ({
+      to: r.user!.email!,
+      playerName: getDisplayName(r.user!.firstName, r.user!.lastName, r.user!.email!),
+    }));
+
+  const hostRecipients = hosts
+    .filter((h) => h.user?.email)
+    .map((h) => ({
+      to: h.user!.email!,
+      playerName: getDisplayName(h.user!.firstName, h.user!.lastName, h.user!.email!),
+    }));
+
+  return { participants, hosts: hostRecipients };
+}

--- a/src/app/actions/moment.ts
+++ b/src/app/actions/moment.ts
@@ -26,6 +26,7 @@ import type { LocationType, Moment } from "@/domain/models/moment";
 import type { RegistrationWithUser } from "@/domain/models/registration";
 import type { ActionResult } from "./types";
 import { toActionResult } from "./helpers/to-action-result";
+import { partitionMomentUpdateRecipients } from "./helpers/moment-update-recipients";
 import { processCoverImage } from "./cover-image";
 import { revalidatePath } from "next/cache";
 import { invalidateDashboardCache } from "@/lib/dashboard-cache";
@@ -316,14 +317,18 @@ async function sendMomentUpdateEmails(
   t: TranslationFunction,
   locale: string
 ): Promise<void> {
-  const [circle, registrations] = await Promise.all([
+  const [circle, registrations, hosts] = await Promise.all([
     prismaCircleRepository.findById(moment.circleId),
     prismaRegistrationRepository.findActiveWithUserByMomentId(moment.id),
+    prismaCircleRepository.findMembersByRole(moment.circleId, "HOST"),
   ]);
   if (!circle) return;
 
   const confirmed = registrations.filter((r) => r.status === "REGISTERED");
   if (confirmed.length === 0) return;
+
+  const { participants: participantRecipients, hosts: hostRecipients } =
+    partitionMomentUpdateRecipients(confirmed, hosts);
 
   const dateFnsLocale = getDateFnsLocale(locale);
   const momentDate = formatInTimeZone(moment.startsAt, PLATFORM_TIMEZONE, "EEEE d MMMM yyyy, HH:mm", {
@@ -379,14 +384,7 @@ async function sendMomentUpdateEmails(
     icsContent,
   };
 
-  // Notifier les participants en batch
-  const participantRecipients = confirmed
-    .filter((r) => r.user?.email)
-    .map((r) => ({
-      to: r.user!.email!,
-      playerName: getDisplayName(r.user!.firstName, r.user!.lastName, r.user!.email!),
-    }));
-
+  // Notifier les participants (les HOSTs inscrits sont exclus, ils reçoivent la version Organisateur)
   if (participantRecipients.length > 0) {
     await emailService.sendMomentUpdateBatch({
       ...commonFields,
@@ -395,15 +393,7 @@ async function sendMomentUpdateEmails(
     });
   }
 
-  // Notifier les Organisateurs en batch
-  const hosts = await prismaCircleRepository.findMembersByRole(circle.id, "HOST");
-  const hostRecipients = hosts
-    .filter((h) => h.user?.email)
-    .map((h) => ({
-      to: h.user!.email!,
-      playerName: getDisplayName(h.user!.firstName, h.user!.lastName, h.user!.email!),
-    }));
-
+  // Notifier les Organisateurs
   if (hostRecipients.length > 0) {
     await emailService.sendMomentUpdateBatch({
       ...commonFields,


### PR DESCRIPTION
## Contexte

Lors de la modification de l'événement « After work post-AGFr » ce matin, l'Organisateur `cdeniaud@gmail.com` a reçu **deux emails** de notification de changement de date :
- La version « Participant » (car il était inscrit à son propre événement)
- La version « Organisateur » (car il est HOST du Circle)

## Cause

Dans `sendMomentUpdateEmails` (`src/app/actions/moment.ts`), deux batches étaient envoyés sans déduplication :
1. Tous les inscrits `REGISTERED` → template Participant
2. Tous les HOSTs du Circle → template Organisateur

Un Organisateur inscrit à son propre événement apparaissait dans les deux listes.

## Fix

- Les HOSTs du Circle sont exclus du batch Participants. Ils reçoivent uniquement la version Organisateur, plus informative pour eux.
- La logique de partition est extraite dans un helper pur `partitionMomentUpdateRecipients` (`src/app/actions/helpers/moment-update-recipients.ts`), testable en isolation.
- `findMembersByRole` passe du séquentiel au `Promise.all` parallèle avec les autres lectures.

## Comportement préservé

- Admin skip (`!isAdminUser(session)`) : intact.
- Early return si aucun participant `REGISTERED` : intact.
- ICS attaché (méthode REQUEST) : intact.
- Templates distincts Participant / Organisateur : intacts.

## Test plan

- [x] Typecheck passe
- [x] Tests unitaires BDD (4 cas) : HOST inscrit exclu, Participants purs, multi-HOSTs, zéro participant
- [ ] Vérifier après merge sur prod : modifier la date d'un événement auquel l'Organisateur est inscrit → un seul email reçu (la version Organisateur)

🤖 Generated with [Claude Code](https://claude.com/claude-code)