### PR TITLE
feat(sentry): analyse explicite de l'impact utilisateur dans les notifs

### DIFF
--- a/src/infrastructure/services/sentry/analyze-issue.ts
+++ b/src/infrastructure/services/sentry/analyze-issue.ts
@@ -92,12 +92,36 @@ function extractStacktraceSummary(event: SentryEvent): string {
   return lines.join("\n");
 }
 
+export type UserImpactLevel = "none" | "silent" | "degraded" | "blocking";
+
+export type UserImpact = {
+  level: UserImpactLevel;
+  description: string;
+};
+
 type AnalysisResult = {
   urgency: "critical" | "high" | "medium" | "low" | "noise";
-  impact: string;
+  userImpact: UserImpact;
   diagnosis: string;
   remediation: string;
 };
+
+const FALLBACK_USER_IMPACT: UserImpact = {
+  level: "silent",
+  description: "Impact utilisateur non évalué, à vérifier manuellement dans Sentry",
+};
+
+function isValidUserImpact(value: unknown): value is UserImpact {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  const validLevels: UserImpactLevel[] = ["none", "silent", "degraded", "blocking"];
+  return (
+    typeof v.level === "string" &&
+    validLevels.includes(v.level as UserImpactLevel) &&
+    typeof v.description === "string" &&
+    v.description.length > 0
+  );
+}
 
 async function analyzeWithClaude(
   issue: IssueInput,
@@ -107,7 +131,7 @@ async function analyzeWithClaude(
   if (!apiKey) {
     return {
       urgency: "medium",
-      impact: "Impossible d'analyser (ANTHROPIC_API_KEY manquante)",
+      userImpact: { level: "silent", description: "Impossible d'analyser (ANTHROPIC_API_KEY manquante)" },
       diagnosis: issue.issueTitle,
       remediation: "Vérifier manuellement dans Sentry",
     };
@@ -130,39 +154,56 @@ ${stacktrace || "(aucune stacktrace disponible)"}
 Réponds UNIQUEMENT avec un JSON valide:
 {
   "urgency": "critical|high|medium|low|noise",
-  "impact": "description courte de l'impact utilisateur (1 phrase)",
+  "userImpact": {
+    "level": "none|silent|degraded|blocking",
+    "description": "Ce que l'utilisateur voit ou fait concrètement. Commence par 'L'utilisateur...'. 1 à 2 phrases."
+  },
   "diagnosis": "explication technique de la cause (2-3 phrases max)",
   "remediation": "plan de correction concret (fichier à modifier, approche, 2-3 phrases max)"
 }
 
-Règles:
+Règles de priorisation technique (urgency):
 - "noise" = erreur d'extension navigateur, bot, ou erreur non-actionnable
 - "critical" = perte de données, paiement échoué, auth cassée
 - "high" = fonctionnalité principale cassée pour les utilisateurs
 - "medium" = bug visible mais contournable
-- "low" = cosmétique, edge case rare`;
+- "low" = cosmétique, edge case rare
+
+Règles d'impact utilisateur (userImpact.level) — OBLIGATOIRE, s'évalue séparément de urgency:
+- "none" = l'utilisateur ne perçoit absolument rien (script tiers, handler pagehide/unload, erreur silencieuse, bot)
+- "silent" = erreur visible uniquement en devtools, aucune gêne fonctionnelle
+- "degraded" = expérience dégradée mais utilisable (feature secondaire cassée, fallback, latence)
+- "blocking" = l'utilisateur est bloqué et ne peut pas accomplir son action
+
+Avant de choisir le level, parcours cette checklist:
+1. L'erreur vient-elle d'un script tiers (PostHog, Google Analytics, Stripe.js, extension) sans notre code dans la stack ? → level ≤ silent
+2. L'erreur se déclenche-t-elle pendant pagehide, unload, visibilitychange, beforeunload ? → level = none (l'utilisateur a déjà quitté)
+3. L'erreur est-elle handled (try/catch, mécanisme handled:true) ? → level ≤ silent
+4. La stack ou le contexte prouvent-ils un crash visuel, un message d'erreur UI, ou une action bloquée ? → sinon level ≠ blocking
+
+Règle d'or: "level" décrit ce que voit ou fait l'utilisateur, pas ce qui se passe en interne. Dans le doute, préfère "none" ou "silent". Ne jamais inventer un impact non prouvé par la stack.`;
 
   const resp = await client.messages.create({
     model: ANTHROPIC_MODEL,
-    max_tokens: 500,
+    max_tokens: 600,
     messages: [{ role: "user", content: prompt }],
   });
 
   const tb = resp.content.find((b): b is Anthropic.Messages.TextBlock => b.type === "text");
   if (!tb) {
-    return { urgency: "medium", impact: "Analyse indisponible", diagnosis: issue.issueTitle, remediation: "Vérifier manuellement" };
+    return { urgency: "medium", userImpact: FALLBACK_USER_IMPACT, diagnosis: issue.issueTitle, remediation: "Vérifier manuellement" };
   }
 
   try {
     const raw = tb.text.trim();
     const jsonStr = raw.startsWith("{") ? raw : raw.slice(raw.indexOf("{"), raw.lastIndexOf("}") + 1);
-    const parsed = JSON.parse(jsonStr) as AnalysisResult;
-    if (!parsed.urgency || !parsed.impact || !parsed.diagnosis || !parsed.remediation) {
-      return { urgency: "medium", impact: "Analyse incomplète", diagnosis: tb.text.slice(0, 200), remediation: "Vérifier manuellement" };
+    const parsed = JSON.parse(jsonStr) as Partial<AnalysisResult>;
+    if (!parsed.urgency || !parsed.diagnosis || !parsed.remediation || !isValidUserImpact(parsed.userImpact)) {
+      return { urgency: "medium", userImpact: FALLBACK_USER_IMPACT, diagnosis: tb.text.slice(0, 200), remediation: "Vérifier manuellement" };
     }
-    return parsed;
+    return parsed as AnalysisResult;
   } catch {
-    return { urgency: "medium", impact: "Analyse malformée", diagnosis: tb.text.slice(0, 200), remediation: "Vérifier manuellement" };
+    return { urgency: "medium", userImpact: FALLBACK_USER_IMPACT, diagnosis: tb.text.slice(0, 200), remediation: "Vérifier manuellement" };
   }
 }
 
@@ -196,7 +237,7 @@ async function sendAnalysisEmail(
       culprit: issue.culprit,
       urgency: analysis.urgency,
       urgencyLabel,
-      impact: analysis.impact,
+      userImpact: analysis.userImpact,
       diagnosis: analysis.diagnosis,
       remediation: analysis.remediation,
       sentryUrl,
@@ -227,7 +268,7 @@ export async function analyzeSentryIssue(issue: IssueInput): Promise<void> {
       issueTitle: issue.issueTitle,
       culprit: issue.culprit,
       urgencyLabel,
-      impact: analysis.impact,
+      userImpact: analysis.userImpact,
       diagnosis: analysis.diagnosis,
       remediation: analysis.remediation,
       sentryUrl,

--- a/src/infrastructure/services/sentry/sentry-issue-analysis-email.tsx
+++ b/src/infrastructure/services/sentry/sentry-issue-analysis-email.tsx
@@ -8,6 +8,7 @@ import {
   infoLabel,
   infoValue,
 } from "../email/templates/components/email-styles";
+import type { UserImpact, UserImpactLevel } from "./analyze-issue";
 
 type Props = {
   issueShortId: string;
@@ -15,7 +16,7 @@ type Props = {
   culprit: string;
   urgency: string;
   urgencyLabel: string;
-  impact: string;
+  userImpact: UserImpact;
   diagnosis: string;
   remediation: string;
   sentryUrl: string;
@@ -29,18 +30,26 @@ const URGENCY_COLORS: Record<string, string> = {
   noise: "#71717a",
 };
 
+const USER_IMPACT_META: Record<UserImpactLevel, { label: string; color: string }> = {
+  none: { label: "AUCUN IMPACT UTILISATEUR", color: "#16a34a" },
+  silent: { label: "IMPACT SILENCIEUX", color: "#71717a" },
+  degraded: { label: "EXPÉRIENCE DÉGRADÉE", color: "#ea580c" },
+  blocking: { label: "UTILISATEUR BLOQUÉ", color: "#dc2626" },
+};
+
 export function SentryIssueAnalysisEmail({
   issueShortId,
   issueTitle,
   culprit,
   urgency,
   urgencyLabel,
-  impact,
+  userImpact,
   diagnosis,
   remediation,
   sentryUrl,
 }: Props) {
   const color = URGENCY_COLORS[urgency] ?? "#71717a";
+  const impactMeta = USER_IMPACT_META[userImpact.level];
 
   return (
     <EmailLayout
@@ -55,12 +64,16 @@ export function SentryIssueAnalysisEmail({
       <Text style={heading}>{issueShortId}</Text>
       <Text style={titleStyle}>{issueTitle}</Text>
 
+      <Section style={{ ...infoCard, borderLeft: `4px solid ${impactMeta.color}` }}>
+        <Text style={{ ...infoLabel, color: impactMeta.color, fontWeight: 700 }}>
+          {impactMeta.label}
+        </Text>
+        <Text style={bodyText}>{userImpact.description}</Text>
+      </Section>
+
       <Section style={infoCard}>
         <Text style={infoLabel}>Culprit</Text>
         <Text style={infoValue}>{culprit}</Text>
-
-        <Text style={infoLabel}>Impact</Text>
-        <Text style={infoValue}>{impact}</Text>
       </Section>
 
       <Section style={infoCard}>

--- a/src/infrastructure/services/slack/slack-notification-service.ts
+++ b/src/infrastructure/services/slack/slack-notification-service.ts
@@ -130,25 +130,36 @@ export async function notifySlackNewComment(params: {
   });
 }
 
+type UserImpactSlackLevel = "none" | "silent" | "degraded" | "blocking";
+
+const USER_IMPACT_SLACK: Record<UserImpactSlackLevel, { emoji: string; label: string }> = {
+  none: { emoji: "🟢", label: "Aucun impact utilisateur" },
+  silent: { emoji: "⚪", label: "Impact silencieux" },
+  degraded: { emoji: "🟠", label: "Experience degradee" },
+  blocking: { emoji: "🔴", label: "Utilisateur bloque" },
+};
+
 export async function notifySlackSentryIssue(params: {
   issueShortId: string;
   issueTitle: string;
   culprit: string;
   urgencyLabel: string;
-  impact: string;
+  userImpact: { level: UserImpactSlackLevel; description: string };
   diagnosis: string;
   remediation: string;
   sentryUrl: string;
 }): Promise<void> {
+  const impactMeta = USER_IMPACT_SLACK[params.userImpact.level];
   await sendSlack({
     text: `🚨 [Sentry ${params.urgencyLabel}] ${params.issueShortId} — ${params.issueTitle}`,
     blocks: [
       { type: "header", text: { type: "plain_text", text: `🚨 Sentry — Urgence ${params.urgencyLabel}`, emoji: true } },
       { type: "section", text: { type: "mrkdwn", text: `*${params.issueShortId}*\n${params.issueTitle}` } },
       { type: "divider" },
+      { type: "section", text: { type: "mrkdwn", text: `${impactMeta.emoji} *${impactMeta.label}*\n${params.userImpact.description}` } },
+      { type: "divider" },
       { type: "section", fields: [
         { type: "mrkdwn", text: `*Culprit*\n\`${params.culprit}\`` },
-        { type: "mrkdwn", text: `*Impact*\n${params.impact}` },
       ]},
       { type: "section", text: { type: "mrkdwn", text: `*Diagnostic*\n${params.diagnosis}` } },
       { type: "section", text: { type: "mrkdwn", text: `*Remediation*\n${params.remediation}` } },


### PR DESCRIPTION
## Contexte

L'analyse Claude des issues Sentry renvoyait un champ libre `impact` qui mélangeait gravité technique et gravité UX. Exemple observé aujourd'hui sur une erreur dans `posthog-recorder.js` (déclenchée pendant `pagehide`, totalement invisible pour l'utilisateur) :

> Les utilisateurs accédant aux pages de communautés/événements (/m/:slug) peuvent expérimenter des erreurs console et une instrumentation analytics (PostHog) défaillante.

Faussement alarmiste : l'utilisateur ne voit strictement rien.

## Changements

- **`analyze-issue.ts`** : nouveau type `UserImpact { level, description }` avec 4 niveaux explicites (`none` / `silent` / `degraded` / `blocking`). Prompt Claude enrichi d'une **checklist contrefactuelle** (script tiers, handler pagehide/unload, erreur handled, preuve d'un crash UI) et d'une règle d'or : *"level" décrit ce que voit ou fait l'utilisateur, pas ce qui se passe en interne*. Validation stricte du JSON retour avec fallback `silent` si malformé.
- **`sentry-issue-analysis-email.tsx`** : bloc dédié "Impact utilisateur" avec badge coloré (vert / gris / orange / rouge selon `level`) placé juste après le badge d'urgence, pour distinguer au premier coup d'œil la gravité technique de la gravité UX.
- **`slack-notification-service.ts`** : ligne impact dédiée avec emoji (🟢⚪🟠🔴) + libellé + description, avant les champs techniques.

## Effet attendu

Sur l'issue PostHog d'aujourd'hui, on aurait reçu :

> 🟢 **Aucun impact utilisateur**
> L'utilisateur ne voit rien. L'erreur se déclenche dans le recorder PostHog pendant `pagehide`, l'utilisateur est déjà en train de quitter la page.

## Test plan

- [ ] Déclencher un webhook Sentry de test et vérifier l'email reçu (bloc impact coloré, description UX)
- [ ] Vérifier le message Slack correspondant (emoji + ligne impact en tête des champs techniques)
- [ ] Vérifier que les 4 niveaux `none` / `silent` / `degraded` / `blocking` s'affichent correctement (couleurs, labels)
- [ ] Fallback : simuler une réponse Claude malformée, vérifier qu'on reçoit bien le fallback `silent`

🤖 Generated with [Claude Code](https://claude.com/claude-code)