### PR TITLE
chore(dast): ne plus exposer les rapports de scan sur GitHub

### DIFF
--- a/.github/workflows/dast-preview-full.yml
+++ b/.github/workflows/dast-preview-full.yml
@@ -14,8 +14,8 @@ jobs:
     name: ZAP Full Scan — Preview
     runs-on: ubuntu-latest
     permissions:
-      issues: write
-      pull-requests: write  # Pour commenter la PR avec le résumé du scan
+      contents: read
+      actions: write # pour supprimer les artifacts publiés par l'action ZAP
 
     steps:
       - name: Checkout
@@ -30,23 +30,21 @@ jobs:
           rules_file_name: ".zap/rules.tsv"
           # Ne pas faire échouer le CI — alertes en avertissement uniquement
           fail_action: false
-          # Ouvrir une issue GitHub si de nouvelles alertes critiques sont détectées
-          allow_issue_writing: true
+          # Pas d'issue GitHub automatique (repo public : ne pas exposer les vulnérabilités)
+          allow_issue_writing: false
           # Durée max du spider (en minutes)
           cmd_options: "-m 5"
 
-      - name: Upload rapport HTML
-        uses: actions/upload-artifact@v4
+      # Le rapport reste consultable via les logs du run.
+      # L'action ZAP upload un artifact `zap_scan` par défaut — on le supprime immédiatement
+      # pour éviter toute exposition publique du rapport détaillé.
+      - name: Purger les artifacts du run (exposition publique interdite)
         if: always()
-        with:
-          name: zap-full-report-${{ github.run_number }}
-          path: report_html.html
-          retention-days: 14
-
-      - name: Upload rapport JSON
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: zap-full-report-json-${{ github.run_number }}
-          path: report_json.json
-          retention-days: 14
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ids=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts --jq '.artifacts[].id')
+          for id in $ids; do
+            echo "Suppression artifact $id"
+            gh api -X DELETE repos/${{ github.repository }}/actions/artifacts/$id
+          done

--- a/.github/workflows/dast-prod-baseline.yml
+++ b/.github/workflows/dast-prod-baseline.yml
@@ -12,7 +12,8 @@ jobs:
     name: ZAP Baseline Scan — Production
     runs-on: ubuntu-latest
     permissions:
-      issues: write  # ZAP peut ouvrir des issues GitHub sur les alertes
+      contents: read
+      actions: write # pour supprimer les artifacts publiés par l'action ZAP
 
     steps:
       - name: Checkout
@@ -27,21 +28,19 @@ jobs:
           rules_file_name: ".zap/rules.tsv"
           # Ne pas faire échouer le CI — alertes en avertissement uniquement
           fail_action: false
-          # Ouvrir une issue GitHub si de nouvelles alertes sont détectées
-          allow_issue_writing: true
+          # Pas d'issue GitHub automatique (repo public : ne pas exposer les vulnérabilités)
+          allow_issue_writing: false
 
-      - name: Upload rapport HTML
-        uses: actions/upload-artifact@v4
+      # Le rapport reste consultable via les logs du run.
+      # L'action ZAP upload un artifact `zap_scan` par défaut — on le supprime immédiatement
+      # pour éviter toute exposition publique du rapport détaillé.
+      - name: Purger les artifacts du run (exposition publique interdite)
         if: always()
-        with:
-          name: zap-baseline-report-${{ github.run_number }}
-          path: report_html.html
-          retention-days: 30
-
-      - name: Upload rapport JSON
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: zap-baseline-report-json-${{ github.run_number }}
-          path: report_json.json
-          retention-days: 30
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ids=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts --jq '.artifacts[].id')
+          for id in $ids; do
+            echo "Suppression artifact $id"
+            gh api -X DELETE repos/${{ github.repository }}/actions/artifacts/$id
+          done


### PR DESCRIPTION
## Summary

Le repo étant public, les artifacts ZAP (HTML/JSON) et les issues ouvertes automatiquement par l'action ZAP exposaient le détail des vulnérabilités détectées à tout utilisateur GitHub authentifié. Cette PR applique l'option C1 : on conserve les scans en CI mais plus aucun rapport n'est publié sur GitHub.

- Retrait des étapes `upload-artifact` explicites sur les deux workflows DAST
- `allow_issue_writing: false` : plus d'issue GitHub automatique
- Ajout d'une étape de purge qui supprime immédiatement l'artifact `zap_scan` créé automatiquement par l'action ZAP (la seule option pour le désactiver est de le supprimer a posteriori)
- Permissions resserrées : `contents: read` + `actions: write` (pour la purge)

## Mesures prises hors PR

- Suppression des 3 artifacts du dernier run manuel
- Suppression des 7 issues ZAP publiques existantes (1 ouverte + 6 fermées)

## Limite assumée

Les logs du run restent publics sur repo public : ils contiennent les alertes ZAP en texte brut. Pour du 100% local, il faudrait passer à l'option C2 (supprimer les workflows + scan ZAP via docker local). L'agent `dast-runner` devra être adapté pour parser les logs au lieu de télécharger les artifacts, à traiter dans une PR suivante.

## Test plan

- [ ] Déclencher manuellement DAST Baseline Scan Production depuis l'onglet Actions
- [ ] Vérifier que le workflow se termine en succès
- [ ] Vérifier qu'aucun artifact n'apparaît sur le run (onglet Artifacts vide)
- [ ] Vérifier qu'aucune issue n'a été créée

🤖 Generated with [Claude Code](https://claude.com/claude-code)