### PR TITLE
docs(blog): récit de 2 mois de build avec Claude Code (FR + EN)

### DIFF
--- a/src/content/blog/en/construire-avec-claude-code.md
+++ b/src/content/blog/en/construire-avec-claude-code.md
@@ -1,0 +1,356 @@
+---
+title: "What I Learned Building The Playground with Claude Code"
+description: "A Product Builder's story from the trenches. Two months, 1,780 commits, not a single line of code typed by hand: a field report on building a SaaS solo with an AI."
+date: "2026-04-17"
+author: "Dragos Dreptate"
+keywords:
+  - claude code
+  - AI
+  - product builder
+  - field report
+  - solo saas build
+  - hexagonal architecture
+  - ai agents
+---
+
+*A Product Builder's story from the trenches.*
+
+## What I built, in brief
+
+February 19, 2026, 7:53pm: first commit, an `Initial commit: Next.js 16 + Auth.js v5 + Prisma 7 + i18n`.
+
+April 16, 2026, 10:23pm: `docs(spec): add Proposed status spec and Community voting on an event`.
+
+Two months exactly. Between the two, [The Playground](https://the-playground.fr): a free platform to run communities around events, **built in France, open-source on GitHub, deployed on European servers**. Meetup's community model, Luma's premium experience, free, zero commission. Live in production, with its first users, communities and events.
+
+1,780 commits, 373 PRs, 64,000 lines, 110 test files, 10 versions shipped, strict hexagonal architecture. Stack: Next.js 16, Auth.js v5, Prisma 7 + Neon, Stripe Connect, Resend, Sentry, PostHog, Vercel. One developer, evenings and weekends.
+
+All of it built with [Claude Code](https://claude.com/claude-code). I never typed a single line of code. I never read what it wrote either. What checks the code is not my human eye, it's a chain of agents and tools.
+
+That's the heart of the story that follows.
+
+---
+
+## Day 1: nine commits for a solid foundation
+
+The first evening, in less than four hours, the platform was deployed on Vercel with:
+
+- Next.js 16 App Router
+- Auth.js v5 configured with magic link
+- Prisma 7 connected to Neon PostgreSQL serverless
+- Tailwind 4 + shadcn/ui
+- next-intl for FR/EN bilingualism
+
+None of these components is trivial to wire together. Each has its pitfalls. Auth.js v5 is still unstable, Prisma 7 changes the runtime for Vercel, next-intl enforces a precise routing structure, Neon requires a specific serverless adapter.
+
+Without AI, this first evening would have taken a week. Not because each piece is individually hard. Because it's hard **together**, and each config mistake costs you an hour of documentation and stack traces to decode.
+
+With AI, it becomes a dialogue. I describe what I want, it proposes, we adjust. When Vercel fails at deploy because `@prisma/client` isn't in the right dependencies, it spots it before I do in the logs. When Neon demands a specific adapter for the serverless runtime, it knows the name.
+
+And since the foundation was in place, the evening didn't stop there. Before midnight, the first two business features were written: the `Circle` (Communities) CRUD at 9:42pm, the `Moment` (events) CRUD at 11:37pm. With shareable public pages, forms, validations. All of it on the project's first real hexagonal architecture.
+
+> **First lesson:** the barrier to entry for a new project has collapsed. What used to take weeks now takes hours. But that says nothing about what comes next.
+
+---
+
+## Claude Code's real role: not a copilot, a demanding partner
+
+There's an image that circulates a lot about AI and code. The "copilot". You type a few lines, the AI completes the rest. Autocomplete on steroids.
+
+That's not how I worked.
+
+Claude Code, in its CLI version, doesn't do autocomplete. It's an agent. You give it an objective, it reads the code, asks questions, plans, executes, verifies. When it's wrong, it self-corrects. When you're wrong, it flags it.
+
+A concrete example. Feature "Community Networks" (v2.6.0). An evening of building, a Tuesday, 9pm to 10:30pm. When the PR opens, the diff is split into three commits by layer:
+
+```
+feat(network): add CircleNetwork schema, domain model, ports and usecases
+feat(network): add Prisma adapter and admin server actions
+feat(network): add public page, badge, admin pages and i18n
+```
+
+Domain, infrastructure, UI. Three layers, three commits. It's not that the agent writes in this order line by line, it's that the diff is *thought* in this order. The hexagonal separation is inscribed in the final artifact, reviewable, versionable.
+
+Then comes the rest of the evening: unit and E2E tests, a few `fix(network)` UX tweaks, a `refactor(network)` that cleans things up, the help page update. At 10:30pm, merge. It's not a raw speed feat, it's the rhythm of a pair that respects an architecture. The AI knows how to read a `CLAUDE.md` that imposes hexagonal, it knows not to start with the UI, it knows a usecase shouldn't import Prisma. Layers stack in the right order because the order is written down, black on white, in the project's rules.
+
+When I drift (for example, I ask for a shortcut that would violate layer separation), it flags it. It explains why that would be a problem later, and proposes the alternative that respects the contract.
+
+> **Second lesson:** a well-framed AI agent doesn't just execute blindly. It helps you hold your own rules when fatigue would push you to bend them.
+
+---
+
+## Architecture as guardrail: AI amplifies debt as much as it amplifies velocity
+
+Here's what no one says loud enough.
+
+**AI doesn't simplify system complexity. It amplifies it.**
+
+If the frame is fuzzy, you generate 10x more fuzzy code, 10x faster. Two weeks in, your project is an unreadable wasteland and every modification breaks three others.
+
+If the frame is clear, you generate 10x more clean code, 10x faster. Two months in, you have a SaaS that holds together.
+
+At my end, the frame is called hexagonal architecture. A discipline I imposed from day 1. The domain depends on nothing. Ports are TypeScript interfaces. Adapters implement ports. Usecases orchestrate.
+
+The project's `CLAUDE.md` file is 600 lines long. It contains:
+
+- Product vision and business rules
+- Strict hexagonal contract (which layer can import which)
+- Design system rules (button variants, sizes, tokens)
+- Testing strategy (BDD lightweight, test.each for spec by example)
+- Dated architectural decisions
+
+This file is read by the AI every session. It's a moral contract between me and the agent. It pins down the invariants I want to preserve even when I'm tired at 11pm and tempted to cobble together a quick fix.
+
+The commits show it. Almost systematically, a feature ends with a `refactor(...)` commit that cleans up what was just produced. It has become a reflex imposed by the agent's long-term memory: after each implementation, re-read the produced code and simplify.
+
+It's not optional. It's a rule.
+
+> **Third lesson:** the frame you set before the first commit decides what the project will be at commit 1,780. AI won't give you that for free, it only replicates what's already there.
+
+---
+
+## Long-term memory, or how not to repeat the same mistakes
+
+Claude Code maintains a persistent memory directory. Markdown files the agent writes for itself, and re-reads at the start of every session.
+
+My directory currently contains about twenty files, each dedicated to a precise topic. Examples:
+
+- `feedback_workflow_git.md`: systematic branching rules (one branch per feature, never commit direct to main, PRs with conventional title).
+- `feedback_accents_agents.md`: reminder that all written French must carry its accents.
+- `feedback_tests_never_red.md`: never leave a test red, even if flaky.
+- `feedback_release_process.md`: the full checklist for versioning with Release Please.
+- `feedback_email_content_separation.md`: every email must separate content (editable `.md`) and React template.
+
+Each file was born from a mistake. The first time it was made, I flagged it. The agent created the file. The next times, it reads it before acting. The mistake stops repeating.
+
+It's the equivalent of continuous onboarding for a teammate who never leaves the team.
+
+More interesting still: this mechanism forced me to **formalize my own rules**. When I get annoyed because the agent took a shortcut, I ask myself: this rule, did I write it down anywhere? If not, it's my fault. I write the rule. Next time, it will be held.
+
+Two months in, I have a living documentation of my engineering preferences that I had never taken the time to write down for myself.
+
+> **Fourth lesson:** working with an AI agent is writing the code and the contract that governs how that code must be written, at the same time. They train each other.
+
+---
+
+## Product, spec, exploration: how we decide what to build
+
+Up to now I've talked about code, architecture, tests. That's half the subject.
+
+The other half, the one people talk about even less when they talk about AI, is **the upstream work**. How you decide what to build, how you explore a fuzzy idea, how you turn it into something executable. That's the territory of product, spec, mockups, backlog. And that's where AI changes the craft as much, maybe more, than on the code side.
+
+On The Playground, no significant feature arrived straight into implementation. Every time, there was an **exploratory cycle** before the first line of code. And in that cycle, the agent plays an active role.
+
+**1. The exploratory conversation.**
+
+I show up with a fuzzy idea, often poorly framed. A real example: "we should be able to group several Communities under a common page, something like a federation". The agent doesn't jump on code. It asks questions: who would need this? what concrete cases do you have in mind? what alternatives exist (Meetup Pro, Eventbrite Organization)? what impact on the data model? what potential tensions with existing Communities?
+
+After 20 to 30 minutes of dialogue, the fuzzy idea has become a clear scope. That scope isn't arbitrary: it has been sculpted by questions I would have asked myself alone, but more slowly, and often after already having had useless code built.
+
+**2. The HTML mockup as intermediate artifact.**
+
+Before any implementation, I ask the agent for an **interactive HTML mockup**. A self-contained `.mockup.html` file, inline Tailwind, clickable navigation. Not a wireframe, a precise visual, pixel-accurate, showing what the user would see.
+
+It sounds trivial. It's fundamental. An HTML mockup forces decisions on details invisible in a textual spec: visual hierarchy, field order, empty states, error states, mobile behavior. And since the agent produces it in minutes, the cost of iteration is zero. I sometimes go through three versions before validating one. What would have taken a day with an external designer takes an hour.
+
+The mockup then becomes the **shared reference** for implementation. The agent that codes reads the mockup. I don't need to describe the UI in a ticket, it's already expressed.
+
+**3. The markdown spec, written by the agent from the conversation.**
+
+Once the scope is clarified and the mockup is validated, I ask the agent to **write the spec** in a markdown file under `spec/`. It synthesizes the conversation, structures the sections (context, problem, solution, technical impacts, risks, steps), lists decisions with their reasoning.
+
+I re-read the spec (yes, that I re-read, because it's intent text, not code), I correct what doesn't reflect my thinking, I add what's missing. Often very little. The agent has captured the exchange well.
+
+The spec becomes the reference document for next sessions, which can be days apart. Without a spec, the agent would forget context. With a spec, it picks up exactly where we left off.
+
+**4. The living backlog.**
+
+In parallel, a `BACKLOG.md` centralizes all upcoming ideas, prioritized P0/P1/P2, with for each entry the problem targeted, the envisioned scope, and the status. The agent reads the backlog, can propose groupings, flag dependencies between entries, suggest splits.
+
+The backlog isn't an external tool like Linear or Jira. It's a file in the repo, versioned, read-write accessible to the agent. It updates at the pace of user feedback and trade-offs. It becomes the project's product memory, always consultable.
+
+**5. The "a question is not an instruction" discipline.**
+
+A hard rule, born from several frustrations: when I ask a question ("should we be able to mark an event as proposed before it's published?"), the agent does **not** interpret it as an instruction to implement. It analyzes the impact, presents the trade-offs, asks for confirmation before writing a single line.
+
+It sounds obvious. In practice, without this explicit rule, an eager agent jumps on implementation at the first signal. And you end up with 200 lines of code on a feature you hadn't yet decided to build.
+
+This rule turns the conversation into a real **product workshop**. I explore without risk. I can say "what if we did X?" without worrying that X is already half-coded when I want to back out.
+
+> **Fifth lesson:** AI doesn't just replace technical execution. It also replaces part of the product management work: reformulating fuzzy ideas, rapid production of intermediate artifacts (mockups, specs), maintaining a living product memory. The CPO or CPTO who wants to understand where their craft is headed should pay close attention. Product itself doesn't get delegated to AI, but its **shaping** changes radically. It's the birth of a new role, the Product Builder.
+
+---
+
+## What AI does badly
+
+Not everything is rosy. There are classes of problems where AI consistently slips. Here are three, lived firsthand.
+
+**1. The blind spot on side effects.**
+
+When you ask "add a `website` field to the Community", the AI does it cleanly: migration, form, validation, display on the page. But it won't on its own update the twelve other places where this field should appear: the invitation email, the CSV export, the public API, French and English translations, the help page, the sitemap, the SEO structured data, the Host dashboard. It reasons locally, well. It reasons cross-cuttingly, badly.
+
+That's precisely why we have dedicated agents that sweep behind, each specialized on a cross-cutting axis: `docs-coherence-guardian` for doc/code coherence, `i18n-guardian` for keys forgotten between `fr.json` and `en.json`, `test-coverage-guardian` for missing E2E paths. Without this chain, side effects pile up silently. With it, they become visible and get fixed on the next PR.
+
+Corollary: **AI is formidable at solving well-framed problems, mediocre at grasping the real scope of a change**. Human work is not to re-read the code, but to design the agents that hunt what the main agent wouldn't have caught.
+
+**2. Silent over-engineering.**
+
+Without a contrary instruction, it adds defense in depth: redundant validations, try/catch everywhere, fallbacks for cases that will never occur. The code works, but it bloats.
+
+An explicit rule in `CLAUDE.md` was needed:
+
+> Never add error handling, fallback or validation for scenarios that cannot happen. Trust the internal code and framework guarantees. Only validate at the system boundaries (user input, external APIs).
+
+With this rule, the code slimmed down. Without it, it grew with every feature.
+
+**3. Hallucinations on recent libraries.**
+
+Next.js 16, Auth.js v5, Prisma 7. Three stack pillars, all recently released. The AI sometimes invents APIs that don't exist, or that existed in a previous version. I don't see it by re-reading, since I don't re-read. I see it in two places: the CI that fails on typecheck or build, and the review agents that run on the PR. Those two layers are enough, in the vast majority of cases, to surface the hallucination before merge.
+
+When a doubt remains on a "too magical" API, I don't dive into the code. I ask the agent to point to the official documentation, precise version. If it can't, that's probably because it doesn't exist, and we correct.
+
+> **Sixth lesson:** AI doesn't relieve you from controlling, but control shifts. What used to be line-by-line human reading becomes a system of automated checks: strict CI, tests, specialized review agents, observability. The developer industrializes mistrust instead of exercising it by hand.
+
+---
+
+## The agents that check the other agents
+
+This is a topic that, in my view, is fundamental and completely changes the game.
+
+When the AI writes 100% of the code and I don't re-read it by hand, the question becomes: who guarantees that what ships to prod is sound? The answer isn't "trust". The answer is a **chain of specialized agents and tools**, each with a clear responsibility on a precise axis.
+
+On The Playground, this chain looks like:
+
+- **`security-guardian`**: security audit across 6 dimensions (RBAC, IDOR, CSRF, CSP, input validation, GDPR, CI/CD, secrets). Run regularly, and systematically after any sensitive feature.
+- **`performance-guardian`**: N+1 query detection, missing indexes, JS bundle regressions, Core Web Vitals issues.
+- **`test-coverage-guardian`**: checks usecase and E2E coverage, creates missing tests.
+- **`i18n-guardian`**: detects hardcoded text in French or English, desynchronized keys between `fr.json` and `en.json`, missing namespaces.
+- **`docs-coherence-guardian`**: audits coherence between documentation, help page, and the actual state of the code. Updates drifted documents.
+- **`dast-runner`**: automatic OWASP ZAP scan on preview and prod.
+
+These agents are specialized, run on demand or in CI, and they produce reports that the main agent can then exploit to fix. A guardian that finds a vulnerability is a new task for Claude Code. A guardian that finds hardcoded text is a chained i18n correction.
+
+To that, add the classic layers, made stricter by the "code isn't re-read" rule:
+
+- **Strict TypeScript** everywhere, blocking typecheck in CI.
+- **Vitest**: 86 unit test files (domain + usecases with mocked ports, BDD lightweight in native Given/When/Then).
+- **Playwright**: 24 E2E scenarios that replay critical paths (event signup, Stripe payment, waitlist, check-in).
+- **axe-core** integrated into Playwright for accessibility.
+- **Lighthouse CI** on event pages (the viral unit, must be fast).
+- **pnpm audit** in CI to catch CVEs in dependencies.
+- **Sentry + PostHog** to catch whatever slips through to production.
+
+What this chain enables: I can ship a feature at 11pm without having read a single line of the diff, merge it the next morning, and sleep easy. Not because I trust the agent that wrote. Because I trust the **other agents** that checked after it, each on their axis.
+
+> **Seventh lesson:** you don't replace human re-reading with nothing. You replace it with a system of specialized agents whose role is precisely to find what the main agent didn't catch. Human work becomes the design of that chain, not its execution.
+
+---
+
+## Observability: the last line of defense
+
+Something people talk about too little: an AI-built project only really works if **the feedback loop is near real-time**.
+
+My observability stack:
+
+- **Vercel** for deployment. Every PR gets a preview URL, every merge deploys to prod.
+- **Sentry** for errors. Every production exception arrives with full stack trace.
+- **PostHog** for product. Who does what, how long, at what point they leave.
+- **Slack** for critical signals (new signup, new comment, admin alerts).
+
+When a feature ships, I see within minutes whether it breaks, whether it's used, whether it creates friction. Sentry surfaces a spike of exceptions on a given component, PostHog shows me a button that's seen but not clicked, or clicked and then abandoned right after.
+
+With this loop, the AI becomes a fast-correction executor. I see, I describe, it fixes, we ship. In an hour, a bug spotted at 9am is fixed in prod at 10am.
+
+Without this loop, AI would produce code in a vacuum. It's observability, paired with real-time monitoring, that gives meaning to iterations.
+
+> **Eighth lesson:** observability is no longer a luxury, it's an AI multiplier. Your agent is only useful if you can tell it, with numbers, what works and what doesn't.
+
+---
+
+## What remains deeply human
+
+Here's where I'm getting to.
+
+Over two months, the AI wrote all the code. Really all of it. Not a single line typed by hand. And no line-by-line re-reading either. The only things I wrote myself are the prompts and, in part, the intent documents: specifications, marketing messages, product decisions.
+
+But there are things it didn't do.
+
+**It didn't decide what to build.**
+
+The "community-centric" model that sets The Playground apart from Luma and Meetup is a product conviction. It comes from years running or taking part in communities, from having seen Meetup lock itself into its model, from having seen Luma shine on the event page and stop there. The AI couldn't have formulated that diagnosis. It translated it into code, very well. But the thesis is mine.
+
+**It didn't listen to the users.**
+
+There's [Chris Deniaud](https://www.linkedin.com/in/christophe-deniaud/), Host of Agile Bordeaux, the first active community on the platform, who reports concrete pain points from the field, at every event he runs. There's [Fatima](https://www.linkedin.com/in/fzhamil/), who tested the platform and shared detailed feedback on LinkedIn, bugs included. There's [Greg](https://www.linkedin.com/in/greg-lhotellier/), Host of [Dev With AI](https://www.devw.ai/) who explained why he hesitates to migrate from Luma, even though he wants to: his community of 800 members already built, the webhooks of his automation already in place, the free discoverability Luma gives him. There's [La Grappe Numérique](https://www.lagrappenumerique.fr/#/), a network of Bordeaux communities, whose invitation to pitch gave birth to the Networks feature I described earlier.
+
+Those feedback loops, I sought them out, listened to them, digested them. I decided which ones to turn into priority features and which ones to defer.
+
+**It didn't arbitrate tensions.**
+
+Free 100% product or take a 1% commission to sustain it? Open public discovery or reserve it to invited communities? Require sign-in or allow anonymous exploration? These trade-offs came from conversations with users, personal hesitations, sleepless nights. AI helps explore trade-offs. It doesn't rule.
+
+> **Ninth lesson:** AI hasn't replaced the developer or the product manager. It has replaced the "typing code" part, a big chunk of the verification, and a good half of the product shaping (specs, mockups, backlog). It hasn't replaced the vision, the listening to users, the strategic calls. What was rare before AI has become even rarer, and even more precious.
+
+---
+
+## What this changes for those who code
+
+I'm saving the last observation for the end.
+
+For a long time, the senior developer was the one who knew how to write clean code in complex systems. That was their capital.
+
+That capital isn't worth much anymore. Or rather, it's still worth something, but for a very different reason and under a different hat, that of Product Builder. They know how to **judge decisions** in a complex system. They know how to say "that abstraction is premature", "that test tests nothing", "that optimization will cost us dearly in readability", "that dependency will lock us in six months from now".
+
+The Product Builder becomes an **architect of an agent system**. They build the frame in which agents work: written rules, architectural contracts, test guardrails, specialized review agents, observability loops. They orient execution, they arbitrate product and technical trade-offs. Writing and re-reading are delegated. Structuring intelligence stays with them.
+
+What I lived these two months is that passage. From day one, I forbade myself from writing a single line of code or re-reading one by hand. Not out of ideology, but because every time I would have been tempted to "take back control" by typing myself, I'd have missed the chance to formalize the rule that would have prevented the problem from recurring. Depriving myself of the keyboard forces me to write the rule. Next time, the agent holds it alone, and another agent verifies it has been held.
+
+Today, at the 373rd merged PR, I don't see myself working any other way. Not because it's faster (even though it is). Because it's **intellectually more right**. I spend my time deciding, arbitrating, listening to users, formulating questions, connecting signals. Not typing or re-reading code.
+
+---
+
+## What I don't know yet
+
+I want to be honest about the scope.
+
+This is a **solo** experiment. I haven't tested this method with three developers, let alone thirty. How does the `CLAUDE.md` get shared across several hands? How do you keep the rules alive when everyone has their own style? How does a new joiner catch up? I don't know.
+
+It's an experiment over **two months**. A fresh SaaS, built in one stretch, with an architecture I laid down myself on day 1. I don't know what this method gives on a 5-year-old legacy monolith, with 10 years of debt, modules no one understands anymore and test coverage capped at 20%. My gut says it works there too, but only after a significant upfront work of documentation and delimitation. I have no proof.
+
+It's an experiment on a **modern stack** (Next.js, Prisma, Auth.js, Vercel). The AI knows these tools. It would probably be more hesitant on COBOL, SAP ABAP, enterprise Ruby on Rails 3.2. I haven't tested.
+
+And it's the experiment of a developer with twenty-five years of craft behind him. My architectural intuition, the one that lets me judge in three seconds whether an agent's proposal holds or drifts, comes from there. I don't know what this method would look like for a junior starting out. Maybe it works too, with a different frame. Maybe not.
+
+Take it as that: the field report of a solo, over two months, on a fresh product, with a modern stack, by someone who has already coded a lot before. Every parameter matters.
+
+---
+
+## In conclusion
+
+Two months, 1,780 commits, a SaaS platform in production. One developer. Evenings and weekends.
+
+This isn't a feat. It's the new normal for anyone who wants to take it seriously.
+
+What made it possible:
+
+- An architectural frame set before the first line
+- Written rules, alive, improved at every mistake
+- A real-time feedback loop (deployment, error monitoring, product observability)
+- A chain of review agents that industrializes mistrust in place of human re-reading
+- A product conviction that precedes the technical work, nourished by real user feedback
+
+What used to matter and doesn't anymore:
+
+- Raw development skills
+- Up-to-date knowledge of languages and frameworks
+- Memory of patterns
+
+What remains rare, and what will keep being rare, is **knowing what to build, for whom, and why**.
+
+AI gives the tools to those who have the vision. It doesn't give the vision to those who have the tools.
+
+The Playground is live. If you run a community, I'd be glad to have you take a look.
+
+→ [the-playground.fr](https://the-playground.fr)
+
+And for those who want to see how it's made, the repo is public on [GitHub](https://github.com/DragosDreptate/the-playground).

--- a/src/content/blog/fr/construire-avec-claude-code.md
+++ b/src/content/blog/fr/construire-avec-claude-code.md
@@ -1,0 +1,356 @@
+---
+title: "Ce que j'ai appris en construisant The Playground avec Claude Code"
+description: "Récit d'un Product Builder depuis les tranchées. Deux mois, 1 780 commits, pas une ligne de code tapée à la main : retour d'expérience sur la construction d'un SaaS en solo avec une IA."
+date: "2026-04-17"
+author: "Dragos Dreptate"
+keywords:
+  - claude code
+  - IA
+  - product builder
+  - retour d'expérience
+  - build saas solo
+  - architecture hexagonale
+  - agents ia
+---
+
+*Récit d'un Product Builder depuis les tranchées.*
+
+## Ce que j'ai construit, en bref
+
+19 février 2026, 19h53 : premier commit, un `Initial commit: Next.js 16 + Auth.js v5 + Prisma 7 + i18n`.
+
+16 avril 2026, 22h23 : `docs(spec): ajouter la spec statut Proposé et vote Communauté sur un événement`.
+
+Deux mois pile. Entre les deux, [The Playground](https://the-playground.fr) : une plateforme gratuite pour animer des communautés autour d'événements, **créée en France, en code ouvert sur GitHub, déployée sur des serveurs en Europe**. Le modèle communautaire de [Meetup](https://www.meetup.com), l'expérience premium de [Luma](https://lu.ma), gratuite, zéro commission. En production, avec ses premiers utilisateurs, communautés et événements.
+
+1 780 commits, 373 PR, 64 000 lignes, 110 fichiers de tests, 10 versions livrées, architecture hexagonale stricte. Stack : Next.js 16, Auth.js v5, Prisma 7 + Neon, Stripe Connect, Resend, Sentry, PostHog, Vercel. Un seul développeur, ses soirées et ses week-ends.
+
+Le tout construit avec [Claude Code](https://claude.com/claude-code). Je n'ai jamais tapé la moindre ligne de code. Je n'ai jamais relu ce qu'il a écrit non plus. Ce qui vérifie le code n'est pas mon œil humain, c'est une chaîne d'agents et d'outils.
+
+C'est le cœur du récit qui suit.
+
+---
+
+## Jour 1 : neuf commits pour un socle qui tient
+
+Le premier soir, en moins de quatre heures, la plateforme était déployée sur Vercel avec :
+
+- Next.js 16 App Router
+- Auth.js v5 configuré avec magic link
+- Prisma 7 connecté à Neon PostgreSQL serverless
+- Tailwind 4 + shadcn/ui
+- next-intl pour le bilinguisme FR/EN
+
+Aucun de ces composants n'est trivial à brancher. Chacun a ses pièges. Auth.js v5 est encore instable, Prisma 7 change le runtime pour Vercel, next-intl impose une structure de routing précise, Neon demande un adaptateur serverless spécifique.
+
+Sans l'IA, ce premier soir aurait duré une semaine. Pas parce que c'est compliqué individuellement. Parce que c'est compliqué **ensemble**, et que chaque erreur de configuration te coûte une heure de documentation et de traces d'erreur à déchiffrer.
+
+Avec l'IA, ça devient un dialogue. Je décris ce que je veux, elle propose, on ajuste. Quand Vercel casse au deploy parce que `@prisma/client` n'est pas dans les bonnes dépendances, elle le voit avant moi dans les logs. Quand Neon réclame un adaptateur spécifique pour le runtime serverless, elle connaît le nom.
+
+Et comme le socle était en place, la soirée ne s'est pas arrêtée là. Avant minuit, les deux premières features métier étaient écrites : le CRUD `Circle` (les Communautés) à 21h42, le CRUD `Moment` (les événements) à 23h37. Avec pages publiques partageables, formulaires, validations. Le tout sur la première vraie architecture hexagonale du projet.
+
+> **Premier apprentissage :** le coût d'entrée d'un projet neuf s'est effondré. Ce qui prenait des semaines prend des heures. Mais ça ne dit rien de ce qui vient après.
+
+---
+
+## Le vrai rôle de Claude Code : pas un copilote, un binôme exigeant
+
+Il y a une image qui circule beaucoup sur l'IA et le code. Le "copilote". Tu tapes quelques lignes, l'IA complète le reste. Autocomplétion sous stéroïdes.
+
+Ce n'est pas comme ça que j'ai travaillé.
+
+Claude Code, dans sa version CLI, ne fait pas de l'autocomplétion. C'est un agent. Tu lui donnes un objectif, il lit le code, pose des questions, planifie, exécute, vérifie. Quand il se trompe, il se corrige. Quand tu te trompes, il le signale.
+
+Un exemple concret. Feature "Réseaux de communautés" (v2.6.0). Une soirée de build, un mardi, 21h à 22h30. À l'ouverture de la PR, le diff se découpe en trois commits par couche :
+
+```
+feat(network): add CircleNetwork schema, domain model, ports and usecases
+feat(network): add Prisma adapter and admin server actions
+feat(network): add public page, badge, admin pages and i18n
+```
+
+Domaine, infrastructure, UI. Trois couches, trois commits. Ce n'est pas que l'agent écrit dans cet ordre ligne après ligne, c'est que le diff est *pensé* dans cet ordre. La séparation hexagonale est inscrite dans l'artefact final, relisible, versionnable.
+
+Puis vient le reste de la soirée : les tests unitaires et E2E, quelques `fix(network)` d'ajustement UX, un `refactor(network)` qui nettoie, la mise à jour de la page d'aide. À 22h30, merge. Ce n'est pas un exploit de vitesse brute, c'est le rythme d'un binôme qui respecte une architecture. L'IA sait lire un `CLAUDE.md` qui impose l'hexagonal, elle sait qu'on ne commence pas par l'UI, elle sait qu'un usecase ne doit pas importer Prisma. Les couches s'enchaînent dans le bon ordre parce que l'ordre est écrit noir sur blanc dans les règles du projet.
+
+Quand je m'égare (par exemple, je demande un shortcut qui violerait la séparation des couches), elle le signale. Elle explique pourquoi ça poserait problème plus tard, et propose l'alternative qui respecte le contrat.
+
+> **Deuxième apprentissage :** un agent IA bien cadré n'exécute pas bêtement. Il t'aide à tenir tes propres règles quand la fatigue te pousserait à les contourner.
+
+---
+
+## L'architecture comme garde-fou : l'IA amplifie la dette autant qu'elle amplifie la vélocité
+
+Voici ce que personne ne dit assez fort.
+
+**L'IA ne simplifie pas la complexité d'un système. Elle l'amplifie.**
+
+Si le cadre est flou, tu génères 10 fois plus de code flou, 10 fois plus vite. Au bout de deux semaines, ton projet est un champ de ruines illisible et chaque modification casse trois autres choses.
+
+Si le cadre est clair, tu génères 10 fois plus de code propre, 10 fois plus vite. Au bout de deux mois, tu as un SaaS qui tient la route.
+
+Chez moi, le cadre s'appelle l'architecture hexagonale. C'est une discipline que j'ai imposée dès le jour 1. Le domaine ne dépend de rien. Les ports sont des interfaces TypeScript. Les adapters implémentent les ports. Les usecases orchestrent.
+
+Le fichier `CLAUDE.md` du projet fait 600 lignes. Il contient :
+
+- La vision produit et les règles métier
+- Le contrat strict de l'architecture hexagonale (quelle couche peut importer quelle couche)
+- Les règles du design system (variants de boutons, tailles, tokens)
+- La stratégie de tests (BDD lightweight, test.each pour les spec by example)
+- Les décisions architecturales datées
+
+Ce fichier est lu par l'IA à chaque session. C'est un contrat moral entre moi et l'agent. Il fixe les invariants que je veux préserver même quand je suis fatigué à 23h et que j'aurais la tentation de bricoler une solution rapide.
+
+Les commits le montrent. Quasi systématiquement, une feature se termine par un commit `refactor(...)` qui nettoie ce qui vient d'être produit. C'est devenu un réflexe imposé par la mémoire long terme de l'agent : après chaque implémentation, relire le code produit et le simplifier.
+
+Ce n'est pas une option. C'est une règle.
+
+> **Troisième apprentissage :** le cadre que tu poses avant le premier commit décide de ce que le projet sera au commit 1 780. L'IA ne t'en fait pas cadeau, elle ne fait que répliquer ce qui est déjà là.
+
+---
+
+## La mémoire long terme, ou comment ne pas répéter les mêmes conneries
+
+Claude Code maintient un répertoire de mémoire persistante. Des fichiers markdown que l'agent écrit pour lui-même, et qu'il relit au début de chaque session.
+
+Mon répertoire contient aujourd'hui une vingtaine de fichiers, chacun dédié à un sujet précis. Exemples :
+
+- `feedback_workflow_git.md` : les règles de branching systématique (une branche par feature, jamais de commit direct sur main, PR avec titre conventionnel).
+- `feedback_accents_agents.md` : rappel que tout le français écrit doit porter ses accents.
+- `feedback_tests_never_red.md` : ne jamais laisser un test en rouge, même flaky.
+- `feedback_release_process.md` : la checklist complète de montée de version avec Release Please.
+- `feedback_email_content_separation.md` : tout email doit séparer contenu (`.md` éditable) et template React.
+
+Chaque fichier est né d'une erreur. La première fois qu'elle a été commise, je l'ai signalée. L'agent a créé le fichier. Les fois suivantes, il le relit avant d'agir. L'erreur ne se répète plus.
+
+C'est l'équivalent d'un onboarding continu pour un collègue qui ne quitte jamais l'équipe.
+
+Plus intéressant encore : ce mécanisme m'a forcé à **formaliser mes propres règles**. Quand je m'énerve parce que l'agent a pris un raccourci, je me demande : cette règle, est-ce que je l'ai écrite quelque part ? Si non, c'est de ma faute. J'écris la règle. La prochaine fois, elle sera tenue.
+
+Au bout de deux mois, j'ai une documentation vivante de mes préférences d'ingénieur que je n'avais jamais pris le temps d'écrire pour moi-même.
+
+> **Quatrième apprentissage :** travailler avec un agent IA, c'est écrire en même temps le code et le contrat qui gouverne comment ce code doit être écrit. Les deux s'entraînent mutuellement.
+
+---
+
+## Produit, spec, exploratoire : comment on décide quoi construire
+
+Jusqu'ici j'ai parlé de code, d'architecture, de tests. C'est la moitié du sujet.
+
+L'autre moitié, celle dont on parle encore moins quand on parle d'IA, c'est **le travail amont**. Comment on décide quoi construire, comment on explore une idée floue, comment on la transforme en quelque chose d'exécutable. C'est le territoire du produit, de la spec, des mockups, du backlog. Et c'est là que l'IA change autant le métier, peut-être plus, que côté code.
+
+Sur The Playground, aucune feature significative n'est arrivée directement en implémentation. Chaque fois, il y a eu un **cycle exploratoire** avant la première ligne de code. Et ce cycle, l'agent y joue un rôle actif.
+
+**1. La conversation exploratoire.**
+
+J'arrive avec une idée floue, souvent mal formulée. Exemple vécu : "il faudrait pouvoir regrouper plusieurs Communautés sous une page commune, un truc genre fédération". L'agent ne se jette pas sur le code. Il pose des questions : qui en aurait besoin ? quels cas concrets tu as en tête ? quelles alternatives existent (Meetup Pro, Eventbrite Organization) ? quel impact sur le modèle de données ? quelles tensions potentielles avec les Communautés existantes ?
+
+Au bout de 20 à 30 minutes de dialogue, l'idée floue est devenue un périmètre clair. Ce périmètre n'est pas arbitraire : il a été sculpté par des questions que je me serais posées tout seul, mais plus lentement, et souvent après avoir déjà fait construire du code inutile.
+
+**2. Le mockup HTML comme artefact intermédiaire.**
+
+Avant toute implémentation, je demande à l'agent un **mockup HTML interactif**. Fichier `.mockup.html` autonome, Tailwind inline, navigation cliquable. Pas du wireframe, du visuel précis, au pixel près, qui montre ce que verrait l'utilisateur.
+
+Ça a l'air anodin. C'est fondamental. Un mockup HTML oblige à trancher sur des détails qui sont invisibles dans une spec textuelle : hiérarchie visuelle, ordre des champs, états vides, états d'erreur, comportement mobile. Et comme c'est l'agent qui le produit en quelques minutes, le coût d'itération est nul. J'en ai parfois trois versions avant d'en valider une. Ce qui aurait pris une journée avec un designer externe prend une heure.
+
+Le mockup devient ensuite la **référence partagée** pour l'implémentation. L'agent qui code relit le mockup. Je n'ai pas besoin de décrire l'UI dans un ticket, elle est déjà exprimée.
+
+**3. La spec markdown, écrite par l'agent à partir de la conversation.**
+
+Une fois le périmètre clarifié et le mockup validé, je demande à l'agent de **rédiger la spec** dans un fichier markdown sous `spec/`. Il synthétise la conversation, structure les sections (contexte, problème, solution, impacts techniques, risques, étapes), liste les décisions prises avec leur raison.
+
+Je relis la spec (ça, je la relis, parce que c'est du texte d'intention, pas du code), je corrige ce qui ne reflète pas ma pensée, j'ajoute ce qui manque. Souvent très peu. L'agent a bien saisi l'échange.
+
+La spec devient le document de référence pour les sessions suivantes, qui peuvent être à plusieurs jours d'intervalle. Sans spec, l'agent oublierait le contexte. Avec spec, il reprend exactement là où on s'est arrêté.
+
+**4. Le backlog vivant.**
+
+Parallèlement, un `BACKLOG.md` centralise toutes les idées à venir, priorisées P0/P1/P2, avec pour chaque entrée le problème visé, le périmètre envisagé, et le statut. L'agent lit le backlog, peut proposer des regroupements, signaler des dépendances entre entrées, suggérer des découpages.
+
+Le backlog n'est pas un outil externe type Linear ou Jira. C'est un fichier dans le repo, versionné, accessible à l'agent en lecture et en écriture. Il se met à jour au fil des retours utilisateurs et des arbitrages. Il devient la mémoire produit du projet, consultable à tout moment.
+
+**5. La discipline "une question n'est pas instruction".**
+
+Une règle dure, née de plusieurs frustrations : quand je pose une question ("est-ce qu'on devrait pouvoir marquer un événement comme proposé avant qu'il soit publié ?"), l'agent ne l'interprète **pas** comme une instruction à implémenter. Il analyse l'impact, présente les trade-offs, demande confirmation avant d'écrire la moindre ligne.
+
+Ça paraît évident. En pratique, sans cette règle explicite, un agent zélé se jette sur l'implémentation au premier signal. Et tu te retrouves avec 200 lignes de code sur une feature que tu n'avais pas encore décidé de faire.
+
+Cette règle transforme la conversation en vrai **atelier produit**. J'explore sans risque. Je peux dire "et si on faisait X ?" sans craindre que X soit déjà à moitié codé quand je veux revenir en arrière.
+
+> **Cinquième apprentissage :** l'IA ne fait pas que remplacer l'exécution technique. Elle remplace aussi une partie du travail de product management : reformulation d'idées floues, production rapide d'artefacts intermédiaires (mockups, specs), maintien d'une mémoire produit vivante. Le CPO ou le CPTO qui veut comprendre où va son métier a intérêt à regarder ça de près. Le produit ne se délègue pas à l'IA, mais sa **mise en forme** change radicalement. C'est la naissance d'un nouveau rôle, celui de Product Builder.
+
+---
+
+## Ce que l'IA fait mal
+
+Tout n'est pas rose. Il y a des classes de problèmes où l'IA dérape systématiquement. En voici trois, vécues en direct.
+
+**1. L'angle mort sur les effets de bord.**
+
+Quand tu demandes "ajoute un champ `website` à la Communauté", l'IA le fait proprement : migration, formulaire, validation, affichage sur la page. Mais elle ne va pas d'elle-même mettre à jour les douze autres endroits où ce champ devrait apparaître : l'email d'invitation, l'export CSV, l'API publique, les traductions FR et EN, la page d'aide, le sitemap, les données structurées SEO, le dashboard Organisateur. Elle raisonne localement, bien. Elle raisonne transversalement, mal.
+
+C'est précisément pour ça qu'on a des agents dédiés qui repassent derrière, chacun spécialisé sur un axe transversal : `docs-coherence-guardian` pour la cohérence documentation et code, `i18n-guardian` pour les clés oubliées entre `fr.json` et `en.json`, `test-coverage-guardian` pour les parcours E2E manquants. Sans cette chaîne, les effets de bord s'accumulent silencieusement. Avec elle, ils se voient et se corrigent à la PR suivante.
+
+Corollaire : **l'IA est redoutable pour résoudre des problèmes bien posés, médiocre pour percevoir la portée réelle d'un changement**. Le travail humain n'est pas de relire le code, mais de concevoir les agents qui traquent ce que l'agent principal n'aurait pas vu.
+
+**2. La sur-ingénierie silencieuse.**
+
+Sans instruction contraire, elle ajoute de la défense en profondeur : validations redondantes, try/catch partout, fallbacks pour des cas qui ne se produiront jamais. Le code marche, mais il gonfle.
+
+Il a fallu une règle explicite dans `CLAUDE.md` :
+
+> Ne jamais ajouter de gestion d'erreur, de fallback ou de validation pour des scénarios qui ne peuvent pas arriver. Faire confiance au code interne et aux garanties du framework. Ne valider qu'aux frontières du système (input utilisateur, API externes).
+
+Avec cette règle, le code a maigri. Sans elle, il grossissait à chaque feature.
+
+**3. Les hallucinations sur les librairies récentes.**
+
+Next.js 16, Auth.js v5, Prisma 7. Trois piliers du stack, tous sortis récemment. L'IA invente parfois des APIs qui n'existent pas, ou qui existaient dans une version antérieure. Je ne le vois pas en relisant, puisque je ne relis pas. Je le vois à deux endroits : la CI qui échoue en typecheck ou au build, et les agents de revue qui tournent sur la PR. Les deux couches suffisent, dans la grande majorité des cas, à faire remonter l'hallucination avant le merge.
+
+Quand il reste un doute sur une API "trop magique", je ne plonge pas dans le code. Je demande à l'agent de pointer la documentation officielle, version précise. S'il n'y arrive pas, c'est probablement qu'elle n'existe pas et on corrige.
+
+> **Sixième apprentissage :** l'IA ne dispense pas de contrôler, mais le contrôle se déplace. Ce qui était autrefois une relecture humaine ligne par ligne devient un système de vérifications automatisées : CI stricte, tests, agents de revue spécialisés, observabilité. Le développeur industrialise la méfiance au lieu de l'exercer à la main.
+
+---
+
+## Les agents qui vérifient les autres agents
+
+C'est un sujet qui, à mes yeux, est fondamental et qui change complètement la donne.
+
+Quand l'IA écrit 100% du code et que je ne le relis pas à la main, la question devient : qui garantit que ce qui part en prod est sain ? La réponse n'est pas "la confiance". La réponse est une **chaîne d'agents et d'outils spécialisés**, chacun ayant une responsabilité claire sur un axe précis.
+
+Sur The Playground, cette chaîne ressemble à ça :
+
+- **`security-guardian`** : audit de sécurité à 6 dimensions (RBAC, IDOR, CSRF, CSP, validation des inputs, RGPD, CI/CD, secrets). Lancé régulièrement, et systématiquement après une feature sensible.
+- **`performance-guardian`** : détection des N+1 queries, index manquants, régressions de bundle JS, problèmes Core Web Vitals.
+- **`test-coverage-guardian`** : vérifie la couverture des usecases et des parcours E2E, crée les tests manquants.
+- **`i18n-guardian`** : détecte les textes hardcodés en français ou en anglais, les clés désynchronisées entre `fr.json` et `en.json`, les namespaces manquants.
+- **`docs-coherence-guardian`** : audite la cohérence entre la documentation, la page Aide, et l'état réel du code. Met à jour les documents qui ont dérivé.
+- **`dast-runner`** : scan OWASP ZAP automatique sur la preview et la prod.
+
+Ces agents sont spécialisés, lancés à la demande ou en CI, et ils produisent des rapports que l'agent principal peut ensuite exploiter pour corriger. Un guardian qui trouve une faille, c'est une nouvelle tâche pour Claude Code. Un guardian qui trouve un texte hardcodé, c'est une correction i18n enchaînée.
+
+À cela s'ajoutent les couches classiques mais rendues plus strictes par la règle "le code n'est pas relu" :
+
+- **TypeScript strict** partout, typecheck bloquant en CI.
+- **Vitest** : 86 fichiers de tests unitaires (domaine + usecases avec ports mockés, BDD lightweight en Given/When/Then natif).
+- **Playwright** : 24 scénarios E2E qui rejouent les parcours critiques (inscription événement, paiement Stripe, liste d'attente, check-in).
+- **axe-core** intégré dans Playwright pour l'accessibilité.
+- **Lighthouse CI** sur les pages événement (l'unité virale, doit être rapide).
+- **pnpm audit** en CI pour détecter les CVE dans les dépendances.
+- **Sentry + PostHog** pour attraper ce qui glisse quand même jusqu'en production.
+
+Ce que cette chaîne permet : je peux livrer une feature à 23h sans avoir lu une seule ligne du diff, la merger le lendemain matin, et dormir tranquille. Pas parce que je fais confiance à l'agent qui a écrit. Parce que je fais confiance aux **autres agents** qui ont vérifié après lui, chacun sur son axe.
+
+> **Septième apprentissage :** on ne remplace pas la relecture humaine par rien. On la remplace par un système d'agents spécialisés dont le rôle est précisément de trouver ce que l'agent principal n'a pas vu. Le travail humain devient la conception de cette chaîne, pas son exécution.
+
+---
+
+## L'observabilité : la dernière ligne de défense
+
+Un truc dont on parle peu : un projet fait avec l'IA ne marche vraiment que si **la boucle de feedback est quasi temps réel**.
+
+Mon stack de télémétrie :
+
+- **Vercel** pour le déploiement. Chaque PR génère une URL de preview, chaque merge déploie en prod.
+- **Sentry** pour les erreurs. Chaque exception en prod arrive avec stack trace complète.
+- **PostHog** pour le produit. Qui fait quoi, combien de temps, à quel moment il part.
+- **Slack** pour les signaux critiques (nouvelle inscription, nouveau commentaire, alertes admin).
+
+Quand une feature part en prod, je vois en quelques minutes si elle casse, si elle est utilisée, si elle génère de la friction. Sentry me remonte un pic d'exceptions sur tel composant, PostHog me montre qu'un bouton est vu mais pas cliqué, ou cliqué puis abandonné juste après.
+
+Avec cette boucle, l'IA devient un exécuteur de corrections rapides. Je vois, je décris, elle corrige, on déploie. En une heure, un bug identifié à 9h est résolu en prod à 10h.
+
+Sans cette boucle, l'IA produirait du code dans le vide. C'est l'observabilité, couplée au monitoring en temps réel, qui donne du sens aux itérations.
+
+> **Huitième apprentissage :** l'observabilité n'est plus un luxe, c'est un multiplicateur de l'IA. Ton agent n'est utile que si tu peux lui dire, chiffres à l'appui, ce qui marche et ce qui ne marche pas.
+
+---
+
+## Ce qui reste profondément humain
+
+Voilà où je veux arriver.
+
+Sur deux mois, l'IA a écrit tout le code. Vraiment tout. Pas une seule ligne tapée à la main. Et pas de relecture ligne à ligne non plus. Les seules choses que j'ai écrites moi-même, ce sont les prompts et en partie les documents d'intention : spécifications, messages marketing, décisions produit.
+
+Mais il y a des choses qu'elle n'a pas faites.
+
+**Elle n'a pas décidé quoi construire.**
+
+Le modèle "community-centric" qui différencie The Playground de Luma et de Meetup, c'est une conviction produit. Elle vient d'années à animer ou à participer à des communautés, d'avoir vu Meetup s'enfermer dans son modèle, d'avoir vu Luma briller sur la page événement et s'arrêter là. L'IA ne pouvait pas formuler ce diagnostic. Elle l'a traduit en code, très bien. Mais la thèse, c'est la mienne.
+
+**Elle n'a pas écouté les utilisateurs.**
+
+Il y a [Chris Deniaud](https://www.linkedin.com/in/christophe-deniaud/), organisateur d'Agile Bordeaux, la première communauté active sur la plateforme, qui me remonte des irritants concrets depuis le terrain, à chaque événement qu'il organise. Il y a [Fatima](https://www.linkedin.com/in/fzhamil/), qui a testé la plateforme et partagé des retours détaillés sur LinkedIn, bugs inclus. Il y a [Greg](https://www.linkedin.com/in/greg-lhotellier/), organisateur de [Dev With AI](https://www.devw.ai/) qui m'a expliqué pourquoi il hésite à migrer depuis Luma, malgré son envie : sa communauté de 800 membres déjà construite, les webhooks de son automatisation déjà en place, la découvrabilité gratuite que Luma lui offre. Il y a [La Grappe Numérique](https://www.lagrappenumerique.fr/#/), réseau de communautés bordelaises, dont l'invitation à pitcher a fait naître la fonctionnalité Réseaux que je décrivais plus haut.
+
+Ces retours, c'est moi qui les ai cherchés, écoutés, digérés. C'est moi qui ai décidé lesquels transformer en features prioritaires et lesquels reporter.
+
+**Elle n'a pas arbitré les tensions.**
+
+Faire un produit gratuit à 100% ou prélever une commission de 1% pour pérenniser ? Ouvrir la découverte publique ou la réserver aux communautés invitées ? Imposer la connexion obligatoire ou permettre l'exploration anonyme ? Ces arbitrages sont venus de conversations avec des utilisateurs, d'hésitations personnelles, de nuits blanches. L'IA aide à explorer les trade-offs. Elle ne tranche pas.
+
+> **Neuvième apprentissage :** l'IA n'a pas remplacé le développeur ni le product manager. Elle a remplacé la partie "taper du code", une grande partie de la vérification, et une bonne moitié de la mise en forme produit (specs, mockups, backlog). Elle n'a pas remplacé la vision, l'écoute des utilisateurs, les arbitrages stratégiques. Ce qui était rare avant l'IA est devenu encore plus rare, et encore plus précieux.
+
+---
+
+## Ce que ça change pour ceux qui codent
+
+Je garde la dernière observation pour la fin.
+
+Pendant longtemps, le développeur senior était celui qui savait écrire du code propre dans des systèmes complexes. C'était son capital.
+
+Ce capital ne vaut plus grand-chose. Ou plutôt, il vaut encore quelque chose, mais pour une raison très différente et sous une casquette différente, celle de Product Builder. Il sait **juger les décisions** dans un système complexe. Il sait dire "cette abstraction est prématurée", "ce test ne teste rien", "cette optimisation va nous coûter cher en lisibilité", "cette dépendance va nous verrouiller dans six mois".
+
+Le Product Builder devient un **architecte d'un système d'agents**. Il construit le cadre dans lequel les agents travaillent : les règles écrites, les contrats d'architecture, les garde-fous de tests, les agents de revue spécialisés, les boucles d'observabilité. Il oriente l'exécution, il tranche les arbitrages produit et techniques. L'écriture et la relecture sont déléguées. L'intelligence structurante reste chez lui.
+
+Ce que j'ai vécu ces deux mois, c'est ce passage. Dès le premier jour, je me suis interdit d'écrire la moindre ligne de code et d'en relire une seule à la main. Pas par idéologie, mais parce que chaque fois que j'aurais été tenté de "reprendre le contrôle" en tapant moi-même, j'aurais manqué l'occasion de formaliser la règle qui empêchait le problème de se répéter. Me priver du clavier m'oblige à écrire la règle. La prochaine fois, l'agent la tient tout seul, et un autre agent vérifie qu'il l'a tenue.
+
+Aujourd'hui, à la 373e PR mergée, je ne me vois plus travailler autrement. Non pas parce que c'est plus rapide (même si ça l'est). Parce que c'est **intellectuellement plus juste**. Je passe mon temps à décider, à arbitrer, à écouter les utilisateurs, à formuler des questions, à relier les signaux. Pas à taper ni à relire du code.
+
+---
+
+## Ce que je ne sais pas encore
+
+Je veux être honnête sur le périmètre.
+
+C'est une expérience **solo**. Je n'ai pas testé cette méthode avec trois développeurs, encore moins avec trente. Comment se partage le `CLAUDE.md` entre plusieurs mains ? Comment on fait vivre les règles quand chacun a son style ? Comment un nouvel arrivant prend le train en route ? Je ne sais pas.
+
+C'est une expérience sur **deux mois**. Un SaaS neuf, bâti d'un trait, avec une architecture que j'ai posée moi-même le jour 1. Je ne sais pas ce que donne cette méthode sur un monolithe legacy de cinq ans, avec dix ans de dette, des modules que personne ne comprend plus et une couverture de tests qui plafonne à 20%. Mon intuition est que ça marche aussi, mais à condition de commencer par un gros travail de documentation et de délimitation. Je n'ai pas la preuve.
+
+C'est une expérience sur **un stack moderne** (Next.js, Prisma, Auth.js, Vercel). L'IA connaît ces outils. Elle serait probablement plus hésitante sur du COBOL, du SAP ABAP, du Ruby on Rails 3.2 d'entreprise. Je n'ai pas testé.
+
+Et c'est une expérience d'un développeur qui a vingt-cinq ans de métier derrière lui. Mon intuition architecturale, celle qui me permet de juger en trois secondes si une proposition de l'agent tient ou dérape, elle vient de là. Je ne sais pas à quoi ressemblerait cette méthode pour un junior qui démarre. Peut-être qu'elle marche aussi, avec un autre cadre. Peut-être pas.
+
+À prendre comme ça : le retour d'un solo, sur deux mois, sur un produit neuf, avec un stack moderne, par quelqu'un qui a déjà beaucoup codé avant. Chaque paramètre compte.
+
+---
+
+## En conclusion
+
+Deux mois, 1 780 commits, une plateforme SaaS en production. Un seul développeur. Des soirées et des week-ends.
+
+Ce n'est pas un exploit. C'est la nouvelle normalité pour qui veut s'y mettre sérieusement.
+
+Ce qui a rendu ça possible :
+
+- Un cadre architectural posé avant la première ligne
+- Des règles écrites, vivantes, améliorées à chaque erreur
+- Une boucle de feedback temps réel (déploiement, monitoring d'erreurs, observabilité produit)
+- Une chaîne d'agents de revue qui industrialise la méfiance à la place de la relecture humaine
+- Une conviction produit qui précède la technique, nourrie par des retours utilisateurs réels
+
+Ce qui, autrefois, comptait et ne compte plus :
+
+- Les compétences brutes de développement
+- La connaissance des langages et des frameworks à jour
+- La mémoire des patterns
+
+Ce qui reste rare, et ce qui va continuer à l'être, c'est **savoir quoi construire, pour qui, et pourquoi**.
+
+L'IA donne les outils à ceux qui ont la vision. Elle ne donne pas la vision à ceux qui ont les outils.
+
+The Playground est en ligne. Si vous animez une communauté, je serais heureux que vous la regardiez.
+
+→ [the-playground.fr](https://the-playground.fr)
+
+Et pour ceux qui veulent voir comment c'est fait, le repo est public sur [GitHub](https://github.com/DragosDreptate/the-playground).


### PR DESCRIPTION
## Summary

- Ajoute un article long-format retraçant deux mois de construction de The Playground en solo avec Claude Code
- Couvre : architecture hexagonale comme garde-fou, mémoire long terme, workflow produit (spec + mockup + backlog), agents de revue spécialisés, observabilité comme multiplicateur IA, paragraphe honnête "Ce que je ne sais pas encore"
- Publie simultanément les versions **FR et EN** sous le slug `construire-avec-claude-code`

## Contenu

- **Titre FR** : Ce que j'ai appris en construisant The Playground avec Claude Code
- **Titre EN** : What I Learned Building The Playground with Claude Code
- **Sous-titre** : Récit d'un Product Builder depuis les tranchées
- **Longueur** : ~4 000 mots, ~18 min de lecture
- **Public cible** : dev / CTO / tech lead / CPO / CPTO
- **Keywords** : claude code, IA, product builder, retour d'expérience, build saas solo, architecture hexagonale, agents IA

## Test plan

- [ ] Vérifier rendu `/fr/blog/construire-avec-claude-code` sur la preview Vercel
- [ ] Vérifier rendu `/en/blog/construire-avec-claude-code` sur la preview Vercel
- [ ] Vérifier que les blockquotes (apprentissages) s'affichent bien avec la barre rose
- [ ] Vérifier que les liens externes (LinkedIn Chris, Fatima, Greg, Dev With AI, La Grappe) pointent correctement
- [ ] Vérifier le temps de lecture estimé en en-tête
- [ ] Vérifier les données structurées OpenGraph et canonical

🤖 Generated with [Claude Code](https://claude.com/claude-code)