### PR TITLE
docs(blog): réécrire l'intro et les titres de sections dans un style plus allusif

### DIFF
--- a/src/content/blog/en/construire-avec-claude-code.md
+++ b/src/content/blog/en/construire-avec-claude-code.md
@@ -15,15 +15,11 @@ keywords:
 
 *A Product Builder's story from the trenches.*
 
-## What I built, in brief
+It's April 17, 2026. The project's first commit is dated February 19: `Initial commit: Next.js 16 + Auth.js v5 + Prisma 7 + i18n`. Two months exactly.
 
-February 19, 2026, 7:53pm: first commit, an `Initial commit: Next.js 16 + Auth.js v5 + Prisma 7 + i18n`.
+Between the two, [The Playground](https://the-playground.fr): a free platform to run communities around events. Built in France, open-source on [GitHub](https://github.com/DragosDreptate/the-playground), servers in Europe. Meetup's community model, Luma's premium experience, zero commission. Live in production, with its first users, communities and events.
 
-April 16, 2026, 10:23pm: `docs(spec): add Proposed status spec and Community voting on an event`.
-
-Two months exactly. Between the two, [The Playground](https://the-playground.fr): a free platform to run communities around events, **built in France, open-source on GitHub, deployed on European servers**. Meetup's community model, Luma's premium experience, free, zero commission. Live in production, with its first users, communities and events.
-
-1,780 commits, 373 PRs, 64,000 lines, 110 test files, 10 versions shipped, strict hexagonal architecture. Stack: Next.js 16, Auth.js v5, Prisma 7 + Neon, Stripe Connect, Resend, Sentry, PostHog, Vercel. One developer, evenings and weekends.
+1,780 commits, 373 PRs, 64,000 lines, 110 test files, ten versions shipped, strict hexagonal architecture. Stack: Next.js 16, Auth.js v5, Prisma 7 + Neon, Stripe Connect, Resend, Sentry, PostHog, Vercel. One developer. Evenings and weekends.
 
 All of it built with [Claude Code](https://claude.com/claude-code). I never typed a single line of code. I never read what it wrote either. What checks the code is not my human eye, it's a chain of agents and tools.
 
@@ -31,7 +27,7 @@ That's the heart of the story that follows.
 
 ---
 
-## Day 1: nine commits for a solid foundation
+## First evening
 
 The first evening, in less than four hours, the platform was deployed on Vercel with:
 
@@ -53,7 +49,7 @@ And since the foundation was in place, the evening didn't stop there. Before mid
 
 ---
 
-## Claude Code's real role: not a copilot, a demanding partner
+## The copilot? No thanks.
 
 There's an image that circulates a lot about AI and code. The "copilot". You type a few lines, the AI completes the rest. Autocomplete on steroids.
 
@@ -79,7 +75,7 @@ When I drift (for example, I ask for a shortcut that would violate layer separat
 
 ---
 
-## Architecture as guardrail: AI amplifies debt as much as it amplifies velocity
+## Architecture becomes central again
 
 Here's what no one says loud enough.
 
@@ -109,7 +105,7 @@ It's not optional. It's a rule.
 
 ---
 
-## Long-term memory, or how not to repeat the same mistakes
+## A memory that doesn't forget
 
 Claude Code maintains a persistent memory directory. Markdown files the agent writes for itself, and re-reads at the start of every session.
 
@@ -133,7 +129,7 @@ Two months in, I have a living documentation of my engineering preferences that 
 
 ---
 
-## Product, spec, exploration: how we decide what to build
+## Product is built in the conversation
 
 Up to now I've talked about code, architecture, tests. That's half the subject.
 
@@ -246,7 +242,7 @@ What this chain enables: I can ship a feature at 11pm without having read a sing
 
 ---
 
-## Observability: the last line of defense
+## Observability, the last line of defense
 
 Something people talk about too little: an AI-built project only really works if **the feedback loop is near real-time**.
 
@@ -267,7 +263,7 @@ Without this loop, AI would produce code in a vacuum. It's observability, paired
 
 ---
 
-## What remains deeply human
+## What remains human
 
 Here's where I'm getting to.
 

--- a/src/content/blog/fr/construire-avec-claude-code.md
+++ b/src/content/blog/fr/construire-avec-claude-code.md
@@ -15,23 +15,19 @@ keywords:
 
 *Récit d'un Product Builder depuis les tranchées.*
 
-## Ce que j'ai construit, en bref
+On est le 17 avril 2026. Le premier commit du projet est daté du 19 février : `Initial commit: Next.js 16 + Auth.js v5 + Prisma 7 + i18n`. Deux mois pile.
 
-19 février 2026, 19h53 : premier commit, un `Initial commit: Next.js 16 + Auth.js v5 + Prisma 7 + i18n`.
+Entre les deux, [The Playground](https://the-playground.fr) : une plateforme gratuite pour animer des communautés autour d'événements. Créée en France, code ouvert sur [GitHub](https://github.com/DragosDreptate/the-playground), serveurs en Europe. Le modèle communautaire de [Meetup](https://www.meetup.com), l'expérience premium de [Luma](https://lu.ma), zéro commission. En production, avec ses premiers utilisateurs, communautés et événements.
 
-16 avril 2026, 22h23 : `docs(spec): ajouter la spec statut Proposé et vote Communauté sur un événement`.
+1 780 commits, 373 PR, 64 000 lignes, 110 fichiers de tests, dix versions livrées, architecture hexagonale stricte. Stack : Next.js 16, Auth.js v5, Prisma 7 + Neon, Stripe Connect, Resend, Sentry, PostHog, Vercel. Un seul développeur. Mes soirées et mes week-ends.
 
-Deux mois pile. Entre les deux, [The Playground](https://the-playground.fr) : une plateforme gratuite pour animer des communautés autour d'événements, **créée en France, en code ouvert sur GitHub, déployée sur des serveurs en Europe**. Le modèle communautaire de [Meetup](https://www.meetup.com), l'expérience premium de [Luma](https://lu.ma), gratuite, zéro commission. En production, avec ses premiers utilisateurs, communautés et événements.
-
-1 780 commits, 373 PR, 64 000 lignes, 110 fichiers de tests, 10 versions livrées, architecture hexagonale stricte. Stack : Next.js 16, Auth.js v5, Prisma 7 + Neon, Stripe Connect, Resend, Sentry, PostHog, Vercel. Un seul développeur, ses soirées et ses week-ends.
-
-Le tout construit avec [Claude Code](https://claude.com/claude-code). Je n'ai jamais tapé la moindre ligne de code. Je n'ai jamais relu ce qu'il a écrit non plus. Ce qui vérifie le code n'est pas mon œil humain, c'est une chaîne d'agents et d'outils.
+Tout a été construit avec [Claude Code](https://claude.com/claude-code). Je n'ai jamais tapé une ligne de code. Je n'ai jamais relu ce qu'il a écrit non plus. Ce qui vérifie le code n'est pas mon œil humain, c'est une chaîne d'agents et d'outils.
 
 C'est le cœur du récit qui suit.
 
 ---
 
-## Jour 1 : neuf commits pour un socle qui tient
+## Premier soir
 
 Le premier soir, en moins de quatre heures, la plateforme était déployée sur Vercel avec :
 
@@ -53,7 +49,7 @@ Et comme le socle était en place, la soirée ne s'est pas arrêtée là. Avant 
 
 ---
 
-## Le vrai rôle de Claude Code : pas un copilote, un binôme exigeant
+## Le copilote, très peu pour moi
 
 Il y a une image qui circule beaucoup sur l'IA et le code. Le "copilote". Tu tapes quelques lignes, l'IA complète le reste. Autocomplétion sous stéroïdes.
 
@@ -79,7 +75,7 @@ Quand je m'égare (par exemple, je demande un shortcut qui violerait la séparat
 
 ---
 
-## L'architecture comme garde-fou : l'IA amplifie la dette autant qu'elle amplifie la vélocité
+## L'architecture redevient centrale
 
 Voici ce que personne ne dit assez fort.
 
@@ -109,7 +105,7 @@ Ce n'est pas une option. C'est une règle.
 
 ---
 
-## La mémoire long terme, ou comment ne pas répéter les mêmes conneries
+## Une mémoire qui n'oublie pas
 
 Claude Code maintient un répertoire de mémoire persistante. Des fichiers markdown que l'agent écrit pour lui-même, et qu'il relit au début de chaque session.
 
@@ -133,7 +129,7 @@ Au bout de deux mois, j'ai une documentation vivante de mes préférences d'ing�
 
 ---
 
-## Produit, spec, exploratoire : comment on décide quoi construire
+## Le produit se construit dans la conversation
 
 Jusqu'ici j'ai parlé de code, d'architecture, de tests. C'est la moitié du sujet.
 
@@ -246,7 +242,7 @@ Ce que cette chaîne permet : je peux livrer une feature à 23h sans avoir lu un
 
 ---
 
-## L'observabilité : la dernière ligne de défense
+## L'observabilité, dernière ligne de défense
 
 Un truc dont on parle peu : un projet fait avec l'IA ne marche vraiment que si **la boucle de feedback est quasi temps réel**.
 
@@ -267,7 +263,7 @@ Sans cette boucle, l'IA produirait du code dans le vide. C'est l'observabilité,
 
 ---
 
-## Ce qui reste profondément humain
+## Ce qui reste humain
 
 Voilà où je veux arriver.
 


### PR DESCRIPTION
## Summary

- Réécrit l'**intro** de l'article blog "Ce que j'ai appris en construisant The Playground avec Claude Code" en attaque directe ("On est le 17 avril 2026...") plutôt qu'en symétrie datée premier/dernier commit
- Raccourcit les **7 titres de sections** pour les rendre plus allusifs et mémorables, sans toucher au fond
- Versions **FR et EN** alignées

## Titres remplacés

| Avant | Après |
|---|---|
| Jour 1 : neuf commits pour un socle qui tient | Premier soir |
| Le vrai rôle de Claude Code : pas un copilote, un binôme exigeant | Le copilote, très peu pour moi |
| L'architecture comme garde-fou : l'IA amplifie la dette autant qu'elle amplifie la vélocité | L'architecture redevient centrale |
| La mémoire long terme, ou comment ne pas répéter les mêmes conneries | Une mémoire qui n'oublie pas |
| Produit, spec, exploratoire : comment on décide quoi construire | Le produit se construit dans la conversation |
| L'observabilité : la dernière ligne de défense | L'observabilité, dernière ligne de défense |
| Ce qui reste profondément humain | Ce qui reste humain |

Même logique en EN ("Day 1: nine commits..." → "First evening", "Claude Code's real role..." → "The copilot? No thanks.", etc).

## Pourquoi

Décision éditoriale suite à la comparaison entre trois versions de l'article (originale, style full Pernot, hybride). L'intro hybride et les titres raccourcis sont les deux éléments qui apportent le plus de mordant sans risquer le pastiche.

## Test plan

- [ ] Vérifier rendu `/fr/blog/construire-avec-claude-code` sur la preview Vercel
- [ ] Vérifier rendu `/en/blog/construire-avec-claude-code` sur la preview Vercel
- [ ] Vérifier que la table des matières (si présente) reflète les nouveaux titres
- [ ] Vérifier que les OpenGraph et canonicals restent corrects

🤖 Generated with [Claude Code](https://claude.com/claude-code)