### PR TITLE
feat(co-host): implémentation complète des co-organisateurs de Communauté

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -246,7 +246,9 @@
     },
     "noCirclesMember": "You are not a member of any community yet.",
     "role": {
+      "owner": "Owner",
       "host": "Organizer",
+      "coHost": "Co-organizer",
       "player": "Member"
     },
     "pendingRequests": {
@@ -343,6 +345,19 @@
       "description": "{name} will lose access to this community. Their registrations for upcoming events will be automatically cancelled.",
       "confirm": "Remove",
       "cancel": "Cancel"
+    },
+    "memberActions": {
+      "label": "Actions"
+    },
+    "promoteToCoHost": {
+      "action": "Promote to co-organizer",
+      "success": "{name} is now a co-organizer",
+      "error": "Unable to promote this member"
+    },
+    "demoteFromCoHost": {
+      "action": "Demote to member",
+      "success": "{name} is now a member",
+      "error": "Unable to demote this co-organizer"
     },
     "errors": {
       "notFound": "Community not found",
@@ -730,6 +745,7 @@
       "noUpcomingMoments": "No upcoming Events",
       "nextMoment": "Next Event",
       "roleBadge": {
+        "owner": "Owner",
         "host": "Organizer",
         "member": "Member",
         "pending": "Pending approval"
@@ -932,6 +948,31 @@
     "signOut": "Sign out"
   },
   "Email": {
+    "coHostPromoted": {
+      "subject": "You're a co-organizer of {circleName}",
+      "heading": "You're a co-organizer of {circleName}",
+      "intro": "{inviterName} just promoted you to co-organizer of their Community. You can now help manage events and members.",
+      "rightsTitle": "Your new rights",
+      "rightCreateEvents": "Create and edit events",
+      "rightManageRegistrations": "Manage registrations and the waitlist",
+      "rightUpdateCircle": "Update Community settings",
+      "rightBroadcast": "Broadcast messages to the Community",
+      "rightReceiveNotifications": "Receive Organizer notifications",
+      "limitsNote": "Only the owner can delete the Community, manage the Stripe account, or promote other co-organizers.",
+      "ctaLabel": "Open dashboard",
+      "footer": "You're receiving this email because you were promoted to co-organizer of a Community you belong to.",
+      "leaveLink": "Leave the Community"
+    },
+    "coHostDemoted": {
+      "subject": "Your role changed in {circleName}",
+      "heading": "Your role changed in {circleName}",
+      "intro": "You are no longer a co-organizer of {circleName}. You remain a member of the Community.",
+      "newRoleLabel": "You are now a Member",
+      "registrationsNote": "Your existing event registrations are not affected. You continue to receive Community updates.",
+      "ctaLabel": "View Community",
+      "footer": "You're receiving this email because your role changed in a Community you belong to.",
+      "preferencesLink": "Manage my notification preferences"
+    },
     "registration": {
       "subject": "You've joined {momentTitle}",
       "heading": "Registration confirmed!",

--- a/messages/en.json
+++ b/messages/en.json
@@ -331,7 +331,7 @@
       "joined": "Member",
       "pendingApproval": "Request pending approval",
       "isMember": "You are a member",
-      "isHost": "You are an organizer",
+      "isOrganizer": "You are an organizer",
       "manageCircle": "Manage this community",
       "shareableLink": "Shareable link",
       "signInToSeeMembers": "Sign in to see the members of this community",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1513,6 +1513,7 @@
       "radar": "The Radar",
       "share": "Share your event",
       "members": "Manage members",
+      "coHosts": "Co-organizers",
       "inviteMembers": "Invite members",
       "approvalRegistrations": "Approve registrations",
       "payments": "Enable payments"
@@ -1688,6 +1689,21 @@
         "title": "Manage community members",
         "intro": "From your community page, you can see the full member list with their emails. Each name is clickable and links to the member's public profile. You can remove a member via the <strong>⋮</strong> menu next to their name.",
         "outro": "Members automatically join your community when they register for one of your events."
+      },
+      "coHosts": {
+        "title": "Share management with co-organizers",
+        "intro": "You can delegate community management to other members by <strong>promoting them to co-organizer</strong>. A co-organizer has almost all the same powers as you, except for a few sensitive actions that stay with the owner.",
+        "rightsIntro": "A co-organizer can:",
+        "right1": "Create, edit, publish and delete events",
+        "right2": "Approve or reject registrations and membership requests",
+        "right3": "Update community settings and broadcast messages to members",
+        "right4": "Receive the same notifications you do (new registrations, comments, etc.)",
+        "limitsIntro": "Only the owner can:",
+        "limit1": "Delete the community",
+        "limit2": "Manage the Stripe Connect account (for paid events)",
+        "limit3": "Promote, demote, or remove another co-organizer",
+        "howTo": "To promote a member: on the <strong>Members</strong> page of your community, open the <strong>⋮</strong> menu next to their name and click <strong>Promote to co-organizer</strong>. They'll receive an email confirming their new rights, and can immediately start helping you manage the community.",
+        "demote": "To revoke a co-organizer's rights, open the same menu and click Demote to member. The person remains a member of the community but loses their management rights, and receives a plain email informing them of the change."
       },
       "inviteMembers": {
         "title": "Invite members",

--- a/messages/en.json
+++ b/messages/en.json
@@ -246,7 +246,6 @@
     },
     "noCirclesMember": "You are not a member of any community yet.",
     "role": {
-      "owner": "Owner",
       "host": "Organizer",
       "coHost": "Co-organizer",
       "player": "Member"
@@ -745,7 +744,6 @@
       "noUpcomingMoments": "No upcoming Events",
       "nextMoment": "Next Event",
       "roleBadge": {
-        "owner": "Owner",
         "host": "Organizer",
         "member": "Member",
         "pending": "Pending approval"

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -246,7 +246,6 @@
     },
     "noCirclesMember": "Vous n'êtes membre d'aucune communauté.",
     "role": {
-      "owner": "Propriétaire",
       "host": "Organisateur",
       "coHost": "Co-organisateur",
       "player": "Participant"
@@ -745,7 +744,6 @@
       "noUpcomingMoments": "Aucun événement à venir",
       "nextMoment": "Prochain événement",
       "roleBadge": {
-        "owner": "Propriétaire",
         "host": "Organisateur",
         "member": "Membre",
         "pending": "En attente de validation"

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1513,6 +1513,7 @@
       "radar": "Le Radar",
       "share": "Partager l'événement",
       "members": "Gérer les membres",
+      "coHosts": "Co-organisateurs",
       "inviteMembers": "Inviter des membres",
       "approvalRegistrations": "Valider les inscriptions",
       "payments": "Activer les paiements"
@@ -1688,6 +1689,21 @@
         "title": "Gérer les membres de votre communauté",
         "intro": "Depuis la page de votre communauté, vous voyez la liste complète des membres avec leurs emails. Chaque nom est cliquable et pointe vers le profil public du membre. Vous pouvez retirer un membre via le menu <strong>⋮</strong> à côté de son nom.",
         "outro": "Les membres rejoignent automatiquement votre communauté lorsqu'ils s'inscrivent à l'un de vos événements."
+      },
+      "coHosts": {
+        "title": "Partager la gestion avec des co-organisateurs",
+        "intro": "Vous pouvez déléguer la gestion de votre communauté à d'autres membres en les <strong>promouvant co-organisateurs</strong>. Un co-organisateur a presque les mêmes pouvoirs que vous, sauf les actions les plus sensibles qui restent réservées au propriétaire.",
+        "rightsIntro": "Un co-organisateur peut :",
+        "right1": "Créer, éditer, publier et supprimer des événements",
+        "right2": "Approuver ou rejeter les inscriptions et les demandes d'adhésion",
+        "right3": "Modifier les paramètres de la communauté et diffuser des messages aux membres",
+        "right4": "Recevoir les mêmes notifications que vous (nouvelles inscriptions, commentaires, etc.)",
+        "limitsIntro": "Seul le propriétaire peut :",
+        "limit1": "Supprimer la communauté",
+        "limit2": "Gérer le compte Stripe Connect (pour les événements payants)",
+        "limit3": "Promouvoir, rétrograder ou retirer un autre co-organisateur",
+        "howTo": "Pour promouvoir un membre : sur la page <strong>Membres</strong> de votre communauté, ouvrez le menu <strong>⋮</strong> à côté de son nom et cliquez sur <strong>Promouvoir en co-organisateur</strong>. La personne reçoit un email lui confirmant ses nouveaux droits, et peut immédiatement commencer à gérer la communauté.",
+        "demote": "Pour retirer les droits d'un co-organisateur, ouvrez le même menu et cliquez sur Rétrograder en participant. La personne reste membre de la communauté mais perd ses droits de gestion, et reçoit un email sobre l'informant du changement."
       },
       "inviteMembers": {
         "title": "Inviter des membres",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -331,7 +331,7 @@
       "joined": "Membre",
       "pendingApproval": "Demande en cours de validation",
       "isMember": "Vous êtes membre",
-      "isHost": "Vous êtes organisateur",
+      "isOrganizer": "Vous êtes organisateur",
       "manageCircle": "Gérer cette communauté",
       "shareableLink": "Lien partageable",
       "signInToSeeMembers": "Connecte-toi pour voir les membres de cette communauté",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -246,7 +246,9 @@
     },
     "noCirclesMember": "Vous n'êtes membre d'aucune communauté.",
     "role": {
+      "owner": "Propriétaire",
       "host": "Organisateur",
+      "coHost": "Co-organisateur",
       "player": "Participant"
     },
     "pendingRequests": {
@@ -343,6 +345,19 @@
       "description": "{name} perdra l'accès à cette communauté. Ses inscriptions aux événements à venir seront annulées automatiquement.",
       "confirm": "Retirer",
       "cancel": "Annuler"
+    },
+    "memberActions": {
+      "label": "Actions"
+    },
+    "promoteToCoHost": {
+      "action": "Promouvoir en co-organisateur",
+      "success": "{name} est désormais co-organisateur",
+      "error": "Impossible de promouvoir ce membre"
+    },
+    "demoteFromCoHost": {
+      "action": "Rétrograder en participant",
+      "success": "{name} est désormais participant",
+      "error": "Impossible de rétrograder ce co-organisateur"
     },
     "errors": {
       "notFound": "Communauté introuvable",
@@ -730,6 +745,7 @@
       "noUpcomingMoments": "Aucun événement à venir",
       "nextMoment": "Prochain événement",
       "roleBadge": {
+        "owner": "Propriétaire",
         "host": "Organisateur",
         "member": "Membre",
         "pending": "En attente de validation"
@@ -932,6 +948,31 @@
     "signOut": "Se déconnecter"
   },
   "Email": {
+    "coHostPromoted": {
+      "subject": "Vous êtes co-organisateur de {circleName}",
+      "heading": "Vous êtes co-organisateur de {circleName}",
+      "intro": "{inviterName} vient de vous promouvoir co-organisateur de sa Communauté. Vous pouvez désormais l'aider à gérer les événements et les membres.",
+      "rightsTitle": "Vos nouveaux droits",
+      "rightCreateEvents": "Créer et éditer des événements",
+      "rightManageRegistrations": "Gérer les inscriptions et la liste d'attente",
+      "rightUpdateCircle": "Modifier les paramètres de la Communauté",
+      "rightBroadcast": "Diffuser des messages à la Communauté",
+      "rightReceiveNotifications": "Recevoir les notifications d'Organisateur",
+      "limitsNote": "Seul le propriétaire peut supprimer la Communauté, gérer le compte Stripe ou promouvoir d'autres co-organisateurs.",
+      "ctaLabel": "Ouvrir le dashboard",
+      "footer": "Vous recevez cet email parce que vous avez été promu co-organisateur d'une Communauté dont vous êtes membre.",
+      "leaveLink": "Quitter la Communauté"
+    },
+    "coHostDemoted": {
+      "subject": "Votre rôle a changé dans {circleName}",
+      "heading": "Votre rôle a changé dans {circleName}",
+      "intro": "Vous n'êtes plus co-organisateur de {circleName}. Vous restez membre de la Communauté en tant que participant.",
+      "newRoleLabel": "Vous êtes désormais Participant",
+      "registrationsNote": "Vos inscriptions aux événements existants ne sont pas impactées. Vous continuez à recevoir les communications de la Communauté.",
+      "ctaLabel": "Voir la Communauté",
+      "footer": "Vous recevez cet email parce que votre rôle a changé dans une Communauté dont vous êtes membre.",
+      "preferencesLink": "Gérer mes préférences de notifications"
+    },
     "registration": {
       "subject": "Inscription confirmée : {momentTitle}",
       "heading": "Inscription confirmée !",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -33,6 +33,7 @@ enum CircleCategory {
 
 enum CircleMemberRole {
   HOST
+  CO_HOST
   PLAYER
 }
 

--- a/spec/mockups/circle-members-dashboard.mockup.html
+++ b/spec/mockups/circle-members-dashboard.mockup.html
@@ -1,0 +1,364 @@
+<!DOCTYPE html>
+<html lang="fr" class="dark">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Liste des membres — co-organisateurs — The Playground</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<style>
+:root {
+  --primary: #e8457a;
+  --primary-foreground: #ffffff;
+  --accent: #4fe0c2;
+  --background: #f5f5fa;
+  --foreground: #1a1b2e;
+  --card: #ffffff;
+  --card-foreground: #1a1b2e;
+  --muted: #f0eff7;
+  --muted-foreground: #6b6f87;
+  --border: #e3e3ec;
+  --input: #e3e3ec;
+  --destructive: #e8457a;
+  --radius: 0.5rem;
+  --shadow-sm: 0 1px 2px rgba(26,27,46,0.05);
+  --shadow-md: 0 4px 12px -2px rgba(26,27,46,0.1), 0 2px 6px -2px rgba(26,27,46,0.06);
+  --shadow-xl: 0 20px 60px -10px rgba(26,27,46,0.22);
+}
+html.dark {
+  --background: #1a1b2e;
+  --foreground: #f0f0f5;
+  --card: #252638;
+  --card-foreground: #f0f0f5;
+  --border: #383a55;
+  --muted: #222336;
+  --muted-foreground: #8385a0;
+  --input: #383a55;
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.3);
+  --shadow-xl: 0 20px 60px -10px rgba(0,0,0,0.6);
+}
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+body { font-family: 'Inter', sans-serif; font-size: 14px; line-height: 1.6; color: var(--foreground); background: var(--background); min-height: 100vh; }
+
+/* Site header */
+.site-header { height: 56px; background: var(--card); border-bottom: 1px solid var(--border); display: flex; align-items: center; padding: 0 24px; position: sticky; top: 0; z-index: 10; }
+.site-logo { font-size: 16px; font-weight: 800; color: var(--primary); margin-right: auto; }
+.nav-avatar { width: 32px; height: 32px; border-radius: 50%; background: linear-gradient(135deg, #3b82f6, #06b6d4); display: flex; align-items: center; justify-content: center; color: white; font-size: 12px; font-weight: 600; }
+
+/* Layout */
+.dashboard { max-width: 1100px; margin: 0 auto; padding: 32px 24px 80px; }
+
+.breadcrumb { display: flex; align-items: center; gap: 4px; font-size: 13px; color: var(--muted-foreground); margin-bottom: 8px; }
+.breadcrumb a { color: var(--muted-foreground); text-decoration: none; }
+.breadcrumb a:hover { color: var(--foreground); }
+.breadcrumb .sep { font-size: 11px; }
+.breadcrumb .current { color: var(--foreground); font-weight: 500; }
+
+.page-title { font-size: 24px; font-weight: 800; letter-spacing: -0.01em; margin-bottom: 4px; }
+.page-desc { font-size: 13px; color: var(--muted-foreground); margin-bottom: 28px; }
+
+/* State toggle */
+.state-bar { display: flex; align-items: center; gap: 8px; margin-bottom: 28px; padding: 12px 16px; background: var(--card); border: 1px solid var(--border); border-radius: 12px; flex-wrap: wrap; }
+.state-bar-label { font-size: 11px; font-weight: 600; color: var(--muted-foreground); text-transform: uppercase; letter-spacing: 0.05em; margin-right: 4px; }
+.state-btn { padding: 6px 14px; border-radius: 8px; font-size: 12px; font-weight: 500; cursor: pointer; border: 1px solid var(--border); background: transparent; color: var(--muted-foreground); transition: all 0.15s; font-family: inherit; }
+.state-btn:hover { background: var(--muted); color: var(--foreground); }
+.state-btn.active { background: var(--primary); color: white; border-color: var(--primary); }
+
+/* Badges */
+.badge { display: inline-flex; align-items: center; gap: 4px; padding: 2px 10px; border-radius: 999px; font-size: 11px; font-weight: 500; white-space: nowrap; }
+.badge-owner { border: 1px solid rgba(232,69,122,0.4); color: var(--primary); }
+.badge-org { border: 1px solid rgba(79,224,194,0.4); color: var(--accent); }
+.badge-outline { border: 1px solid var(--border); color: var(--muted-foreground); background: var(--muted); }
+.badge-you { border: 1px solid var(--border); color: var(--muted-foreground); font-size: 10px; padding: 1px 6px; }
+
+/* Members card */
+.members-card { background: var(--card); border: 1px solid var(--border); border-radius: 16px; padding: 24px; box-shadow: var(--shadow-sm); }
+.members-header { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-bottom: 4px; }
+.members-title { font-size: 17px; font-weight: 600; }
+
+/* Section label */
+.section-label { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em; color: var(--muted-foreground); padding: 14px 0 6px; border-bottom: 1px solid var(--border); margin-top: 4px; }
+
+/* Member row */
+.member-row { display: flex; align-items: center; gap: 12px; padding: 12px 0; border-bottom: 1px solid var(--border); position: relative; }
+.member-row:last-child { border-bottom: none; }
+.avatar { width: 36px; height: 36px; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 12px; font-weight: 600; color: white; flex-shrink: 0; }
+.member-info { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 2px; }
+.member-name { font-size: 14px; font-weight: 500; line-height: 1.3; display: flex; align-items: center; gap: 6px; }
+.member-email { font-size: 12px; color: var(--muted-foreground); }
+
+/* Menu button */
+.menu-btn { width: 32px; height: 32px; border-radius: 8px; display: flex; align-items: center; justify-content: center; border: none; background: transparent; cursor: pointer; color: var(--muted-foreground); transition: all 0.15s; }
+.menu-btn:hover { background: var(--muted); color: var(--foreground); }
+.menu-btn:disabled { opacity: 0.3; cursor: not-allowed; }
+
+/* Dropdown */
+.dropdown { position: absolute; right: 0; top: 50px; z-index: 20; background: var(--card); border: 1px solid var(--border); border-radius: 10px; box-shadow: var(--shadow-xl); padding: 4px; min-width: 240px; }
+.dropdown::before { content: ''; position: absolute; right: 12px; top: -6px; width: 10px; height: 10px; background: var(--card); border-left: 1px solid var(--border); border-top: 1px solid var(--border); transform: rotate(45deg); }
+.dropdown-item { display: flex; align-items: center; gap: 10px; padding: 9px 12px; border-radius: 6px; font-size: 13px; cursor: pointer; color: var(--foreground); transition: background 0.1s; user-select: none; position: relative; z-index: 1; }
+.dropdown-item:hover { background: var(--muted); }
+.dropdown-item.destructive { color: var(--destructive); }
+.dropdown-item.destructive:hover { background: rgba(232,69,122,0.08); }
+.dropdown-sep { height: 1px; background: var(--border); margin: 4px 2px; }
+.dropdown-item svg { width: 15px; height: 15px; flex-shrink: 0; }
+
+/* Notes / matrix */
+.matrix-section { margin-top: 48px; }
+.matrix-title { font-size: 13px; font-weight: 700; margin-bottom: 6px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--muted-foreground); }
+.matrix-desc { font-size: 13px; color: var(--muted-foreground); margin-bottom: 16px; }
+
+.matrix-card { background: var(--card); border: 1px solid var(--border); border-radius: 16px; overflow: hidden; box-shadow: var(--shadow-sm); }
+.matrix-table { width: 100%; border-collapse: collapse; font-size: 13px; }
+.matrix-table th, .matrix-table td { padding: 12px 14px; text-align: left; border-bottom: 1px solid var(--border); }
+.matrix-table th { font-weight: 600; font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--muted-foreground); background: var(--muted); }
+.matrix-table tr:last-child td { border-bottom: none; }
+.matrix-table td:first-child { font-weight: 600; }
+
+.pill { display: inline-flex; align-items: center; gap: 4px; padding: 2px 8px; border-radius: 4px; font-size: 11px; font-weight: 500; margin-right: 4px; margin-bottom: 2px; }
+.pill.yes { background: rgba(79,224,194,0.15); color: var(--accent); }
+.pill.no { background: rgba(232,69,122,0.12); color: var(--primary); }
+.pill.muted { background: var(--muted); color: var(--muted-foreground); }
+.pill.self { background: rgba(234,179,8,0.15); color: #eab308; }
+</style>
+</head>
+<body>
+
+<header class="site-header">
+  <div class="site-logo">The Playground</div>
+  <div class="nav-avatar">D</div>
+</header>
+
+<main class="dashboard">
+  <div class="breadcrumb">
+    <a href="#">Mon espace</a>
+    <span class="sep">›</span>
+    <a href="#">Paris AI Builders</a>
+  </div>
+  <h1 class="page-title">Paris AI Builders</h1>
+  <p class="page-desc">Liste des membres, vue Organisateur (dashboard)</p>
+
+  <div class="state-bar">
+    <span class="state-bar-label">Vue de :</span>
+    <button class="state-btn active" onclick="setView(event,'host')">HOST (propriétaire)</button>
+    <button class="state-btn" onclick="setView(event,'cohost')">CO_HOST</button>
+  </div>
+
+  <!-- VUE HOST -->
+  <div id="view-host" class="members-card">
+    <div class="members-header">
+      <h2 class="members-title">Membres</h2>
+      <span class="badge badge-outline">5 membres</span>
+    </div>
+
+    <div class="section-label">Organisateurs</div>
+
+    <div class="member-row">
+      <div class="avatar" style="background: linear-gradient(135deg, #e8457a, #9333ea);">DD</div>
+      <div class="member-info">
+        <div class="member-name">Dragos Dreptate<span class="badge badge-you">Vous</span></div>
+        <div class="member-email">dragos@example.com</div>
+      </div>
+      <span class="badge badge-owner">
+        <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m2 4 3 12h14l3-12-6 7.5-4-5.5-4 5.5z"/></svg>
+        Propriétaire
+      </span>
+    </div>
+
+    <div class="member-row">
+      <div class="avatar" style="background: linear-gradient(135deg, #3b82f6, #06b6d4);">AM</div>
+      <div class="member-info">
+        <div class="member-name">Alice Martin</div>
+        <div class="member-email">alice.martin@example.com</div>
+      </div>
+      <span class="badge badge-org">
+        <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m2 4 3 12h14l3-12-6 7.5-4-5.5-4 5.5z"/></svg>
+        Organisateur
+      </span>
+      <button class="menu-btn" aria-label="Actions">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="5" r="1"/><circle cx="12" cy="12" r="1"/><circle cx="12" cy="19" r="1"/></svg>
+      </button>
+      <div class="dropdown">
+        <div class="dropdown-item">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>
+          Rétrograder en participant
+        </div>
+        <div class="dropdown-sep"></div>
+        <div class="dropdown-item destructive">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>
+          Retirer de la Communauté
+        </div>
+      </div>
+    </div>
+
+    <div class="section-label">Participants</div>
+
+    <div class="member-row">
+      <div class="avatar" style="background: linear-gradient(135deg, #10b981, #059669);">BD</div>
+      <div class="member-info">
+        <div class="member-name">Bob Durand</div>
+        <div class="member-email">bob.durand@example.com</div>
+      </div>
+      <button class="menu-btn" aria-label="Actions">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="5" r="1"/><circle cx="12" cy="12" r="1"/><circle cx="12" cy="19" r="1"/></svg>
+      </button>
+      <div class="dropdown">
+        <div class="dropdown-item">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m2 4 3 12h14l3-12-6 7.5-4-5.5-4 5.5z"/></svg>
+          Promouvoir en co-organisateur
+        </div>
+        <div class="dropdown-sep"></div>
+        <div class="dropdown-item destructive">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>
+          Retirer de la Communauté
+        </div>
+      </div>
+    </div>
+
+    <div class="member-row">
+      <div class="avatar" style="background: linear-gradient(135deg, #f59e0b, #d97706);">CL</div>
+      <div class="member-info">
+        <div class="member-name">Claire Leblanc</div>
+        <div class="member-email">claire.l@example.com</div>
+      </div>
+      <button class="menu-btn" aria-label="Actions">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="5" r="1"/><circle cx="12" cy="12" r="1"/><circle cx="12" cy="19" r="1"/></svg>
+      </button>
+    </div>
+
+    <div class="member-row">
+      <div class="avatar" style="background: linear-gradient(135deg, #8b5cf6, #6366f1);">EP</div>
+      <div class="member-info">
+        <div class="member-name">Éric Payet</div>
+        <div class="member-email">eric.payet@example.com</div>
+      </div>
+      <span class="badge badge-outline">En attente</span>
+      <button class="menu-btn" aria-label="Actions" disabled title="Pas d'actions pour un membre en attente (D22)">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="5" r="1"/><circle cx="12" cy="12" r="1"/><circle cx="12" cy="19" r="1"/></svg>
+      </button>
+    </div>
+  </div>
+
+  <!-- VUE CO_HOST -->
+  <div id="view-cohost" class="members-card" style="display:none;">
+    <div class="members-header">
+      <h2 class="members-title">Membres</h2>
+      <span class="badge badge-outline">5 membres</span>
+    </div>
+
+    <div class="section-label">Organisateurs</div>
+
+    <div class="member-row">
+      <div class="avatar" style="background: linear-gradient(135deg, #e8457a, #9333ea);">DD</div>
+      <div class="member-info">
+        <div class="member-name">Dragos Dreptate</div>
+        <div class="member-email">dragos@example.com</div>
+      </div>
+      <span class="badge badge-owner">
+        <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m2 4 3 12h14l3-12-6 7.5-4-5.5-4 5.5z"/></svg>
+        Propriétaire
+      </span>
+    </div>
+
+    <div class="member-row">
+      <div class="avatar" style="background: linear-gradient(135deg, #3b82f6, #06b6d4);">AM</div>
+      <div class="member-info">
+        <div class="member-name">Alice Martin<span class="badge badge-you">Vous</span></div>
+        <div class="member-email">alice.martin@example.com</div>
+      </div>
+      <span class="badge badge-org">
+        <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m2 4 3 12h14l3-12-6 7.5-4-5.5-4 5.5z"/></svg>
+        Organisateur
+      </span>
+    </div>
+
+    <div class="section-label">Participants</div>
+
+    <div class="member-row">
+      <div class="avatar" style="background: linear-gradient(135deg, #10b981, #059669);">BD</div>
+      <div class="member-info">
+        <div class="member-name">Bob Durand</div>
+        <div class="member-email">bob.durand@example.com</div>
+      </div>
+      <button class="menu-btn" aria-label="Actions">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="5" r="1"/><circle cx="12" cy="12" r="1"/><circle cx="12" cy="19" r="1"/></svg>
+      </button>
+      <div class="dropdown">
+        <div class="dropdown-item destructive">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>
+          Retirer de la Communauté
+        </div>
+      </div>
+    </div>
+
+    <div class="member-row">
+      <div class="avatar" style="background: linear-gradient(135deg, #f59e0b, #d97706);">CL</div>
+      <div class="member-info">
+        <div class="member-name">Claire Leblanc</div>
+        <div class="member-email">claire.l@example.com</div>
+      </div>
+      <button class="menu-btn" aria-label="Actions">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="5" r="1"/><circle cx="12" cy="12" r="1"/><circle cx="12" cy="19" r="1"/></svg>
+      </button>
+    </div>
+
+    <div class="member-row">
+      <div class="avatar" style="background: linear-gradient(135deg, #8b5cf6, #6366f1);">EP</div>
+      <div class="member-info">
+        <div class="member-name">Éric Payet</div>
+        <div class="member-email">eric.payet@example.com</div>
+      </div>
+      <span class="badge badge-outline">En attente</span>
+    </div>
+  </div>
+
+  <!-- Matrice des actions -->
+  <section class="matrix-section">
+    <div class="matrix-title">Matrice des actions du menu contextuel</div>
+    <p class="matrix-desc">Visibilité des actions dans le <code>DropdownMenu</code> selon le rôle de l'appelant et du membre cible.</p>
+    <div class="matrix-card">
+      <table class="matrix-table">
+        <thead>
+          <tr>
+            <th>Appelant</th>
+            <th>Cible PLAYER (ACTIVE)</th>
+            <th>Cible PLAYER (PENDING)</th>
+            <th>Cible CO_HOST</th>
+            <th>Cible HOST</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>HOST</td>
+            <td><span class="pill yes">Promouvoir</span><span class="pill no">Retirer</span></td>
+            <td><span class="pill muted">Menu désactivé</span></td>
+            <td><span class="pill yes">Rétrograder</span><span class="pill no">Retirer</span></td>
+            <td><span class="pill self">Soi-même</span></td>
+          </tr>
+          <tr>
+            <td>CO_HOST</td>
+            <td><span class="pill no">Retirer</span></td>
+            <td><span class="pill muted">Menu désactivé</span></td>
+            <td><span class="pill muted">Aucune action</span></td>
+            <td><span class="pill muted">Aucune action</span></td>
+          </tr>
+          <tr>
+            <td>PLAYER</td>
+            <td colspan="4"><span class="pill muted">Menu jamais affiché (vue Participant)</span></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+</main>
+
+<script>
+function setView(e, view) {
+  document.querySelectorAll('.state-btn').forEach(b => b.classList.remove('active'));
+  e.currentTarget.classList.add('active');
+  document.getElementById('view-host').style.display = view === 'host' ? 'block' : 'none';
+  document.getElementById('view-cohost').style.display = view === 'cohost' ? 'block' : 'none';
+}
+</script>
+
+</body>
+</html>

--- a/spec/mockups/circle-team-section.mockup.html
+++ b/spec/mockups/circle-team-section.mockup.html
@@ -1,0 +1,217 @@
+<!DOCTYPE html>
+<html lang="fr" class="dark">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Équipe d'organisation — paramètres Communauté — The Playground</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<style>
+:root {
+  --primary: #e8457a;
+  --primary-foreground: #ffffff;
+  --accent: #4fe0c2;
+  --background: #f5f5fa;
+  --foreground: #1a1b2e;
+  --card: #ffffff;
+  --card-foreground: #1a1b2e;
+  --muted: #f0eff7;
+  --muted-foreground: #6b6f87;
+  --border: #e3e3ec;
+  --input: #e3e3ec;
+  --destructive: #e8457a;
+  --radius: 0.5rem;
+  --shadow-sm: 0 1px 2px rgba(26,27,46,0.05);
+}
+html.dark {
+  --background: #1a1b2e;
+  --foreground: #f0f0f5;
+  --card: #252638;
+  --card-foreground: #f0f0f5;
+  --border: #383a55;
+  --muted: #222336;
+  --muted-foreground: #8385a0;
+  --input: #383a55;
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.3);
+}
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+body { font-family: 'Inter', sans-serif; font-size: 14px; line-height: 1.6; color: var(--foreground); background: var(--background); min-height: 100vh; }
+
+.site-header { height: 56px; background: var(--card); border-bottom: 1px solid var(--border); display: flex; align-items: center; padding: 0 24px; position: sticky; top: 0; z-index: 10; }
+.site-logo { font-size: 16px; font-weight: 800; color: var(--primary); margin-right: auto; }
+.nav-avatar { width: 32px; height: 32px; border-radius: 50%; background: linear-gradient(135deg, #3b82f6, #06b6d4); display: flex; align-items: center; justify-content: center; color: white; font-size: 12px; font-weight: 600; }
+
+.dashboard { max-width: 900px; margin: 0 auto; padding: 32px 24px 80px; }
+
+.breadcrumb { display: flex; align-items: center; gap: 4px; font-size: 13px; color: var(--muted-foreground); margin-bottom: 8px; }
+.breadcrumb a { color: var(--muted-foreground); text-decoration: none; }
+.breadcrumb a:hover { color: var(--foreground); }
+.breadcrumb .sep { font-size: 11px; }
+.breadcrumb .current { color: var(--foreground); font-weight: 500; }
+
+.page-title { font-size: 24px; font-weight: 800; letter-spacing: -0.01em; margin-bottom: 4px; }
+.page-desc { font-size: 13px; color: var(--muted-foreground); margin-bottom: 28px; }
+
+/* Settings nav tabs (simplified context) */
+.context-tabs { display: flex; gap: 4px; padding: 4px; background: var(--muted); border-radius: 10px; margin-bottom: 24px; width: fit-content; opacity: 0.6; }
+.context-tab { padding: 6px 14px; border-radius: 6px; font-size: 13px; font-weight: 500; color: var(--muted-foreground); cursor: pointer; }
+.context-tab.active { background: var(--card); color: var(--foreground); opacity: 1; box-shadow: var(--shadow-sm); }
+
+/* Section header */
+.section-title { font-size: 17px; font-weight: 600; margin-bottom: 4px; display: flex; align-items: center; gap: 8px; }
+.section-desc { font-size: 13px; color: var(--muted-foreground); margin-bottom: 20px; line-height: 1.55; }
+
+/* Badges */
+.badge { display: inline-flex; align-items: center; gap: 4px; padding: 2px 10px; border-radius: 999px; font-size: 11px; font-weight: 500; white-space: nowrap; }
+.badge-owner { border: 1px solid rgba(232,69,122,0.4); color: var(--primary); }
+.badge-org { border: 1px solid rgba(79,224,194,0.4); color: var(--accent); }
+.badge-outline { border: 1px solid var(--border); color: var(--muted-foreground); background: var(--muted); font-size: 10px; padding: 1px 6px; }
+
+/* Team card */
+.team-card { background: var(--card); border: 1px solid var(--border); border-radius: 16px; padding: 24px; box-shadow: var(--shadow-sm); }
+
+/* Team row */
+.team-row { display: flex; align-items: center; gap: 12px; padding: 12px 0; border-bottom: 1px solid var(--border); position: relative; }
+.team-row:last-of-type { border-bottom: none; padding-bottom: 4px; }
+.team-row:first-of-type { padding-top: 4px; }
+.avatar { width: 40px; height: 40px; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 13px; font-weight: 600; color: white; flex-shrink: 0; }
+.member-info { flex: 1; min-width: 0; }
+.member-name { font-size: 14px; font-weight: 500; line-height: 1.3; display: flex; align-items: center; gap: 6px; }
+.member-email { font-size: 12px; color: var(--muted-foreground); margin-top: 1px; }
+.role-pill { font-size: 12px; color: var(--muted-foreground); margin-top: 1px; }
+
+/* Menu button */
+.menu-btn { width: 32px; height: 32px; border-radius: 8px; display: flex; align-items: center; justify-content: center; border: none; background: transparent; cursor: pointer; color: var(--muted-foreground); transition: all 0.15s; }
+.menu-btn:hover { background: var(--muted); color: var(--foreground); }
+
+/* Add button */
+.add-section { display: flex; align-items: center; justify-content: space-between; padding: 14px 0 4px; border-top: 1px solid var(--border); margin-top: 8px; }
+.add-hint { font-size: 12px; color: var(--muted-foreground); }
+.btn-outline { display: inline-flex; align-items: center; gap: 6px; padding: 7px 12px; border-radius: 8px; font-size: 13px; font-weight: 500; border: 1px solid var(--border); background: transparent; color: var(--foreground); cursor: pointer; transition: all 0.15s; font-family: inherit; }
+.btn-outline:hover { background: var(--muted); border-color: var(--muted-foreground); }
+
+/* Info callout */
+.info-callout { margin-top: 16px; padding: 12px 14px; background: var(--muted); border: 1px solid var(--border); border-radius: 10px; display: flex; gap: 10px; align-items: flex-start; }
+.info-callout svg { color: var(--accent); flex-shrink: 0; margin-top: 2px; }
+.info-callout p { font-size: 12.5px; color: var(--muted-foreground); line-height: 1.55; }
+.info-callout strong { color: var(--foreground); font-weight: 600; }
+
+/* Dropdown */
+.dropdown { position: absolute; right: 0; top: 52px; z-index: 20; background: var(--card); border: 1px solid var(--border); border-radius: 10px; box-shadow: 0 20px 60px -10px rgba(0,0,0,0.6); padding: 4px; min-width: 240px; }
+.dropdown-item { display: flex; align-items: center; gap: 10px; padding: 9px 12px; border-radius: 6px; font-size: 13px; cursor: pointer; color: var(--foreground); transition: background 0.1s; }
+.dropdown-item:hover { background: var(--muted); }
+.dropdown-item.destructive { color: var(--destructive); }
+.dropdown-item.destructive:hover { background: rgba(232,69,122,0.08); }
+.dropdown-sep { height: 1px; background: var(--border); margin: 4px 2px; }
+.dropdown-item svg { width: 15px; height: 15px; flex-shrink: 0; }
+
+/* State label (mockup only) */
+.state-hint { display: inline-flex; align-items: center; gap: 6px; padding: 3px 10px; border-radius: 999px; font-size: 11px; font-weight: 500; background: rgba(232,69,122,0.1); color: var(--primary); margin-bottom: 12px; }
+</style>
+</head>
+<body>
+
+<header class="site-header">
+  <div class="site-logo">The Playground</div>
+  <div class="nav-avatar">D</div>
+</header>
+
+<main class="dashboard">
+  <div class="breadcrumb">
+    <a href="#">Mon espace</a>
+    <span class="sep">›</span>
+    <a href="#">Paris AI Builders</a>
+    <span class="sep">›</span>
+    <span class="current">Paramètres</span>
+  </div>
+  <h1 class="page-title">Paramètres</h1>
+  <p class="page-desc">Paris AI Builders</p>
+
+  <div class="context-tabs">
+    <div class="context-tab">Général</div>
+    <div class="context-tab">Apparence</div>
+    <div class="context-tab active">Équipe</div>
+    <div class="context-tab">Paiements</div>
+    <div class="context-tab">Zone de danger</div>
+  </div>
+
+  <div class="state-hint">Vue Propriétaire (HOST) — actions complètes disponibles</div>
+
+  <h2 class="section-title">
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
+    Équipe d'organisation
+  </h2>
+  <p class="section-desc">Les co-organisateurs peuvent gérer les événements et les membres de la Communauté. Ils partagent vos droits, sauf la suppression de la Communauté, la gestion Stripe Connect et la promotion d'autres co-organisateurs.</p>
+
+  <div class="team-card">
+
+    <div class="team-row">
+      <div class="avatar" style="background: linear-gradient(135deg, #e8457a, #9333ea);">DD</div>
+      <div class="member-info">
+        <div class="member-name">Dragos Dreptate<span class="badge badge-outline">Vous</span></div>
+        <div class="member-email">dragos@example.com</div>
+      </div>
+      <span class="badge badge-owner">
+        <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m2 4 3 12h14l3-12-6 7.5-4-5.5-4 5.5z"/></svg>
+        Propriétaire
+      </span>
+    </div>
+
+    <div class="team-row">
+      <div class="avatar" style="background: linear-gradient(135deg, #3b82f6, #06b6d4);">AM</div>
+      <div class="member-info">
+        <div class="member-name">Alice Martin</div>
+        <div class="member-email">alice.martin@example.com</div>
+      </div>
+      <span class="badge badge-org">
+        <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m2 4 3 12h14l3-12-6 7.5-4-5.5-4 5.5z"/></svg>
+        Organisateur
+      </span>
+      <button class="menu-btn" aria-label="Actions">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="5" r="1"/><circle cx="12" cy="12" r="1"/><circle cx="12" cy="19" r="1"/></svg>
+      </button>
+      <div class="dropdown">
+        <div class="dropdown-item">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>
+          Rétrograder en participant
+        </div>
+        <div class="dropdown-sep"></div>
+        <div class="dropdown-item destructive">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>
+          Retirer de la Communauté
+        </div>
+      </div>
+    </div>
+
+    <div class="team-row">
+      <div class="avatar" style="background: linear-gradient(135deg, #10b981, #059669);">MR</div>
+      <div class="member-info">
+        <div class="member-name">Marc Robin</div>
+        <div class="member-email">marc.robin@example.com</div>
+      </div>
+      <span class="badge badge-org">
+        <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m2 4 3 12h14l3-12-6 7.5-4-5.5-4 5.5z"/></svg>
+        Organisateur
+      </span>
+      <button class="menu-btn" aria-label="Actions">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="5" r="1"/><circle cx="12" cy="12" r="1"/><circle cx="12" cy="19" r="1"/></svg>
+      </button>
+    </div>
+
+    <div class="add-section">
+      <span class="add-hint">Promouvoir un membre depuis la liste complète</span>
+      <a href="#" class="btn-outline">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><line x1="19" y1="8" x2="19" y2="14"/><line x1="22" y1="11" x2="16" y2="11"/></svg>
+        Voir tous les membres
+      </a>
+    </div>
+  </div>
+
+  <div class="info-callout">
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
+    <p><strong>Comment promouvoir un membre ?</strong> Depuis la page des membres, ouvrez le menu d'un participant ACTIF et choisissez "Promouvoir en co-organisateur". Le membre reçoit un email de confirmation et gagne immédiatement les droits d'organisateur.</p>
+  </div>
+</main>
+
+</body>
+</html>

--- a/spec/mockups/email-co-host-demoted.mockup.html
+++ b/spec/mockups/email-co-host-demoted.mockup.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="fr" class="dark">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Email — Rétrogradation — The Playground</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<style>
+:root {
+  --primary: #e8457a;
+  --primary-foreground: #ffffff;
+  --background: #1a1b2e;
+  --foreground: #f0f0f5;
+  --card: #252638;
+  --border: #383a55;
+  --muted: #222336;
+  --muted-foreground: #8385a0;
+}
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+body { font-family: 'Inter', sans-serif; font-size: 14px; line-height: 1.6; color: var(--foreground); background: var(--background); min-height: 100vh; padding: 48px 24px 80px; }
+
+.stage-header { max-width: 640px; margin: 0 auto 32px; text-align: center; }
+.stage-title { font-size: 13px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; color: var(--muted-foreground); margin-bottom: 4px; }
+.stage-desc { font-size: 12px; color: var(--muted-foreground); }
+
+.email { max-width: 560px; margin: 0 auto; background: var(--card); border: 1px solid var(--border); border-radius: 12px; overflow: hidden; box-shadow: 0 20px 60px -10px rgba(0,0,0,0.4); }
+
+.email-header { padding: 32px 40px 20px; border-bottom: 1px solid var(--border); }
+.brand { display: flex; align-items: center; gap: 10px; }
+.brand-logo { width: 28px; height: 28px; border-radius: 7px; background: linear-gradient(135deg, var(--primary), #9333ea); display: flex; align-items: center; justify-content: center; color: white; font-weight: 800; font-size: 14px; }
+.brand-name { font-size: 15px; font-weight: 700; color: var(--foreground); }
+
+.email-body { padding: 32px 40px 28px; }
+
+.subject { font-size: 22px; font-weight: 700; line-height: 1.3; color: var(--foreground); margin-bottom: 20px; letter-spacing: -0.01em; }
+
+.paragraph { font-size: 15px; line-height: 1.6; color: var(--foreground); margin-bottom: 16px; }
+.paragraph.muted { color: var(--muted-foreground); font-size: 14px; }
+
+.circle-card { display: flex; align-items: center; gap: 12px; padding: 14px 16px; background: var(--muted); border: 1px solid var(--border); border-radius: 12px; margin: 20px 0; }
+.circle-avatar { width: 44px; height: 44px; border-radius: 10px; background: linear-gradient(135deg, #10b981, #6366f1); display: flex; align-items: center; justify-content: center; color: white; font-size: 16px; font-weight: 700; flex-shrink: 0; }
+.circle-name { font-size: 15px; font-weight: 600; color: var(--foreground); }
+.circle-meta { font-size: 12px; color: var(--muted-foreground); margin-top: 2px; }
+
+.cta-block { text-align: center; padding: 24px 0 8px; }
+.cta-btn { display: inline-flex; align-items: center; justify-content: center; gap: 8px; padding: 10px 22px; border-radius: 10px; background: transparent; border: 1px solid var(--border); color: var(--foreground); font-size: 14px; font-weight: 500; text-decoration: none; transition: background 0.15s; }
+.cta-btn:hover { background: var(--muted); }
+
+.fine-print { padding: 20px 40px 28px; border-top: 1px solid var(--border); background: var(--muted); }
+.fine-print p { font-size: 12px; color: var(--muted-foreground); line-height: 1.55; }
+.fine-print p + p { margin-top: 8px; }
+.fine-print a { color: var(--muted-foreground); text-decoration: underline; }
+</style>
+</head>
+<body>
+
+<div class="stage-header">
+  <div class="stage-title">Email — Rétrogradation (D19)</div>
+  <div class="stage-desc">Envoyé automatiquement par <code>demoteFromCoHost</code>. Ton sobre, factuel, pas de justification imposée.</div>
+</div>
+
+<div class="email">
+  <div class="email-header">
+    <div class="brand">
+      <div class="brand-logo">P</div>
+      <div class="brand-name">The Playground</div>
+    </div>
+  </div>
+
+  <div class="email-body">
+    <h1 class="subject">Votre rôle a changé dans Paris AI Builders</h1>
+
+    <p class="paragraph">Bonjour Alice,</p>
+    <p class="paragraph">Vous n'êtes plus co-organisateur de Paris AI Builders. Vous restez membre de la Communauté en tant que participant.</p>
+
+    <div class="circle-card">
+      <div class="circle-avatar">P</div>
+      <div>
+        <div class="circle-name">Paris AI Builders</div>
+        <div class="circle-meta">Vous êtes désormais Participant</div>
+      </div>
+    </div>
+
+    <p class="paragraph muted">Vos inscriptions aux événements existants ne sont pas impactées. Vous continuez à recevoir les communications de la Communauté.</p>
+
+    <div class="cta-block">
+      <a href="#" class="cta-btn">
+        Voir la Communauté
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
+      </a>
+    </div>
+  </div>
+
+  <div class="fine-print">
+    <p>Vous recevez cet email parce que votre rôle a changé dans une Communauté dont vous êtes membre.</p>
+    <p>Vous pouvez <a href="#">gérer vos préférences de notifications</a> à tout moment.</p>
+  </div>
+</div>
+
+</body>
+</html>

--- a/spec/mockups/email-co-host-promoted.mockup.html
+++ b/spec/mockups/email-co-host-promoted.mockup.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="fr" class="dark">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Email — Promotion en co-organisateur — The Playground</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<style>
+:root {
+  --primary: #e8457a;
+  --primary-foreground: #ffffff;
+  --accent: #4fe0c2;
+  --background: #1a1b2e;
+  --foreground: #f0f0f5;
+  --card: #252638;
+  --border: #383a55;
+  --muted: #222336;
+  --muted-foreground: #8385a0;
+}
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+body { font-family: 'Inter', sans-serif; font-size: 14px; line-height: 1.6; color: var(--foreground); background: var(--background); min-height: 100vh; padding: 48px 24px 80px; }
+
+.stage-header { max-width: 640px; margin: 0 auto 32px; text-align: center; }
+.stage-title { font-size: 13px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; color: var(--muted-foreground); margin-bottom: 4px; }
+.stage-desc { font-size: 12px; color: var(--muted-foreground); }
+
+/* Email container */
+.email { max-width: 560px; margin: 0 auto; background: var(--card); border: 1px solid var(--border); border-radius: 12px; overflow: hidden; box-shadow: 0 20px 60px -10px rgba(0,0,0,0.4); }
+
+.email-header { padding: 32px 40px 20px; border-bottom: 1px solid var(--border); }
+.brand { display: flex; align-items: center; gap: 10px; }
+.brand-logo { width: 28px; height: 28px; border-radius: 7px; background: linear-gradient(135deg, var(--primary), #9333ea); display: flex; align-items: center; justify-content: center; color: white; font-weight: 800; font-size: 14px; }
+.brand-name { font-size: 15px; font-weight: 700; color: var(--foreground); }
+
+.email-body { padding: 32px 40px 28px; }
+
+.subject { font-size: 22px; font-weight: 700; line-height: 1.3; color: var(--foreground); margin-bottom: 20px; letter-spacing: -0.01em; }
+
+.paragraph { font-size: 15px; line-height: 1.6; color: var(--foreground); margin-bottom: 16px; }
+.paragraph.muted { color: var(--muted-foreground); font-size: 14px; }
+
+.circle-card { display: flex; align-items: center; gap: 12px; padding: 14px 16px; background: var(--muted); border: 1px solid var(--border); border-radius: 12px; margin: 20px 0; }
+.circle-avatar { width: 44px; height: 44px; border-radius: 10px; background: linear-gradient(135deg, #10b981, #6366f1); display: flex; align-items: center; justify-content: center; color: white; font-size: 16px; font-weight: 700; flex-shrink: 0; }
+.circle-name { font-size: 15px; font-weight: 600; color: var(--foreground); }
+.circle-meta { font-size: 12px; color: var(--muted-foreground); margin-top: 2px; }
+
+.rights-list { list-style: none; padding: 18px; background: rgba(79,224,194,0.08); border: 1px solid rgba(79,224,194,0.25); border-radius: 12px; margin: 20px 0 8px; }
+.rights-title { font-size: 12px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em; color: var(--accent); margin-bottom: 10px; }
+.rights-item { display: flex; align-items: flex-start; gap: 10px; padding: 6px 0; font-size: 14px; color: var(--foreground); }
+.rights-item svg { color: var(--accent); flex-shrink: 0; margin-top: 4px; }
+
+.cta-block { text-align: center; padding: 28px 0 12px; }
+.cta-btn { display: inline-flex; align-items: center; justify-content: center; gap: 8px; padding: 12px 28px; border-radius: 10px; background: var(--primary); color: white; font-size: 15px; font-weight: 600; text-decoration: none; transition: opacity 0.15s; }
+.cta-btn:hover { opacity: 0.9; }
+
+.fine-print { padding: 20px 40px 28px; border-top: 1px solid var(--border); background: var(--muted); }
+.fine-print p { font-size: 12px; color: var(--muted-foreground); line-height: 1.55; }
+.fine-print p + p { margin-top: 8px; }
+.fine-print a { color: var(--muted-foreground); text-decoration: underline; }
+</style>
+</head>
+<body>
+
+<div class="stage-header">
+  <div class="stage-title">Email — Promotion en co-organisateur (D19)</div>
+  <div class="stage-desc">Envoyé automatiquement par <code>promoteToCoHost</code></div>
+</div>
+
+<div class="email">
+  <div class="email-header">
+    <div class="brand">
+      <div class="brand-logo">P</div>
+      <div class="brand-name">The Playground</div>
+    </div>
+  </div>
+
+  <div class="email-body">
+    <h1 class="subject">Vous êtes co-organisateur de Paris AI Builders</h1>
+
+    <p class="paragraph">Bonjour Alice,</p>
+    <p class="paragraph">Dragos Dreptate vient de vous promouvoir co-organisateur de sa Communauté. Vous pouvez désormais l'aider à gérer les événements et les membres.</p>
+
+    <div class="circle-card">
+      <div class="circle-avatar">P</div>
+      <div>
+        <div class="circle-name">Paris AI Builders</div>
+        <div class="circle-meta">42 membres · 3 événements à venir</div>
+      </div>
+    </div>
+
+    <div class="rights-list">
+      <div class="rights-title">Vos nouveaux droits</div>
+      <div class="rights-item">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+        <span>Créer et éditer des événements</span>
+      </div>
+      <div class="rights-item">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+        <span>Gérer les inscriptions et la liste d'attente</span>
+      </div>
+      <div class="rights-item">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+        <span>Modifier les paramètres de la Communauté</span>
+      </div>
+      <div class="rights-item">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+        <span>Diffuser des messages à la Communauté</span>
+      </div>
+      <div class="rights-item">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+        <span>Recevoir les notifications d'Organisateur</span>
+      </div>
+    </div>
+
+    <p class="paragraph muted">Seul le propriétaire peut supprimer la Communauté, gérer le compte Stripe ou promouvoir d'autres co-organisateurs.</p>
+
+    <div class="cta-block">
+      <a href="#" class="cta-btn">
+        Ouvrir le dashboard
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
+      </a>
+    </div>
+  </div>
+
+  <div class="fine-print">
+    <p>Vous recevez cet email parce que vous avez été promu co-organisateur d'une Communauté dont vous êtes membre.</p>
+    <p>Ne souhaitez plus ce rôle ? Vous pouvez <a href="#">quitter la Communauté</a> à tout moment.</p>
+  </div>
+</div>
+
+</body>
+</html>

--- a/src/app/[locale]/(routes)/(static)/help/page.tsx
+++ b/src/app/[locale]/(routes)/(static)/help/page.tsx
@@ -107,6 +107,7 @@ export default async function HelpPage() {
         { id: "radar", label: t("sidebar.radar") },
         { id: "share", label: t("sidebar.share") },
         { id: "members", label: t("sidebar.members") },
+        { id: "coHosts", label: t("sidebar.coHosts") },
         { id: "inviteMembers", label: t("sidebar.inviteMembers") },
         { id: "approvalRegistrations", label: t("sidebar.approvalRegistrations") },
         { id: "payments", label: t("sidebar.payments") },
@@ -542,6 +543,39 @@ export default async function HelpPage() {
               </p>
               <p className="text-sm leading-relaxed text-muted-foreground">
                 {t("organizer.members.outro")}
+              </p>
+            </div>
+
+            <hr className="border-border" />
+
+            {/* Co-organisateurs */}
+            <div className="space-y-4">
+              <SectionH3 id="coHosts">{t("organizer.coHosts.title")}</SectionH3>
+              <p className="text-sm leading-relaxed text-muted-foreground">
+                {t.rich("organizer.coHosts.intro", rich)}
+              </p>
+              <p className="text-sm leading-relaxed text-muted-foreground">
+                {t.rich("organizer.coHosts.rightsIntro", rich)}
+              </p>
+              <ul className="space-y-2 ml-6 list-disc text-sm leading-relaxed text-muted-foreground">
+                <li>{t("organizer.coHosts.right1")}</li>
+                <li>{t("organizer.coHosts.right2")}</li>
+                <li>{t("organizer.coHosts.right3")}</li>
+                <li>{t("organizer.coHosts.right4")}</li>
+              </ul>
+              <p className="text-sm leading-relaxed text-muted-foreground">
+                {t.rich("organizer.coHosts.limitsIntro", rich)}
+              </p>
+              <ul className="space-y-2 ml-6 list-disc text-sm leading-relaxed text-muted-foreground">
+                <li>{t("organizer.coHosts.limit1")}</li>
+                <li>{t("organizer.coHosts.limit2")}</li>
+                <li>{t("organizer.coHosts.limit3")}</li>
+              </ul>
+              <p className="text-sm leading-relaxed text-muted-foreground">
+                {t.rich("organizer.coHosts.howTo", rich)}
+              </p>
+              <p className="text-sm leading-relaxed text-muted-foreground">
+                {t("organizer.coHosts.demote")}
               </p>
             </div>
 

--- a/src/app/[locale]/(routes)/circles/[slug]/page.tsx
+++ b/src/app/[locale]/(routes)/circles/[slug]/page.tsx
@@ -272,39 +272,37 @@ export default async function PublicCirclePage({
             </p>
           )}
 
-          {/* Hosts */}
-          {hosts.length > 0 && (
-            <div className="space-y-2 px-1">
-              <p className="text-muted-foreground text-xs font-semibold uppercase tracking-wider">
-                {t("detail.hosts")}
-              </p>
-              <div className="flex flex-wrap items-center gap-1.5">
-                {hosts.slice(0, 5).map((host) => (
-                  <div
-                    key={host.id}
-                    className="flex size-8 shrink-0 items-center justify-center rounded-full text-xs font-semibold text-white"
-                    style={{ background: getMomentGradient(host.user.email) }}
-                    title={host.user.firstName ?? host.user.email}
-                  >
-                    {getCircleUserInitials(host.user)}
-                  </div>
-                ))}
-                {hosts.length > 5 && (
-                  <span className="text-muted-foreground text-xs">
-                    +{hosts.length - 5}
-                  </span>
-                )}
+          {/* Hosts — affiche uniquement le HOST principal (les CO_HOST figurent dans la liste des membres avec leur badge) */}
+          {(() => {
+            const primaryHosts = hosts.filter((h) => h.role === "HOST");
+            return primaryHosts.length > 0 ? (
+              <div className="space-y-2 px-1">
+                <p className="text-muted-foreground text-xs font-semibold uppercase tracking-wider">
+                  {t("detail.hosts")}
+                </p>
+                <div className="flex flex-wrap items-center gap-1.5">
+                  {primaryHosts.map((host) => (
+                    <div
+                      key={host.id}
+                      className="flex size-8 shrink-0 items-center justify-center rounded-full text-xs font-semibold text-white"
+                      style={{ background: getMomentGradient(host.user.email) }}
+                      title={host.user.firstName ?? host.user.email}
+                    >
+                      {getCircleUserInitials(host.user)}
+                    </div>
+                  ))}
+                </div>
+                <p className="flex flex-wrap gap-x-1 text-sm font-medium leading-snug">
+                  {primaryHosts.map((h, i) => (
+                    <span key={h.user.id}>
+                      <HostLink user={h.user} linkDisabled={!isConnected} />
+                      {i < primaryHosts.length - 1 && ", "}
+                    </span>
+                  ))}
+                </p>
               </div>
-              <p className="flex flex-wrap gap-x-1 text-sm font-medium leading-snug">
-                {hosts.map((h, i) => (
-                  <span key={h.user.id}>
-                    <HostLink user={h.user} linkDisabled={!isConnected} />
-                    {i < hosts.length - 1 && ", "}
-                  </span>
-                ))}
-              </p>
-            </div>
-          )}
+            ) : null;
+          })()}
 
           {/* Stats */}
           <div className="flex gap-6 px-1">
@@ -384,19 +382,22 @@ export default async function PublicCirclePage({
         {/* ─── RIGHT column ─────────────────────────────────── */}
         <div className="order-1 flex min-w-0 flex-1 flex-col gap-5 lg:order-2">
 
-          {/* "Organisé par" + raccourci Organisateur */}
+          {/* "Organisé par" : affiche uniquement le HOST principal ; les CO_HOST sont visibles dans la liste des membres avec leur badge */}
           <div className="flex items-center justify-between gap-4">
-            {hosts.length > 0 && (
-              <p className="text-muted-foreground flex flex-wrap items-center gap-x-1 gap-y-1 text-sm">
-                {t("detail.hostedBy")}
-                {hosts.map((h, i) => (
-                  <span key={h.user.id} className="flex items-center gap-1">
-                    <HostLink user={h.user} className="text-foreground font-medium" linkDisabled={!isConnected} />
-                    {i < hosts.length - 1 && <span>,</span>}
-                  </span>
-                ))}
-              </p>
-            )}
+            {(() => {
+              const primaryHosts = hosts.filter((h) => h.role === "HOST");
+              return primaryHosts.length > 0 ? (
+                <p className="text-muted-foreground flex flex-wrap items-center gap-x-1 gap-y-1 text-sm">
+                  {t("detail.hostedBy")}
+                  {primaryHosts.map((h, i) => (
+                    <span key={h.user.id} className="flex items-center gap-1">
+                      <HostLink user={h.user} className="text-foreground font-medium" linkDisabled={!isConnected} />
+                      {i < primaryHosts.length - 1 && <span>,</span>}
+                    </span>
+                  ))}
+                </p>
+              ) : null;
+            })()}
             {isOrganizer && (
               <Button asChild variant="ghost" size="sm" className="shrink-0 gap-1.5">
                 <Link href={`/dashboard/circles/${circle.slug}`}>

--- a/src/app/[locale]/(routes)/circles/[slug]/page.tsx
+++ b/src/app/[locale]/(routes)/circles/[slug]/page.tsx
@@ -153,15 +153,15 @@ export default async function PublicCirclePage({
 
   const isMember = isMemberResult === "ACTIVE";
   const isPendingMember = isMemberResult === "PENDING";
-  const isHost = session?.user?.id
+  const isOrganizer = session?.user?.id
     ? hosts.some((h) => h.user.id === session.user!.id)
     : false;
   const isConnected = !!session?.user?.id;
   // Membres visibles : connecté + (circle public OU membre/organisateur)
-  const canSeeMembers = isConnected && (circle.visibility === "PUBLIC" || isMember || isHost);
+  const canSeeMembers = isConnected && (circle.visibility === "PUBLIC" || isMember || isOrganizer);
   const showJoinButton = isConnected && !isMember && !isPendingMember;
   const showSignInToJoin = !isConnected;
-  const showMemberBadge = isMember && !isHost;
+  const showMemberBadge = isMember && !isOrganizer;
 
   const upcomingMoments = allMoments.filter((m) => m.status === "PUBLISHED");
   const pastMoments = allMoments.filter(
@@ -325,10 +325,10 @@ export default async function PublicCirclePage({
           </div>
 
           {/* Badge Organisateur — visible pour les Organisateurs */}
-          {isHost && (
+          {isOrganizer && (
             <div className="flex w-full items-center justify-center gap-2 rounded-full border border-primary/40 bg-primary/5 px-4 py-2.5 text-sm font-medium text-primary">
               <Crown className="size-4 shrink-0" aria-hidden="true" />
-              {t("detail.isHost")}
+              {t("detail.isOrganizer")}
             </div>
           )}
 
@@ -397,7 +397,7 @@ export default async function PublicCirclePage({
                 ))}
               </p>
             )}
-            {isHost && (
+            {isOrganizer && (
               <Button asChild variant="ghost" size="sm" className="shrink-0 gap-1.5">
                 <Link href={`/dashboard/circles/${circle.slug}`}>
                   <ExternalLink className="size-3.5" />
@@ -581,7 +581,7 @@ export default async function PublicCirclePage({
                       circleSlug={circle.slug}
                       registrationCount={countByMomentId.get(moment.id) ?? 0}
                       userRegistrationStatus={null}
-                      isHost={false}
+                      isOrganizer={false}
                       isLast={i === upcomingMoments.length - 1}
                       variant="public"
                       topAttendees={(topAttendeesByMomentId.get(moment.id) ?? []).map((r) => ({ user: { firstName: r.user.firstName, lastName: r.user.lastName, email: r.user.email, image: r.user.image } }))}
@@ -606,7 +606,7 @@ export default async function PublicCirclePage({
                       circleSlug={circle.slug}
                       registrationCount={countByMomentId.get(moment.id) ?? 0}
                       userRegistrationStatus={null}
-                      isHost={false}
+                      isOrganizer={false}
                       isLast={i === pastMoments.length - 1}
                       variant="public"
                       topAttendees={(topAttendeesByMomentId.get(moment.id) ?? []).map((r) => ({ user: { firstName: r.user.firstName, lastName: r.user.lastName, email: r.user.email, image: r.user.image } }))}

--- a/src/app/[locale]/(routes)/circles/[slug]/page.tsx
+++ b/src/app/[locale]/(routes)/circles/[slug]/page.tsx
@@ -131,7 +131,7 @@ export default async function PublicCirclePage({
     Promise<import("@/domain/models/circle").MembershipStatus | null>,
     ReturnType<typeof prismaCircleRepository.findMembersByRole>,
   ] = [
-    prismaCircleRepository.findMembersByRole(circle.id, "HOST"),
+    prismaCircleRepository.findOrganizers(circle.id),
     // Le Circle est déjà chargé — skipCircleCheck évite un findById redondant
     getCircleMoments(
       circle.id,

--- a/src/app/[locale]/(routes)/dashboard/(app)/(main)/_components/dashboard-content.tsx
+++ b/src/app/[locale]/(routes)/dashboard/(app)/(main)/_components/dashboard-content.tsx
@@ -111,7 +111,7 @@ export async function DashboardContent({
                   key={item.data.id}
                   variant="participant"
                   registration={item.data}
-                  isHost={hostCircleSlugs.has(item.data.moment.circleSlug)}
+                  isOrganizer={hostCircleSlugs.has(item.data.moment.circleSlug)}
                   isLast={i === filteredUpcoming.length - 1 && filteredPast.length === 0}
                 />
               ) : (
@@ -153,7 +153,7 @@ export async function DashboardContent({
                     key={item.data.id}
                     variant="participant"
                     registration={item.data}
-                    isHost={hostCircleSlugs.has(item.data.moment.circleSlug)}
+                    isOrganizer={hostCircleSlugs.has(item.data.moment.circleSlug)}
                     isLast={i === filteredPast.length - 1}
                     isPast
                   />

--- a/src/app/[locale]/(routes)/dashboard/(app)/(main)/_components/dashboard-filter-bar.tsx
+++ b/src/app/[locale]/(routes)/dashboard/(app)/(main)/_components/dashboard-filter-bar.tsx
@@ -11,9 +11,9 @@ export async function DashboardFilterBar({
   userId: string;
 }) {
   const circles = await getCachedDashboardCircles(userId);
-  const isHost = circles.some((c) => c.memberRole === "HOST");
+  const isOrganizer = circles.some((c) => c.memberRole === "HOST");
 
-  if (!isHost) return null;
+  if (!isOrganizer) return null;
 
   return <HostOnlyFilter active={hostOnly} activeTab={activeTab} />;
 }

--- a/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/edit/page.tsx
+++ b/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/edit/page.tsx
@@ -39,10 +39,10 @@ export default async function EditCirclePage({
   const membership = session?.user?.id
     ? await circleRepo.findMembership(circle.id, session.user.id)
     : null;
-  const isHost = membership?.role === "HOST";
+  const isOrganizer = membership?.role === "HOST";
 
   let stripeConnect;
-  if (isHost) {
+  if (isOrganizer) {
     // Default: no account (shows "Activer les paiements" button)
     let hasAccount = false;
     let status = null as import("@/domain/ports/services/payment-service").ConnectAccountStatus | null;

--- a/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/moments/[momentSlug]/page.tsx
+++ b/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/moments/[momentSlug]/page.tsx
@@ -53,7 +53,7 @@ export default async function MomentDetailPage({
   const hasActiveRegistration = userRegistration && userRegistration.status !== "CANCELLED" && userRegistration.status !== "REJECTED";
   if (!hasActiveMembership && !hasActiveRegistration) notFound();
 
-  const isHost = hasActiveMembership && membership!.role === "HOST";
+  const isOrganizer = hasActiveMembership && membership!.role === "HOST";
 
   const [allAttendees, comments, pendingRegistrations, attachments] = await Promise.all([
     prismaRegistrationRepository.findActiveWithUserByMomentId(moment.id),
@@ -61,7 +61,7 @@ export default async function MomentDetailPage({
       { momentId: moment.id },
       { commentRepository: prismaCommentRepository }
     ),
-    isHost ? prismaRegistrationRepository.findPendingApprovals(moment.id) : Promise.resolve([]),
+    isOrganizer ? prismaRegistrationRepository.findPendingApprovals(moment.id) : Promise.resolve([]),
     prismaMomentAttachmentRepository.findByMoment(moment.id),
   ]);
   const registeredCount = allAttendees.filter(
@@ -73,7 +73,7 @@ export default async function MomentDetailPage({
 
   const publicUrl = `${process.env.NEXT_PUBLIC_APP_URL ?? ""}/m/${moment.slug}`;
 
-  if (!isHost) {
+  if (!isOrganizer) {
     const [existingRegistration, upcomingCircleMoments] = await Promise.all([
       prismaRegistrationRepository.findByMomentAndUser(moment.id, session.user.id),
       prismaMomentRepository.findUpcomingByCircleId(moment.circleId, moment.id, 3),
@@ -100,7 +100,7 @@ export default async function MomentDetailPage({
         attachments={attachments}
         currentUserId={session.user.id}
         isAuthenticated={true}
-        isHost={false}
+        isOrganizer={false}
         existingRegistration={existingRegistration}
         signInUrl=""
         isFull={moment.capacity !== null && registeredCount >= moment.capacity}

--- a/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/moments/[momentSlug]/page.tsx
+++ b/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/moments/[momentSlug]/page.tsx
@@ -44,7 +44,7 @@ export default async function MomentDetailPage({
   // Parallélise membership + hosts + registration (indépendants)
   const [membership, hosts, userRegistration] = await Promise.all([
     circleRepo.findMembership(circle.id, session.user.id),
-    prismaCircleRepository.findMembersByRole(circle.id, "HOST"),
+    prismaCircleRepository.findOrganizers(circle.id),
     prismaRegistrationRepository.findByMomentAndUser(moment.id, session.user.id),
   ]);
 

--- a/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/moments/[momentSlug]/page.tsx
+++ b/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/moments/[momentSlug]/page.tsx
@@ -53,7 +53,9 @@ export default async function MomentDetailPage({
   const hasActiveRegistration = userRegistration && userRegistration.status !== "CANCELLED" && userRegistration.status !== "REJECTED";
   if (!hasActiveMembership && !hasActiveRegistration) notFound();
 
-  const isOrganizer = hasActiveMembership && membership!.role === "HOST";
+  const isOrganizer =
+    hasActiveMembership &&
+    (membership!.role === "HOST" || membership!.role === "CO_HOST");
 
   const [allAttendees, comments, pendingRegistrations, attachments] = await Promise.all([
     prismaRegistrationRepository.findActiveWithUserByMomentId(moment.id),

--- a/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/page.tsx
+++ b/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/page.tsx
@@ -78,7 +78,8 @@ export default async function CircleDetailPage({
   const membership = await circleRepo.findMembership(circle.id, session.user.id);
   if (!membership) notFound();
 
-  const isOrganizer = membership.role === "HOST";
+  const isOrganizer = membership.role === "HOST" || membership.role === "CO_HOST";
+  const callerRole = membership.role;
 
 
   const [hosts, players, allMoments, pendingMemberships, circleNetworks] = await Promise.all([
@@ -543,7 +544,13 @@ export default async function CircleDetailPage({
 
           {/* Membres */}
           <div id="members-section" className="border-border bg-card rounded-2xl border p-6">
-            <CircleMembersList hosts={hosts} players={players} variant={isOrganizer ? "host" : "player"} circleId={circle.id} />
+            <CircleMembersList
+              hosts={hosts}
+              players={players}
+              variant={isOrganizer ? "host" : "player"}
+              callerRole={callerRole}
+              circleId={circle.id}
+            />
           </div>
         </div>
       </div>

--- a/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/page.tsx
+++ b/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/page.tsx
@@ -274,7 +274,9 @@ export default async function CircleDetailPage({
                     {tCommon("edit")}
                   </Link>
                 </Button>
-                <DeleteCircleDialog circleId={circle.id} />
+                {membership.role === "HOST" && (
+                  <DeleteCircleDialog circleId={circle.id} />
+                )}
               </div>
             )}
           </div>

--- a/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/page.tsx
+++ b/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/page.tsx
@@ -78,7 +78,7 @@ export default async function CircleDetailPage({
   const membership = await circleRepo.findMembership(circle.id, session.user.id);
   if (!membership) notFound();
 
-  const isHost = membership.role === "HOST";
+  const isOrganizer = membership.role === "HOST";
 
 
   const [hosts, players, allMoments, pendingMemberships, circleNetworks] = await Promise.all([
@@ -90,12 +90,12 @@ export default async function CircleDetailPage({
       { momentRepository: prismaMomentRepository, circleRepository: prismaCircleRepository },
       { skipCircleCheck: true }
     ),
-    isHost ? prismaCircleRepository.findPendingMemberships(circle.id) : Promise.resolve([]),
+    isOrganizer ? prismaCircleRepository.findPendingMemberships(circle.id) : Promise.resolve([]),
     prismaCircleNetworkRepository.findNetworksByCircleId(circle.id),
   ]);
 
   const totalMembers = hosts.length + players.length;
-  const upcomingMoments = allMoments.filter((m) => m.status === "PUBLISHED" || (m.status === "DRAFT" && isHost));
+  const upcomingMoments = allMoments.filter((m) => m.status === "PUBLISHED" || (m.status === "DRAFT" && isOrganizer));
   const pastMoments = allMoments.filter((m) => m.status === "PAST" || m.status === "CANCELLED");
 
   // Récupère compteurs + inscriptions utilisateur pour TOUS les moments (upcoming + past)
@@ -128,10 +128,10 @@ export default async function CircleDetailPage({
           {circle.name}
         </span>
         <Badge
-          variant={isHost ? "outline" : "secondary"}
-          className={isHost ? "border-primary/40 text-primary" : ""}
+          variant={isOrganizer ? "outline" : "secondary"}
+          className={isOrganizer ? "border-primary/40 text-primary" : ""}
         >
-          {isHost ? tDashboard("role.host") : tDashboard("role.player")}
+          {isOrganizer ? tDashboard("role.host") : tDashboard("role.player")}
         </Badge>
       </div>
 
@@ -243,7 +243,7 @@ export default async function CircleDetailPage({
           </div>
 
           {/* Quitter la Communauté — Participant uniquement */}
-          {!isHost && (
+          {!isOrganizer && (
             <div className="px-1">
               <LeaveCircleDialog circleId={circle.id} circleName={circle.name} />
             </div>
@@ -266,7 +266,7 @@ export default async function CircleDetailPage({
                 ))}
               </p>
             )}
-            {isHost && (
+            {isOrganizer && (
               <div className="flex shrink-0 gap-2">
                 <Button asChild size="sm">
                   <Link href={`/dashboard/circles/${circle.slug}/edit`}>
@@ -434,7 +434,7 @@ export default async function CircleDetailPage({
           </div>
 
           {/* Partager & Inviter — visible Organisateurs uniquement */}
-          {isHost && (
+          {isOrganizer && (
             <>
             <div className="border-border border-t" />
             <CircleShareInviteCard
@@ -465,7 +465,7 @@ export default async function CircleDetailPage({
             upcomingLabel={t("detail.upcomingMoments")}
             pastLabel={t("detail.pastMoments")}
             upcomingAction={
-              isHost ? (
+              isOrganizer ? (
                 <Button asChild size="sm" className="w-full md:w-auto">
                   <Link href={`/dashboard/circles/${circle.slug}/moments/new`}>
                     {tMoment("create.title")}
@@ -489,7 +489,7 @@ export default async function CircleDetailPage({
                       circleSlug={circle.slug}
                       registrationCount={countByMomentId.get(moment.id) ?? 0}
                       userRegistrationStatus={userStatusByMomentId.get(moment.id) ?? null}
-                      isHost={isHost}
+                      isOrganizer={isOrganizer}
                       isLast={i === upcomingMoments.length - 1}
                     />
                   ))}
@@ -512,7 +512,7 @@ export default async function CircleDetailPage({
                       circleSlug={circle.slug}
                       registrationCount={countByMomentId.get(moment.id) ?? 0}
                       userRegistrationStatus={userStatusByMomentId.get(moment.id) ?? null}
-                      isHost={isHost}
+                      isOrganizer={isOrganizer}
                       isLast={i === pastMoments.length - 1}
                     />
                   ))}
@@ -525,7 +525,7 @@ export default async function CircleDetailPage({
           <div className="border-border border-t" />
 
           {/* Demandes en attente — visible Organisateurs uniquement si requiresApproval */}
-          {isHost && circle.requiresApproval && (
+          {isOrganizer && circle.requiresApproval && (
             <div className="border-border bg-card rounded-2xl border p-6">
               {pendingMemberships.length > 0 ? (
                 <PendingMembershipsList
@@ -543,7 +543,7 @@ export default async function CircleDetailPage({
 
           {/* Membres */}
           <div id="members-section" className="border-border bg-card rounded-2xl border p-6">
-            <CircleMembersList hosts={hosts} players={players} variant={isHost ? "host" : "player"} circleId={circle.id} />
+            <CircleMembersList hosts={hosts} players={players} variant={isOrganizer ? "host" : "player"} circleId={circle.id} />
           </div>
         </div>
       </div>

--- a/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/page.tsx
+++ b/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/page.tsx
@@ -82,7 +82,7 @@ export default async function CircleDetailPage({
 
 
   const [hosts, players, allMoments, pendingMemberships, circleNetworks] = await Promise.all([
-    prismaCircleRepository.findMembersByRole(circle.id, "HOST"),
+    prismaCircleRepository.findOrganizers(circle.id),
     prismaCircleRepository.findMembersByRole(circle.id, "PLAYER"),
     // Le Circle est déjà chargé — skipCircleCheck évite un findById redondant
     getCircleMoments(

--- a/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/page.tsx
+++ b/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/page.tsx
@@ -191,14 +191,16 @@ export default async function CircleDetailPage({
             </p>
           )}
 
-          {/* Hosts bloc */}
-          {hosts.length > 0 && (
+          {/* Hosts bloc — affiche uniquement le HOST principal (les CO_HOST figurent dans la liste des membres) */}
+          {(() => {
+            const primaryHosts = hosts.filter((h) => h.role === "HOST");
+            return primaryHosts.length > 0 ? (
             <div className="space-y-2 px-1">
               <p className="text-muted-foreground text-xs font-semibold uppercase tracking-wider">
                 {t("detail.hosts")}
               </p>
               <div className="flex flex-wrap items-center gap-1.5">
-                {hosts.slice(0, 5).map((host) => (
+                {primaryHosts.map((host) => (
                   <div
                     key={host.id}
                     className="flex size-8 shrink-0 items-center justify-center rounded-full text-xs font-semibold text-white"
@@ -208,22 +210,18 @@ export default async function CircleDetailPage({
                     {getCircleUserInitials(host.user)}
                   </div>
                 ))}
-                {hosts.length > 5 && (
-                  <span className="text-muted-foreground text-xs">
-                    +{hosts.length - 5}
-                  </span>
-                )}
               </div>
               <p className="flex flex-wrap gap-x-1 text-sm font-medium leading-snug">
-                {hosts.map((h, i) => (
+                {primaryHosts.map((h, i) => (
                   <span key={h.user.id}>
                     <HostLink user={h.user} />
-                    {i < hosts.length - 1 && ", "}
+                    {i < primaryHosts.length - 1 && ", "}
                   </span>
                 ))}
               </p>
             </div>
-          )}
+            ) : null;
+          })()}
 
           {/* Stats */}
           <div className="flex gap-6 px-1">
@@ -254,19 +252,22 @@ export default async function CircleDetailPage({
         {/* ─── RIGHT column ─────────────────────────────────── */}
         <div className="order-1 flex min-w-0 flex-1 flex-col gap-5 lg:order-2">
 
-          {/* "Organisé par" + actions Host */}
+          {/* "Organisé par" : affiche uniquement le HOST principal ; les CO_HOST sont visibles dans la liste des membres */}
           <div className="flex items-center justify-between gap-4">
-            {hosts.length > 0 && (
-              <p className="text-muted-foreground flex flex-wrap items-center gap-x-1 gap-y-1 text-sm">
-                {t("detail.hostedBy")}
-                {hosts.map((h, i) => (
-                  <span key={h.user.id} className="flex items-center gap-1">
-                    <HostLink user={h.user} className="text-foreground font-medium" />
-                    {i < hosts.length - 1 && <span>,</span>}
-                  </span>
-                ))}
-              </p>
-            )}
+            {(() => {
+              const primaryHosts = hosts.filter((h) => h.role === "HOST");
+              return primaryHosts.length > 0 ? (
+                <p className="text-muted-foreground flex flex-wrap items-center gap-x-1 gap-y-1 text-sm">
+                  {t("detail.hostedBy")}
+                  {primaryHosts.map((h, i) => (
+                    <span key={h.user.id} className="flex items-center gap-1">
+                      <HostLink user={h.user} className="text-foreground font-medium" />
+                      {i < primaryHosts.length - 1 && <span>,</span>}
+                    </span>
+                  ))}
+                </p>
+              ) : null;
+            })()}
             {isOrganizer && (
               <div className="flex shrink-0 gap-2">
                 <Button asChild size="sm">

--- a/src/app/[locale]/(routes)/m/[slug]/page.tsx
+++ b/src/app/[locale]/(routes)/m/[slug]/page.tsx
@@ -120,7 +120,7 @@ export default async function PublicMomentPage({
     await measureTime("moment-page:data", () =>
       Promise.all([
         getCircle(moment.circleId),
-        prismaCircleRepository.findMembersByRole(moment.circleId, "HOST"),
+        prismaCircleRepository.findOrganizers(moment.circleId),
         isAuthenticated
           ? getUserRegistration(
               { momentId: moment.id, userId: session!.user!.id! },

--- a/src/app/[locale]/(routes)/m/[slug]/page.tsx
+++ b/src/app/[locale]/(routes)/m/[slug]/page.tsx
@@ -139,7 +139,7 @@ export default async function PublicMomentPage({
 
   if (!circle) notFound();
 
-  const isHost = isAuthenticated && hosts.some((h) => h.userId === session!.user!.id);
+  const isOrganizer = isAuthenticated && hosts.some((h) => h.userId === session!.user!.id);
 
   const registeredCount = allAttendees.filter((r) => r.status === "REGISTERED").length;
 
@@ -274,7 +274,7 @@ export default async function PublicMomentPage({
         attachments={attachments}
         currentUserId={session?.user?.id ?? null}
         isAuthenticated={isAuthenticated}
-        isHost={isHost}
+        isOrganizer={isOrganizer}
         existingRegistration={existingRegistration}
         signInUrl={signInUrl}
         isFull={isFull}

--- a/src/app/[locale]/(routes)/u/[publicId]/page.tsx
+++ b/src/app/[locale]/(routes)/u/[publicId]/page.tsx
@@ -7,6 +7,7 @@ import {
   prismaMomentRepository,
 } from "@/infrastructure/repositories";
 import { getUserPublicProfile } from "@/domain/usecases/get-user-public-profile";
+import { isOrganizerRole } from "@/domain/models/circle";
 import { Link } from "@/i18n/navigation";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
@@ -193,11 +194,11 @@ export default async function UserPublicProfilePage({
                 </p>
 
                 <Badge
-                  variant={membership.role === "HOST" ? "default" : "secondary"}
+                  variant={isOrganizerRole(membership.role) ? "default" : "secondary"}
                   className="shrink-0 gap-1"
                 >
-                  {membership.role === "HOST" && <Crown className="size-3" />}
-                  {membership.role === "HOST" ? t("roleHost") : t("rolePlayer")}
+                  {isOrganizerRole(membership.role) && <Crown className="size-3" />}
+                  {isOrganizerRole(membership.role) ? t("roleHost") : t("rolePlayer")}
                 </Badge>
               </Link>
             ))}

--- a/src/app/actions/broadcast-moment.ts
+++ b/src/app/actions/broadcast-moment.ts
@@ -17,6 +17,7 @@ import {
 import { createResendEmailService } from "@/infrastructure/services";
 import type { ActionResult } from "./types";
 import { isAdminInHostMode } from "@/lib/admin-host-mode";
+import { isActiveOrganizer } from "@/domain/models/circle";
 
 const emailService = createResendEmailService();
 
@@ -56,10 +57,10 @@ export async function broadcastMomentAction(
       moment.circleId,
       session.user.id
     );
-    if (!membership || membership.role !== "HOST") {
+    if (!isActiveOrganizer(membership)) {
       return {
         success: false,
-        error: "Seul l'organisateur peut diffuser",
+        error: "Seul un organisateur peut diffuser",
         code: "FORBIDDEN",
       };
     }

--- a/src/app/actions/circle.ts
+++ b/src/app/actions/circle.ts
@@ -525,7 +525,7 @@ async function notifyHostCircleJoin(
 
   if (pendingApproval) {
     // Demande d'adhésion en attente → notifier les HOSTs
-    const hosts = await prismaCircleRepository.findMembersByRole(circleId, "HOST");
+    const hosts = await prismaCircleRepository.findOrganizers(circleId);
     const hostUserIds = hosts.map((h) => h.userId);
     const prefsMap = await prismaUserRepository.findNotificationPreferencesByIds(hostUserIds);
 

--- a/src/app/actions/circle.ts
+++ b/src/app/actions/circle.ts
@@ -19,6 +19,8 @@ import { leaveCircle } from "@/domain/usecases/leave-circle";
 import { removeCircleMember } from "@/domain/usecases/remove-circle-member";
 import { approveCircleMembership } from "@/domain/usecases/approve-circle-membership";
 import { rejectCircleMembership } from "@/domain/usecases/reject-circle-membership";
+import { promoteToCoHost } from "@/domain/usecases/promote-to-co-host";
+import { demoteFromCoHost } from "@/domain/usecases/demote-from-co-host";
 import { prismaRegistrationRepository, prismaUserRepository } from "@/infrastructure/repositories";
 import type { CircleVisibility, CircleCategory, CircleMembership } from "@/domain/models/circle";
 import type { Circle } from "@/domain/models/circle";
@@ -568,5 +570,88 @@ async function notifyHostCircleJoin(
       }
     );
   }
+}
+
+export async function promoteToCoHostAction(
+  circleId: string,
+  targetUserId: string
+): Promise<ActionResult> {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return { success: false, error: "Not authenticated", code: "UNAUTHORIZED" };
+  }
+
+  const hostUserId = session.user.id;
+
+  return toActionResult(async () => {
+    const t = await getTranslations("Email.coHostPromoted");
+    await promoteToCoHost(
+      { circleId, hostUserId, targetUserId },
+      {
+        circleRepository: prismaCircleRepository,
+        userRepository: prismaUserRepository,
+        emailService,
+        emailStrings: {
+          promotedBy: async (inviterName: string) => ({
+            subject: t("subject", { inviterName }),
+            heading: t("heading"),
+            intro: t("intro", { inviterName }),
+            rightsTitle: t("rightsTitle"),
+            rightCreateEvents: t("rightCreateEvents"),
+            rightManageRegistrations: t("rightManageRegistrations"),
+            rightUpdateCircle: t("rightUpdateCircle"),
+            rightBroadcast: t("rightBroadcast"),
+            rightReceiveNotifications: t("rightReceiveNotifications"),
+            limitsNote: t("limitsNote"),
+            ctaLabel: t("ctaLabel"),
+            footer: t("footer"),
+            leaveLink: t("leaveLink"),
+          }),
+        },
+      }
+    );
+
+    invalidateDashboardCache(hostUserId);
+    invalidateDashboardCache(targetUserId);
+  });
+}
+
+export async function demoteFromCoHostAction(
+  circleId: string,
+  targetUserId: string
+): Promise<ActionResult> {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return { success: false, error: "Not authenticated", code: "UNAUTHORIZED" };
+  }
+
+  const hostUserId = session.user.id;
+
+  return toActionResult(async () => {
+    const t = await getTranslations("Email.coHostDemoted");
+    await demoteFromCoHost(
+      { circleId, hostUserId, targetUserId },
+      {
+        circleRepository: prismaCircleRepository,
+        userRepository: prismaUserRepository,
+        emailService,
+        emailStrings: {
+          demoted: async () => ({
+            subject: t("subject"),
+            heading: t("heading"),
+            intro: t("intro"),
+            newRoleLabel: t("newRoleLabel"),
+            registrationsNote: t("registrationsNote"),
+            ctaLabel: t("ctaLabel"),
+            footer: t("footer"),
+            preferencesLink: t("preferencesLink"),
+          }),
+        },
+      }
+    );
+
+    invalidateDashboardCache(hostUserId);
+    invalidateDashboardCache(targetUserId);
+  });
 }
 

--- a/src/app/actions/circle.ts
+++ b/src/app/actions/circle.ts
@@ -592,9 +592,9 @@ export async function promoteToCoHostAction(
         userRepository: prismaUserRepository,
         emailService,
         emailStrings: {
-          promotedBy: async (inviterName: string) => ({
-            subject: t("subject", { inviterName }),
-            heading: t("heading"),
+          promotedBy: async ({ inviterName, circleName }) => ({
+            subject: t("subject", { circleName }),
+            heading: t("heading", { circleName }),
             intro: t("intro", { inviterName }),
             rightsTitle: t("rightsTitle"),
             rightCreateEvents: t("rightCreateEvents"),
@@ -636,10 +636,10 @@ export async function demoteFromCoHostAction(
         userRepository: prismaUserRepository,
         emailService,
         emailStrings: {
-          demoted: async () => ({
-            subject: t("subject"),
-            heading: t("heading"),
-            intro: t("intro"),
+          demoted: async ({ circleName }) => ({
+            subject: t("subject", { circleName }),
+            heading: t("heading", { circleName }),
+            intro: t("intro", { circleName }),
             newRoleLabel: t("newRoleLabel"),
             registrationsNote: t("registrationsNote"),
             ctaLabel: t("ctaLabel"),

--- a/src/app/actions/circle.ts
+++ b/src/app/actions/circle.ts
@@ -22,6 +22,7 @@ import { rejectCircleMembership } from "@/domain/usecases/reject-circle-membersh
 import { prismaRegistrationRepository, prismaUserRepository } from "@/infrastructure/repositories";
 import type { CircleVisibility, CircleCategory, CircleMembership } from "@/domain/models/circle";
 import type { Circle } from "@/domain/models/circle";
+import { isActiveOrganizer } from "@/domain/models/circle";
 import type { ActionResult } from "./types";
 import { toActionResult } from "./helpers/to-action-result";
 import { processCoverImage } from "./cover-image";
@@ -362,8 +363,8 @@ export async function inviteToCircleByEmailAction(
   const circleRepo = await resolveCircleRepository(session, prismaCircleRepository);
 
   const membership = await circleRepo.findMembership(circleId, userId);
-  if (!membership || membership.role !== "HOST") {
-    return { success: false, error: "Only hosts can send invitations", code: "UNAUTHORIZED" };
+  if (!isActiveOrganizer(membership)) {
+    return { success: false, error: "Only organizers can send invitations", code: "UNAUTHORIZED" };
   }
 
   const circle = await circleRepo.findById(circleId);

--- a/src/app/actions/comment.ts
+++ b/src/app/actions/comment.ts
@@ -187,7 +187,7 @@ async function sendCommentNotifications(
   // Récupère inscrits actifs et hosts en parallèle
   const [registrations, hosts] = await Promise.all([
     prismaRegistrationRepository.findActiveWithUserByMomentId(momentId),
-    prismaCircleRepository.findMembersByRole(moment.circleId, "HOST"),
+    prismaCircleRepository.findOrganizers(moment.circleId),
   ]);
 
   // Combine inscrits + hosts, déduplique par userId

--- a/src/app/actions/moment.ts
+++ b/src/app/actions/moment.ts
@@ -321,7 +321,7 @@ async function sendMomentUpdateEmails(
   const [circle, registrations, hosts] = await Promise.all([
     prismaCircleRepository.findById(moment.circleId),
     prismaRegistrationRepository.findActiveWithUserByMomentId(moment.id),
-    prismaCircleRepository.findMembersByRole(moment.circleId, "HOST"),
+    prismaCircleRepository.findOrganizers(moment.circleId),
   ]);
   if (!circle) return;
 

--- a/src/app/actions/moment.ts
+++ b/src/app/actions/moment.ts
@@ -24,6 +24,7 @@ import { deleteMoment } from "@/domain/usecases/delete-moment";
 import { publishMoment } from "@/domain/usecases/publish-moment";
 import type { LocationType, Moment } from "@/domain/models/moment";
 import type { RegistrationWithUser } from "@/domain/models/registration";
+import { isActiveOrganizer } from "@/domain/models/circle";
 import type { ActionResult } from "./types";
 import { toActionResult } from "./helpers/to-action-result";
 import { partitionMomentUpdateRecipients } from "./helpers/moment-update-recipients";
@@ -444,10 +445,10 @@ export async function deleteMomentAction(
     }
 
     // Skip notifications only when admin moderates someone else's event.
-    const isHostOfEvent = momentToDelete
-      ? (await prismaCircleRepository.findMembership(momentToDelete.circleId, userId))?.role === "HOST"
+    const isOrganizerOfEvent = momentToDelete
+      ? isActiveOrganizer(await prismaCircleRepository.findMembership(momentToDelete.circleId, userId))
       : false;
-    const shouldNotify = momentToDelete && registrationsToNotify.length > 0 && (!isAdminUser(session) || isHostOfEvent);
+    const shouldNotify = momentToDelete && registrationsToNotify.length > 0 && (!isAdminUser(session) || isOrganizerOfEvent);
     if (shouldNotify) {
       sendMomentCancelledEmails(momentToDelete, registrationsToNotify).catch(
         (err) => Sentry.captureException(err)

--- a/src/app/actions/notify-host-new-circle-member.ts
+++ b/src/app/actions/notify-host-new-circle-member.ts
@@ -21,7 +21,7 @@ export async function notifyHostNewCircleMember(
   }
 ): Promise<void> {
   const [hosts, memberCount] = await Promise.all([
-    prismaCircleRepository.findMembersByRole(circleId, "HOST"),
+    prismaCircleRepository.findOrganizers(circleId),
     prismaCircleRepository.countMembers(circleId),
   ]);
 

--- a/src/app/actions/registration.ts
+++ b/src/app/actions/registration.ts
@@ -163,7 +163,7 @@ async function sendHostPaidCancellationEmail(
   const circle = await prismaCircleRepository.findById(moment.circleId);
   if (!circle) return;
 
-  const hosts = await prismaCircleRepository.findMembersByRole(circle.id, "HOST");
+  const hosts = await prismaCircleRepository.findOrganizers(circle.id);
   if (hosts.length === 0) return;
 
   const locale = await getLocale();
@@ -292,7 +292,7 @@ export async function sendRegistrationEmails(
 
   // Send notification to each Host of the Circle (skip if host = player)
   const [hosts, registeredCount] = await Promise.all([
-    prismaCircleRepository.findMembersByRole(moment.circleId, "HOST"),
+    prismaCircleRepository.findOrganizers(moment.circleId),
     prismaRegistrationRepository.countByMomentIdAndStatus(momentId, "REGISTERED"),
   ]);
 
@@ -604,7 +604,7 @@ async function notifyHostsPendingApproval(
 
   const [circle, hosts] = await Promise.all([
     prismaCircleRepository.findById(moment.circleId),
-    prismaCircleRepository.findMembersByRole(moment.circleId, "HOST"),
+    prismaCircleRepository.findOrganizers(moment.circleId),
   ]);
   if (!circle) return;
 

--- a/src/components/circles/circle-card.tsx
+++ b/src/components/circles/circle-card.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button";
 import { Globe, Lock, Users, ImageIcon, Crown, User } from "lucide-react";
 import { getMomentGradient } from "@/lib/gradient";
 import type { Circle, CircleMemberRole } from "@/domain/models/circle";
+import { isOrganizerRole } from "@/domain/models/circle";
 
 type CircleCardProps = {
   circle: Circle;
@@ -88,11 +89,13 @@ export function CircleCard({ circle, href, role, memberCount }: CircleCardProps)
       </Link>
 
       {/* Colonne droite : Organisateur uniquement */}
-      {role === "HOST" && (
+      {role && isOrganizerRole(role) && (
         <div className="flex shrink-0 flex-col items-end justify-center gap-2">
           <Badge variant="outline" className="gap-1 border-primary/40 text-primary">
             <Crown className="size-3" />
-            <span className="hidden sm:inline">{tDashboard("role.host")}</span>
+            <span className="hidden sm:inline">
+              {role === "HOST" ? tDashboard("role.owner") : tDashboard("role.host")}
+            </span>
           </Badge>
           <Button asChild size="sm" className="h-7 px-3 text-xs">
             <Link href={`/dashboard/circles/${circle.slug}/moments/new`}>

--- a/src/components/circles/circle-card.tsx
+++ b/src/components/circles/circle-card.tsx
@@ -93,9 +93,7 @@ export function CircleCard({ circle, href, role, memberCount }: CircleCardProps)
         <div className="flex shrink-0 flex-col items-end justify-center gap-2">
           <Badge variant="outline" className="gap-1 border-primary/40 text-primary">
             <Crown className="size-3" />
-            <span className="hidden sm:inline">
-              {role === "HOST" ? tDashboard("role.owner") : tDashboard("role.host")}
-            </span>
+            <span className="hidden sm:inline">{tDashboard("role.host")}</span>
           </Badge>
           <Button asChild size="sm" className="h-7 px-3 text-xs">
             <Link href={`/dashboard/circles/${circle.slug}/moments/new`}>

--- a/src/components/circles/circle-members-list.tsx
+++ b/src/components/circles/circle-members-list.tsx
@@ -202,13 +202,19 @@ function MemberRow({
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
               {canPromote && (
-                <DropdownMenuItem onSelect={handlePromote}>
+                <DropdownMenuItem
+                  className="focus:bg-muted focus:text-foreground"
+                  onSelect={handlePromote}
+                >
                   <Star className="size-4" />
                   {tCircle("promoteToCoHost.action")}
                 </DropdownMenuItem>
               )}
               {canDemote && (
-                <DropdownMenuItem onSelect={handleDemote}>
+                <DropdownMenuItem
+                  className="focus:bg-muted focus:text-foreground"
+                  onSelect={handleDemote}
+                >
                   <ChevronDown className="size-4" />
                   {tCircle("demoteFromCoHost.action")}
                 </DropdownMenuItem>
@@ -216,7 +222,7 @@ function MemberRow({
               {(canPromote || canDemote) && canRemove && <DropdownMenuSeparator />}
               {canRemove && (
                 <DropdownMenuItem
-                  className="text-destructive focus:text-destructive focus:bg-destructive/10"
+                  className="text-destructive focus:text-destructive focus:bg-muted"
                   onSelect={() => setRemoveDialogOpen(true)}
                 >
                   <Trash2 className="size-4" />
@@ -241,25 +247,16 @@ function MemberRow({
   );
 }
 
-function MemberBadge({
-  role,
-  isDashboardView,
-}: {
-  role: CircleMemberRole;
-  isDashboardView: boolean;
-}) {
+function MemberBadge({ role }: { role: CircleMemberRole; isDashboardView: boolean }) {
   const t = useTranslations("Dashboard");
 
   if (role === "PLAYER") return null;
 
-  // D8 + D23 : côté public, un seul badge "Organisateur" pour HOST et CO_HOST.
-  // Dans le dashboard de gestion, distinction "Propriétaire" (HOST) vs "Organisateur" (CO_HOST).
-  const label = isDashboardView && role === "HOST" ? t("role.owner") : t("role.host");
-
+  // Badge unique "Organisateur" pour HOST et CO_HOST, partout (dashboard + public).
   return (
     <Badge variant="outline" className="border-primary/40 text-primary shrink-0 gap-1">
       <Crown className="size-3" />
-      {label}
+      {t("role.host")}
     </Badge>
   );
 }

--- a/src/components/circles/circle-members-list.tsx
+++ b/src/components/circles/circle-members-list.tsx
@@ -1,21 +1,31 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
+import { toast } from "sonner";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { Crown, MoreVertical } from "lucide-react";
+import { Crown, MoreVertical, ChevronDown, Star, Trash2 } from "lucide-react";
 import { UserAvatar } from "@/components/user-avatar";
 import { RemoveMemberDialog } from "@/components/circles/remove-member-dialog";
 import { Link } from "@/i18n/navigation";
 import { getDisplayName } from "@/lib/display-name";
-import type { CircleMemberWithUser } from "@/domain/models/circle";
+import type {
+  CircleMemberRole,
+  CircleMemberWithUser,
+} from "@/domain/models/circle";
+import {
+  promoteToCoHostAction,
+  demoteFromCoHostAction,
+} from "@/app/actions/circle";
 
 const PAGE_SIZE = 10;
 
@@ -23,6 +33,8 @@ type CircleMembersListProps = {
   hosts: CircleMemberWithUser[];
   players: CircleMemberWithUser[];
   variant?: "host" | "player" | "member-view";
+  /** Rôle de l'utilisateur connecté dans ce Circle — déclenche l'affichage des actions de gestion. */
+  callerRole?: CircleMemberRole;
   circleId?: string;
 };
 
@@ -30,20 +42,20 @@ export function CircleMembersList({
   hosts,
   players,
   variant = "player",
+  callerRole,
   circleId,
 }: CircleMembersListProps) {
   const t = useTranslations("Circle");
   const tCommon = useTranslations("Common");
 
-  const allMembers = [
-    ...hosts.map((m) => ({ ...m, isOrganizer: true })),
-    ...players.map((m) => ({ ...m, isOrganizer: false })),
-  ];
+  const allMembers = [...hosts, ...players];
   const totalMembers = allMembers.length;
 
   const [showAll, setShowAll] = useState(false);
   const displayed = showAll ? allMembers : allMembers.slice(0, PAGE_SIZE);
   const hasMore = totalMembers > PAGE_SIZE;
+
+  const isDashboardOrganizer = variant === "host";
 
   return (
     <div className="space-y-4">
@@ -59,9 +71,9 @@ export function CircleMembersList({
           <MemberRow
             key={member.id}
             member={member}
-            isOrganizer={member.isOrganizer}
-            showEmail={variant === "host"}
-            canRemove={variant === "host" && !member.isOrganizer}
+            isDashboardOrganizer={isDashboardOrganizer}
+            callerRole={callerRole}
+            showEmail={isDashboardOrganizer}
             circleId={circleId}
           />
         ))}
@@ -81,25 +93,72 @@ export function CircleMembersList({
   );
 }
 
+type MemberRowProps = {
+  member: CircleMemberWithUser;
+  /** True quand on est dans le dashboard et que l'appelant peut potentiellement agir. */
+  isDashboardOrganizer: boolean;
+  callerRole: CircleMemberRole | undefined;
+  showEmail: boolean;
+  circleId: string | undefined;
+};
+
 function MemberRow({
   member,
-  isOrganizer = false,
-  showEmail = false,
-  canRemove = false,
+  isDashboardOrganizer,
+  callerRole,
+  showEmail,
   circleId,
-}: {
-  member: CircleMemberWithUser;
-  isOrganizer?: boolean;
-  showEmail?: boolean;
-  canRemove?: boolean;
-  circleId?: string;
-}) {
+}: MemberRowProps) {
   const t = useTranslations("Dashboard");
-  const tRemove = useTranslations("Circle.removeMember");
+  const tCircle = useTranslations("Circle");
   const { user } = member;
   const displayName = getDisplayName(user.firstName, user.lastName, user.email);
+  const router = useRouter();
 
-  const [dialogOpen, setDialogOpen] = useState(false);
+  const [removeDialogOpen, setRemoveDialogOpen] = useState(false);
+  const [isPending, startTransition] = useTransition();
+
+  // Matrice d'actions (D10, D11, D22)
+  const canPromote =
+    circleId !== undefined &&
+    callerRole === "HOST" &&
+    member.role === "PLAYER" &&
+    member.status === "ACTIVE";
+  const canDemote =
+    circleId !== undefined &&
+    callerRole === "HOST" &&
+    member.role === "CO_HOST";
+  const canRemove =
+    circleId !== undefined &&
+    ((callerRole === "HOST" && member.role !== "HOST") ||
+      (callerRole === "CO_HOST" && member.role === "PLAYER"));
+  const hasMenuActions = canPromote || canDemote || canRemove;
+
+  const handlePromote = () => {
+    if (!circleId) return;
+    startTransition(async () => {
+      const result = await promoteToCoHostAction(circleId, user.id);
+      if (result.success) {
+        toast.success(tCircle("promoteToCoHost.success", { name: displayName }));
+        router.refresh();
+      } else {
+        toast.error(tCircle("promoteToCoHost.error"));
+      }
+    });
+  };
+
+  const handleDemote = () => {
+    if (!circleId) return;
+    startTransition(async () => {
+      const result = await demoteFromCoHostAction(circleId, user.id);
+      if (result.success) {
+        toast.success(tCircle("demoteFromCoHost.success", { name: displayName }));
+        router.refresh();
+      } else {
+        toast.error(tCircle("demoteFromCoHost.error"));
+      }
+    });
+  };
 
   return (
     <>
@@ -125,31 +184,45 @@ function MemberRow({
             <p className="text-muted-foreground truncate text-xs">{user.email}</p>
           )}
         </div>
-        {isOrganizer && (
-          <Badge variant="outline" className="border-primary/40 text-primary shrink-0 gap-1">
-            <Crown className="size-3" />
-            {t("role.host")}
-          </Badge>
-        )}
-        {canRemove && circleId && (
+
+        <MemberBadge role={member.role} isDashboardView={isDashboardOrganizer} />
+
+        {hasMenuActions && circleId && (
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button
                 variant="ghost"
                 size="sm"
                 className="size-8 p-0 shrink-0"
-                aria-label={tRemove("action")}
+                aria-label={tCircle("memberActions.label")}
+                disabled={isPending}
               >
                 <MoreVertical className="size-4" />
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
-              <DropdownMenuItem
-                className="text-destructive focus:text-destructive focus:bg-destructive/10"
-                onSelect={() => setDialogOpen(true)}
-              >
-                {tRemove("action")}
-              </DropdownMenuItem>
+              {canPromote && (
+                <DropdownMenuItem onSelect={handlePromote}>
+                  <Star className="size-4" />
+                  {tCircle("promoteToCoHost.action")}
+                </DropdownMenuItem>
+              )}
+              {canDemote && (
+                <DropdownMenuItem onSelect={handleDemote}>
+                  <ChevronDown className="size-4" />
+                  {tCircle("demoteFromCoHost.action")}
+                </DropdownMenuItem>
+              )}
+              {(canPromote || canDemote) && canRemove && <DropdownMenuSeparator />}
+              {canRemove && (
+                <DropdownMenuItem
+                  className="text-destructive focus:text-destructive focus:bg-destructive/10"
+                  onSelect={() => setRemoveDialogOpen(true)}
+                >
+                  <Trash2 className="size-4" />
+                  {tCircle("removeMember.action")}
+                </DropdownMenuItem>
+              )}
             </DropdownMenuContent>
           </DropdownMenu>
         )}
@@ -160,10 +233,33 @@ function MemberRow({
           circleId={circleId}
           userId={user.id}
           memberName={displayName}
-          open={dialogOpen}
-          onOpenChange={setDialogOpen}
+          open={removeDialogOpen}
+          onOpenChange={setRemoveDialogOpen}
         />
       )}
     </>
+  );
+}
+
+function MemberBadge({
+  role,
+  isDashboardView,
+}: {
+  role: CircleMemberRole;
+  isDashboardView: boolean;
+}) {
+  const t = useTranslations("Dashboard");
+
+  if (role === "PLAYER") return null;
+
+  // D8 + D23 : côté public, un seul badge "Organisateur" pour HOST et CO_HOST.
+  // Dans le dashboard de gestion, distinction "Propriétaire" (HOST) vs "Organisateur" (CO_HOST).
+  const label = isDashboardView && role === "HOST" ? t("role.owner") : t("role.host");
+
+  return (
+    <Badge variant="outline" className="border-primary/40 text-primary shrink-0 gap-1">
+      <Crown className="size-3" />
+      {label}
+    </Badge>
   );
 }

--- a/src/components/circles/circle-members-list.tsx
+++ b/src/components/circles/circle-members-list.tsx
@@ -36,8 +36,8 @@ export function CircleMembersList({
   const tCommon = useTranslations("Common");
 
   const allMembers = [
-    ...hosts.map((m) => ({ ...m, isHost: true })),
-    ...players.map((m) => ({ ...m, isHost: false })),
+    ...hosts.map((m) => ({ ...m, isOrganizer: true })),
+    ...players.map((m) => ({ ...m, isOrganizer: false })),
   ];
   const totalMembers = allMembers.length;
 
@@ -59,9 +59,9 @@ export function CircleMembersList({
           <MemberRow
             key={member.id}
             member={member}
-            isHost={member.isHost}
+            isOrganizer={member.isOrganizer}
             showEmail={variant === "host"}
-            canRemove={variant === "host" && !member.isHost}
+            canRemove={variant === "host" && !member.isOrganizer}
             circleId={circleId}
           />
         ))}
@@ -83,13 +83,13 @@ export function CircleMembersList({
 
 function MemberRow({
   member,
-  isHost = false,
+  isOrganizer = false,
   showEmail = false,
   canRemove = false,
   circleId,
 }: {
   member: CircleMemberWithUser;
-  isHost?: boolean;
+  isOrganizer?: boolean;
   showEmail?: boolean;
   canRemove?: boolean;
   circleId?: string;
@@ -125,7 +125,7 @@ function MemberRow({
             <p className="text-muted-foreground truncate text-xs">{user.email}</p>
           )}
         </div>
-        {isHost && (
+        {isOrganizer && (
           <Badge variant="outline" className="border-primary/40 text-primary shrink-0 gap-1">
             <Crown className="size-3" />
             {t("role.host")}

--- a/src/components/circles/dashboard-circle-card.tsx
+++ b/src/components/circles/dashboard-circle-card.tsx
@@ -8,6 +8,7 @@ import { AttendeeAvatarStack } from "@/components/moments/attendee-avatar-stack"
 import { Badge } from "@/components/ui/badge";
 import { CategoryBadge } from "@/components/badges/category-badge";
 import type { DashboardCircle } from "@/domain/models/circle";
+import { isOrganizerRole } from "@/domain/models/circle";
 import { resolveCategoryLabel } from "@/lib/circle-category-helpers";
 
 type Props = {
@@ -96,8 +97,8 @@ export async function DashboardCircleCard({ circle }: Props) {
               <Badge variant="outline" className={`shrink-0 gap-1 text-xs ${circle.membershipStatus === "PENDING" ? "border-amber-500/40 text-amber-500" : "border-primary/40 text-primary"}`}>
                 {circle.membershipStatus === "PENDING"
                   ? <><Clock className="size-3" /><span className="hidden sm:inline">{t("circleCard.roleBadge.pending")}</span></>
-                  : circle.memberRole === "HOST"
-                    ? <><Crown className="size-3" /><span className="hidden sm:inline">{t("circleCard.roleBadge.host")}</span></>
+                  : isOrganizerRole(circle.memberRole)
+                    ? <><Crown className="size-3" /><span className="hidden sm:inline">{circle.memberRole === "HOST" ? t("circleCard.roleBadge.owner") : t("circleCard.roleBadge.host")}</span></>
                     : <><Users className="size-3" /><span className="hidden sm:inline">{t("circleCard.roleBadge.member")}</span></>}
               </Badge>
             </div>

--- a/src/components/circles/dashboard-circle-card.tsx
+++ b/src/components/circles/dashboard-circle-card.tsx
@@ -98,7 +98,7 @@ export async function DashboardCircleCard({ circle }: Props) {
                 {circle.membershipStatus === "PENDING"
                   ? <><Clock className="size-3" /><span className="hidden sm:inline">{t("circleCard.roleBadge.pending")}</span></>
                   : isOrganizerRole(circle.memberRole)
-                    ? <><Crown className="size-3" /><span className="hidden sm:inline">{circle.memberRole === "HOST" ? t("circleCard.roleBadge.owner") : t("circleCard.roleBadge.host")}</span></>
+                    ? <><Crown className="size-3" /><span className="hidden sm:inline">{t("circleCard.roleBadge.host")}</span></>
                     : <><Users className="size-3" /><span className="hidden sm:inline">{t("circleCard.roleBadge.member")}</span></>}
               </Badge>
             </div>

--- a/src/components/circles/moment-timeline-item.tsx
+++ b/src/components/circles/moment-timeline-item.tsx
@@ -16,7 +16,7 @@ type Props = {
   circleSlug: string;
   registrationCount: number;
   userRegistrationStatus: RegistrationStatus | null;
-  isHost: boolean;
+  isOrganizer: boolean;
   isLast: boolean;
   /** "dashboard" (défaut) → lien vers le dashboard Host.
    *  "public" → lien vers /m/[slug], sans badges de statut utilisateur. */
@@ -30,7 +30,7 @@ export async function MomentTimelineItem({
   circleSlug,
   registrationCount,
   userRegistrationStatus,
-  isHost,
+  isOrganizer,
   isLast,
   variant = "dashboard",
   topAttendees = [],
@@ -134,7 +134,7 @@ export async function MomentTimelineItem({
                     <>
                       {isDraft ? (
                         <DraftBadge label={t("status.draft")} />
-                      ) : isHost ? (
+                      ) : isOrganizer ? (
                         <Badge variant="outline" className="shrink-0 gap-1 border-primary/40 text-xs text-primary">
                           <Crown className="size-3" />
                           <span className="hidden sm:inline">{tDashboard("role.host")}</span>

--- a/src/components/moments/comment-thread.tsx
+++ b/src/components/moments/comment-thread.tsx
@@ -42,7 +42,7 @@ type CommentThreadProps = {
   momentId: string;
   comments: CommentWithUser[];
   currentUserId: string | null;
-  isHost: boolean;
+  isOrganizer: boolean;
   isPastMoment: boolean;
   signInUrl: string;
 };
@@ -177,7 +177,7 @@ export function CommentThread({
   momentId,
   comments,
   currentUserId,
-  isHost,
+  isOrganizer,
   isPastMoment,
   signInUrl,
 }: CommentThreadProps) {
@@ -307,7 +307,7 @@ export function CommentThread({
           <div className="space-y-4">
             {comments.map((comment) => {
               const canDelete =
-                currentUserId === comment.user.id || isHost;
+                currentUserId === comment.user.id || isOrganizer;
               return (
                 <div key={comment.id} className="flex gap-3">
                   {/* Avatar */}

--- a/src/components/moments/dashboard-moment-card.tsx
+++ b/src/components/moments/dashboard-moment-card.tsx
@@ -18,7 +18,7 @@ type ParticipantProps = {
   variant: "participant";
   registration: RegistrationWithMoment;
   isLast: boolean;
-  isHost?: boolean;
+  isOrganizer?: boolean;
   isPast?: boolean;
 };
 
@@ -37,13 +37,13 @@ export function DashboardMomentCard(props: DashboardMomentCardProps) {
   const tMoment = useTranslations("Moment");
   const locale = useLocale();
 
-  const isOrganizer = props.variant === "organizer";
+  const isOrganizerView = props.variant === "organizer";
   const isPast = props.isPast ?? false;
   const isLast = props.isLast;
-  const isDraft = isOrganizer && (props as OrganizerProps).moment.status === "DRAFT";
+  const isDraft = isOrganizerView && (props as OrganizerProps).moment.status === "DRAFT";
 
   // Extraire les données selon le variant
-  const momentData = isOrganizer
+  const momentData = isOrganizerView
     ? {
         slug: props.moment.slug,
         title: props.moment.title,
@@ -77,19 +77,19 @@ export function DashboardMomentCard(props: DashboardMomentCardProps) {
     setIsToday(momentData.startsAt.toDateString() === now.toDateString());
   }, [momentData.startsAt]);
 
-  const isHost = !isOrganizer && (props as ParticipantProps).isHost === true;
+  const isOrganizer = !isOrganizerView && (props as ParticipantProps).isOrganizer === true;
   const isRegistered =
+    !isOrganizerView &&
     !isOrganizer &&
-    !isHost &&
     (props.registration.status === "REGISTERED" ||
       props.registration.status === "CHECKED_IN");
-  const isWaitlisted = !isOrganizer && !isHost && props.registration.status === "WAITLISTED";
+  const isWaitlisted = !isOrganizerView && !isOrganizer && props.registration.status === "WAITLISTED";
 
   const dotClass = isPast
     ? "bg-border"
     : isDraft
       ? "bg-muted-foreground/40"
-      : isOrganizer || isHost
+      : isOrganizerView || isOrganizer
         ? "bg-primary"
         : isRegistered
           ? "bg-primary"
@@ -115,7 +115,7 @@ export function DashboardMomentCard(props: DashboardMomentCardProps) {
         : momentData.locationName;
 
   const roleBadge = !isPast && !isDraft ? (
-    isOrganizer || isHost ? (
+    isOrganizerView || isOrganizer ? (
       <Badge variant="outline" className="shrink-0 gap-1 border-primary/40 text-xs text-primary">
         <Crown className="size-3" />
         <span className="hidden sm:inline">{t("role.host")}</span>

--- a/src/components/moments/moment-detail-view.tsx
+++ b/src/components/moments/moment-detail-view.tsx
@@ -191,9 +191,13 @@ function CircleInfoBlock({ circle, circleHref, proposedByLabel }: CircleInfoBloc
 export async function MomentDetailView(props: MomentDetailViewProps) {
   const { moment, circle, hosts, registrations, registeredCount, waitlistedCount, attachments } =
     props;
-  // "Organisé par" n'affiche que le HOST principal (les CO_HOST figurent dans la liste des membres).
+  // "Organisé par" affiche le créateur de l'événement (HOST ou CO_HOST).
+  // Si le créateur n'est plus organisateur (rétrogradé / parti), on retombe sur le HOST principal.
   // On garde `hosts` complet pour les autres usages (exclusions notifications, hostUserIds...).
-  const primaryHosts = hosts.filter((h) => h.role === "HOST");
+  const creator = moment.createdById
+    ? hosts.find((h) => h.user.id === moment.createdById)
+    : null;
+  const primaryHosts = creator ? [creator] : hosts.filter((h) => h.role === "HOST");
   const isHostView = props.variant === "host";
   // Le host est toujours connecté — l'accès au dashboard nécessite une session
   const isAuthenticated = isHostView || (props as PublicViewProps).isAuthenticated;

--- a/src/components/moments/moment-detail-view.tsx
+++ b/src/components/moments/moment-detail-view.tsx
@@ -67,7 +67,7 @@ type HostViewProps = CommonProps & {
 type PublicViewProps = CommonProps & {
   variant: "public";
   isAuthenticated: boolean;
-  isHost: boolean;
+  isOrganizer: boolean;
   existingRegistration: Registration | null;
   signInUrl: string;
   isFull: boolean;
@@ -320,7 +320,7 @@ export async function MomentDetailView(props: MomentDetailViewProps) {
                 <DeleteMomentDialog momentId={moment.id} circleSlug={props.circleSlug} />
               </div>
             )}
-            {!isHostView && props.isHost && (
+            {!isHostView && props.isOrganizer && (
               <Button asChild size="sm" className="shrink-0 gap-1.5">
                 <Link href={`/dashboard/circles/${circle.slug}/moments/${moment.slug}`}>
                   <ExternalLink className="size-3.5" />
@@ -604,7 +604,7 @@ export async function MomentDetailView(props: MomentDetailViewProps) {
                 isFull={props.isFull}
                 spotsRemaining={props.spotsRemaining}
                 registrationCount={registeredCount}
-                isHost={props.isHost}
+                isOrganizer={props.isOrganizer}
                 calendarData={props.calendarData}
                 appUrl={props.appUrl}
                 waitlistPosition={props.waitlistPosition}
@@ -761,7 +761,7 @@ export async function MomentDetailView(props: MomentDetailViewProps) {
             momentId={moment.id}
             comments={props.comments}
             currentUserId={props.currentUserId}
-            isHost={isHostView || (!isHostView && (props as PublicViewProps).isHost)}
+            isOrganizer={isHostView || (!isHostView && (props as PublicViewProps).isOrganizer)}
             isPastMoment={moment.status === "PAST"}
             signInUrl={!isHostView ? (props as PublicViewProps).signInUrl : ""}
           />

--- a/src/components/moments/moment-detail-view.tsx
+++ b/src/components/moments/moment-detail-view.tsx
@@ -191,6 +191,9 @@ function CircleInfoBlock({ circle, circleHref, proposedByLabel }: CircleInfoBloc
 export async function MomentDetailView(props: MomentDetailViewProps) {
   const { moment, circle, hosts, registrations, registeredCount, waitlistedCount, attachments } =
     props;
+  // "Organisé par" n'affiche que le HOST principal (les CO_HOST figurent dans la liste des membres).
+  // On garde `hosts` complet pour les autres usages (exclusions notifications, hostUserIds...).
+  const primaryHosts = hosts.filter((h) => h.role === "HOST");
   const isHostView = props.variant === "host";
   // Le host est toujours connecté — l'accès au dashboard nécessite une session
   const isAuthenticated = isHostView || (props as PublicViewProps).isAuthenticated;
@@ -280,10 +283,10 @@ export async function MomentDetailView(props: MomentDetailViewProps) {
 
           {/* "Organisé par" + actions Host */}
           <div className="flex items-center justify-between gap-4">
-            {hosts.length > 0 && (
+            {primaryHosts.length > 0 && (
               <p className="text-muted-foreground flex flex-wrap items-center gap-x-1 gap-y-1 text-sm">
                 {t("public.hostedBy")}{" "}
-                {hosts.map((h, i) => (
+                {primaryHosts.map((h, i) => (
                   <span key={h.user.id} className="flex items-center gap-1">
                     {isAuthenticated && h.user.publicId ? (
                       <Link
@@ -302,7 +305,7 @@ export async function MomentDetailView(props: MomentDetailViewProps) {
                         {tCommon("you")}
                       </Badge>
                     )}
-                    {i < hosts.length - 1 && <span>,</span>}
+                    {i < primaryHosts.length - 1 && <span>,</span>}
                   </span>
                 ))}
               </p>

--- a/src/components/moments/registration-button.tsx
+++ b/src/components/moments/registration-button.tsx
@@ -40,7 +40,7 @@ type RegistrationButtonProps = {
   isFull: boolean;
   spotsRemaining: number | null;
   registrationCount: number;
-  isHost?: boolean;
+  isOrganizer?: boolean;
   calendarData?: CalendarEventData;
   appUrl?: string;
   waitlistPosition?: number;
@@ -90,7 +90,7 @@ export function RegistrationButton({
   isFull,
   spotsRemaining,
   registrationCount,
-  isHost = false,
+  isOrganizer = false,
   calendarData,
   appUrl,
   waitlistPosition,
@@ -262,11 +262,11 @@ export function RegistrationButton({
           )}
 
           {/* Ligne 3 — Actions */}
-          {(isRegistered || !isHost) && (
+          {(isRegistered || !isOrganizer) && (
             <>
               <div className="border-border ml-[3.25rem] border-t" />
               <div className="flex items-center justify-end gap-1.5 px-4 py-3">
-                {!isHost && (
+                {!isOrganizer && (
                   <AlertDialog>
                     <AlertDialogTrigger asChild>
                       <Button

--- a/src/components/moments/registrations-list.tsx
+++ b/src/components/moments/registrations-list.tsx
@@ -131,7 +131,7 @@ export function RegistrationsList({
                 reg.user.email
               );
               const isWaitlisted = reg.status === "WAITLISTED";
-              const isHost = hostUserIds.has(reg.user.id);
+              const isOrganizer = hostUserIds.has(reg.user.id);
               return (
                 <div key={reg.id} className="flex items-center gap-3 py-2.5">
                   <UserAvatar
@@ -157,19 +157,19 @@ export function RegistrationsList({
                       </p>
                     )}
                   </div>
-                  {isHost && (
+                  {isOrganizer && (
                     <Badge variant="outline" className="border-primary/40 text-primary shrink-0 gap-1">
                       <Crown className="size-3" />
                       {tDashboard("role.host")}
                     </Badge>
                   )}
-                  {isWaitlisted && !isHost && (
+                  {isWaitlisted && !isOrganizer && (
                     <Badge variant="secondary" className="shrink-0 gap-1">
                       <Clock className="size-3" />
                       {t("registrations.status.waitlisted")}
                     </Badge>
                   )}
-                  {variant === "host" && !isHost && (
+                  {variant === "host" && !isOrganizer && (
                     <Button
                       variant="outline"
                       size="sm"

--- a/src/domain/errors/circle-errors.ts
+++ b/src/domain/errors/circle-errors.ts
@@ -65,3 +65,27 @@ export class MembershipNotPendingError extends DomainError {
     super(`Membership for user ${userId} in circle ${circleId} is not pending approval`);
   }
 }
+
+export class CannotPromotePendingMemberError extends DomainError {
+  readonly code = "CANNOT_PROMOTE_PENDING_MEMBER";
+
+  constructor() {
+    super("Only an active member can be promoted to co-organizer (D22)");
+  }
+}
+
+export class InvalidPromotionTargetError extends DomainError {
+  readonly code = "INVALID_PROMOTION_TARGET";
+
+  constructor(currentRole: string) {
+    super(`Cannot promote to co-organizer: target role is ${currentRole} (expected PLAYER)`);
+  }
+}
+
+export class InvalidDemotionTargetError extends DomainError {
+  readonly code = "INVALID_DEMOTION_TARGET";
+
+  constructor(currentRole: string) {
+    super(`Cannot demote from co-organizer: target role is ${currentRole} (expected CO_HOST)`);
+  }
+}

--- a/src/domain/errors/index.ts
+++ b/src/domain/errors/index.ts
@@ -41,7 +41,7 @@ export {
   AlreadyRegisteredError,
   RegistrationNotFoundError,
   UnauthorizedRegistrationActionError,
-  HostCannotCancelRegistrationError,
+  OrganizerCannotCancelRegistrationError,
   CannotRemoveHostRegistrationError,
   RegistrationNotPendingApprovalError,
 } from "./registration-errors";

--- a/src/domain/errors/index.ts
+++ b/src/domain/errors/index.ts
@@ -8,6 +8,9 @@ export {
   CannotRemoveHostError,
   CannotRemoveSelfError,
   MembershipNotPendingError,
+  CannotPromotePendingMemberError,
+  InvalidPromotionTargetError,
+  InvalidDemotionTargetError,
 } from "./circle-errors";
 export {
   MomentNotFoundError,

--- a/src/domain/errors/registration-errors.ts
+++ b/src/domain/errors/registration-errors.ts
@@ -48,11 +48,11 @@ export class UnauthorizedRegistrationActionError extends DomainError {
   }
 }
 
-export class HostCannotCancelRegistrationError extends DomainError {
-  readonly code = "HOST_CANNOT_CANCEL";
+export class OrganizerCannotCancelRegistrationError extends DomainError {
+  readonly code = "ORGANIZER_CANNOT_CANCEL";
 
   constructor() {
-    super("A Host cannot cancel their registration for a Moment they organize");
+    super("An organizer (Host or Co-Host) cannot cancel their registration for a Moment of their own Community");
   }
 }
 

--- a/src/domain/models/circle.ts
+++ b/src/domain/models/circle.ts
@@ -7,9 +7,20 @@ export type CoverImageAttribution = {
   url: string;
 };
 
-export type CircleMemberRole = "HOST" | "PLAYER";
+export type CircleMemberRole = "HOST" | "CO_HOST" | "PLAYER";
 
 export type MembershipStatus = "PENDING" | "ACTIVE";
+
+export function isOrganizerRole(role: CircleMemberRole): boolean {
+  return role === "HOST" || role === "CO_HOST";
+}
+
+export function isActiveOrganizer(
+  membership: Pick<CircleMembership, "role" | "status"> | null | undefined
+): boolean {
+  if (!membership) return false;
+  return membership.status === "ACTIVE" && isOrganizerRole(membership.role);
+}
 
 export type CircleCategory =
   | "TECH"

--- a/src/domain/models/user.ts
+++ b/src/domain/models/user.ts
@@ -1,3 +1,5 @@
+import type { CircleMemberRole } from "@/domain/models/circle";
+
 export type UserRole = "USER" | "ADMIN";
 
 /** Sous-ensemble minimal d'un User pour l'affichage d'avatar (initiales + gradient ou image). */
@@ -31,7 +33,7 @@ export type PublicCircleMembership = {
   circleSlug: string;
   circleName: string;
   circleCover: string | null;
-  role: "HOST" | "PLAYER";
+  role: CircleMemberRole;
 };
 
 export type PublicMomentRegistration = {

--- a/src/domain/ports/repositories/circle-repository.ts
+++ b/src/domain/ports/repositories/circle-repository.ts
@@ -98,6 +98,7 @@ export interface CircleRepository {
   slugExists(slug: string): Promise<boolean>;
   addMembership(circleId: string, userId: string, role: CircleMemberRole, status?: MembershipStatus): Promise<CircleMembership>;
   updateMembershipStatus(circleId: string, userId: string, status: MembershipStatus): Promise<CircleMembership>;
+  updateMembershipRole(circleId: string, userId: string, role: CircleMemberRole): Promise<CircleMembership>;
   findPendingMemberships(circleId: string): Promise<CircleMemberWithUser[]>;
   countPendingMemberships(circleId: string): Promise<number>;
   findAllByUserId(userId: string): Promise<CircleWithRole[]>;

--- a/src/domain/ports/repositories/circle-repository.ts
+++ b/src/domain/ports/repositories/circle-repository.ts
@@ -105,6 +105,11 @@ export interface CircleRepository {
   findAllByUserIdWithStats(userId: string): Promise<DashboardCircle[]>;
   findMembership(circleId: string, userId: string): Promise<CircleMembership | null>;
   findMembersByRole(circleId: string, role: CircleMemberRole): Promise<CircleMemberWithUser[]>;
+  /**
+   * Renvoie les Organisateurs ACTIFS d'un Circle (HOST + CO_HOST, status ACTIVE).
+   * Remplace les appels `findMembersByRole(circleId, "HOST")` côté notifications et affichage.
+   */
+  findOrganizers(circleId: string): Promise<CircleMemberWithUser[]>;
   countMembers(circleId: string): Promise<number>;
   countMoments(circleId: string): Promise<number>;
   /** Renvoie une Map circleId → nombre de membres pour une liste de Circles (une seule requête GROUP BY). */

--- a/src/domain/ports/services/email-service.ts
+++ b/src/domain/ports/services/email-service.ts
@@ -393,6 +393,50 @@ export type OnboardingWelcomeEmailData = {
   firstName: string | null;
 };
 
+// --- Co-host role changes (D19) ---
+
+export type CoHostPromotedEmailData = {
+  to: string;
+  recipientName: string;
+  inviterName: string;
+  circleName: string;
+  circleSlug: string;
+  circleCoverImage: string | null;
+  strings: {
+    subject: string;
+    heading: string;
+    intro: string;
+    rightsTitle: string;
+    rightCreateEvents: string;
+    rightManageRegistrations: string;
+    rightUpdateCircle: string;
+    rightBroadcast: string;
+    rightReceiveNotifications: string;
+    limitsNote: string;
+    ctaLabel: string;
+    footer: string;
+    leaveLink: string;
+  };
+};
+
+export type CoHostDemotedEmailData = {
+  to: string;
+  recipientName: string;
+  circleName: string;
+  circleSlug: string;
+  circleCoverImage: string | null;
+  strings: {
+    subject: string;
+    heading: string;
+    intro: string;
+    newRoleLabel: string;
+    registrationsNote: string;
+    ctaLabel: string;
+    footer: string;
+    preferencesLink: string;
+  };
+};
+
 // --- Port interface ---
 
 export interface EmailService {
@@ -421,4 +465,6 @@ export interface EmailService {
   sendApprovalNotification(data: ApprovalNotificationEmailData): Promise<void>;
   sendHostPaidCancellation(data: HostPaidCancellationEmailData): Promise<void>;
   sendOnboardingWelcome(data: OnboardingWelcomeEmailData): Promise<void>;
+  sendCoHostPromoted(data: CoHostPromotedEmailData): Promise<void>;
+  sendCoHostDemoted(data: CoHostDemotedEmailData): Promise<void>;
 }

--- a/src/domain/usecases/__tests__/cancel-registration.test.ts
+++ b/src/domain/usecases/__tests__/cancel-registration.test.ts
@@ -3,7 +3,7 @@ import { cancelRegistration } from "@/domain/usecases/cancel-registration";
 import {
   RegistrationNotFoundError,
   UnauthorizedRegistrationActionError,
-  HostCannotCancelRegistrationError,
+  OrganizerCannotCancelRegistrationError,
 } from "@/domain/errors";
 import {
   createMockRegistrationRepository,
@@ -130,7 +130,7 @@ describe("CancelRegistration", () => {
   });
 
   describe("given a Host trying to cancel their registration", () => {
-    it("should throw HostCannotCancelRegistrationError", async () => {
+    it("should throw OrganizerCannotCancelRegistrationError", async () => {
       const registrationRepo = createMockRegistrationRepository({
         findById: vi.fn().mockResolvedValue(
           makeRegistration({ status: "REGISTERED" })
@@ -150,7 +150,7 @@ describe("CancelRegistration", () => {
           defaultInput,
           makeDeps({ registrationRepo, momentRepo, circleRepo })
         )
-      ).rejects.toThrow(HostCannotCancelRegistrationError);
+      ).rejects.toThrow(OrganizerCannotCancelRegistrationError);
     });
   });
 

--- a/src/domain/usecases/__tests__/demote-from-co-host.test.ts
+++ b/src/domain/usecases/__tests__/demote-from-co-host.test.ts
@@ -157,7 +157,7 @@ describe("demoteFromCoHost", () => {
         userRepository: userRepo,
         emailService,
         emailStrings: {
-          demoted: async () => ({
+          demoted: async (_args: { circleName: string }) => ({
             subject: "s", heading: "h", intro: "i", newRoleLabel: "n",
             registrationsNote: "r", ctaLabel: "c", footer: "f", preferencesLink: "p",
           }),

--- a/src/domain/usecases/__tests__/demote-from-co-host.test.ts
+++ b/src/domain/usecases/__tests__/demote-from-co-host.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi } from "vitest";
+import { demoteFromCoHost } from "@/domain/usecases/demote-from-co-host";
+import {
+  createMockCircleRepository,
+  makeCircle,
+  makeMembership,
+} from "./helpers/mock-circle-repository";
+import { createMockUserRepository, makeUser } from "./helpers/mock-user-repository";
+import { createMockEmailService } from "./helpers/mock-email-service";
+import {
+  UnauthorizedCircleActionError,
+  NotMemberOfCircleError,
+  InvalidDemotionTargetError,
+} from "@/domain/errors";
+
+const CIRCLE_ID = "circle-1";
+const HOST_ID = "host-user-1";
+const TARGET_ID = "target-user-2";
+
+function makeInput() {
+  return { circleId: CIRCLE_ID, hostUserId: HOST_ID, targetUserId: TARGET_ID };
+}
+
+describe("demoteFromCoHost", () => {
+  describe("given the caller is not the HOST", () => {
+    it("should throw UnauthorizedCircleActionError when caller is CO_HOST", async () => {
+      const circleRepo = createMockCircleRepository({
+        findMembership: vi.fn().mockResolvedValue(
+          makeMembership({ userId: HOST_ID, role: "CO_HOST", status: "ACTIVE" })
+        ),
+      });
+
+      await expect(
+        demoteFromCoHost(makeInput(), {
+          circleRepository: circleRepo,
+          userRepository: createMockUserRepository(),
+        })
+      ).rejects.toThrow(UnauthorizedCircleActionError);
+    });
+
+    it("should throw UnauthorizedCircleActionError when caller HOST is PENDING", async () => {
+      const circleRepo = createMockCircleRepository({
+        findMembership: vi.fn().mockResolvedValue(
+          makeMembership({ userId: HOST_ID, role: "HOST", status: "PENDING" })
+        ),
+      });
+
+      await expect(
+        demoteFromCoHost(makeInput(), {
+          circleRepository: circleRepo,
+          userRepository: createMockUserRepository(),
+        })
+      ).rejects.toThrow(UnauthorizedCircleActionError);
+    });
+  });
+
+  describe("given the target is not a member", () => {
+    it("should throw NotMemberOfCircleError", async () => {
+      const circleRepo = createMockCircleRepository({
+        findMembership: vi
+          .fn()
+          .mockResolvedValueOnce(makeMembership({ role: "HOST", status: "ACTIVE" }))
+          .mockResolvedValueOnce(null),
+      });
+
+      await expect(
+        demoteFromCoHost(makeInput(), {
+          circleRepository: circleRepo,
+          userRepository: createMockUserRepository(),
+        })
+      ).rejects.toThrow(NotMemberOfCircleError);
+    });
+  });
+
+  describe("given the target is not a CO_HOST", () => {
+    it("should throw InvalidDemotionTargetError when target is PLAYER", async () => {
+      const circleRepo = createMockCircleRepository({
+        findMembership: vi
+          .fn()
+          .mockResolvedValueOnce(makeMembership({ role: "HOST", status: "ACTIVE" }))
+          .mockResolvedValueOnce(
+            makeMembership({ userId: TARGET_ID, role: "PLAYER", status: "ACTIVE" })
+          ),
+      });
+
+      await expect(
+        demoteFromCoHost(makeInput(), {
+          circleRepository: circleRepo,
+          userRepository: createMockUserRepository(),
+        })
+      ).rejects.toThrow(InvalidDemotionTargetError);
+    });
+
+    it("should throw InvalidDemotionTargetError when target is HOST", async () => {
+      const circleRepo = createMockCircleRepository({
+        findMembership: vi
+          .fn()
+          .mockResolvedValueOnce(makeMembership({ role: "HOST", status: "ACTIVE" }))
+          .mockResolvedValueOnce(
+            makeMembership({ userId: TARGET_ID, role: "HOST", status: "ACTIVE" })
+          ),
+      });
+
+      await expect(
+        demoteFromCoHost(makeInput(), {
+          circleRepository: circleRepo,
+          userRepository: createMockUserRepository(),
+        })
+      ).rejects.toThrow(InvalidDemotionTargetError);
+    });
+  });
+
+  describe("given a valid demotion (HOST caller, CO_HOST target)", () => {
+    it("should update the role to PLAYER", async () => {
+      const updateRoleMock = vi.fn().mockResolvedValue(
+        makeMembership({ userId: TARGET_ID, role: "PLAYER", status: "ACTIVE" })
+      );
+      const circleRepo = createMockCircleRepository({
+        findMembership: vi
+          .fn()
+          .mockResolvedValueOnce(makeMembership({ role: "HOST", status: "ACTIVE" }))
+          .mockResolvedValueOnce(
+            makeMembership({ userId: TARGET_ID, role: "CO_HOST", status: "ACTIVE" })
+          ),
+        updateMembershipRole: updateRoleMock,
+      });
+
+      const result = await demoteFromCoHost(makeInput(), {
+        circleRepository: circleRepo,
+        userRepository: createMockUserRepository(),
+      });
+
+      expect(updateRoleMock).toHaveBeenCalledWith(CIRCLE_ID, TARGET_ID, "PLAYER");
+      expect(result.role).toBe("PLAYER");
+    });
+
+    it("should send a demotion email when emailService is provided (D19)", async () => {
+      const emailService = createMockEmailService();
+      const circleRepo = createMockCircleRepository({
+        findById: vi.fn().mockResolvedValue(makeCircle()),
+        findMembership: vi
+          .fn()
+          .mockResolvedValueOnce(makeMembership({ role: "HOST", status: "ACTIVE" }))
+          .mockResolvedValueOnce(
+            makeMembership({ userId: TARGET_ID, role: "CO_HOST", status: "ACTIVE" })
+          ),
+        updateMembershipRole: vi.fn().mockResolvedValue(
+          makeMembership({ userId: TARGET_ID, role: "PLAYER", status: "ACTIVE" })
+        ),
+      });
+      const userRepo = createMockUserRepository({
+        findById: vi.fn().mockResolvedValue(makeUser({ id: TARGET_ID })),
+      });
+
+      await demoteFromCoHost(makeInput(), {
+        circleRepository: circleRepo,
+        userRepository: userRepo,
+        emailService,
+        emailStrings: {
+          demoted: async () => ({
+            subject: "s", heading: "h", intro: "i", newRoleLabel: "n",
+            registrationsNote: "r", ctaLabel: "c", footer: "f", preferencesLink: "p",
+          }),
+        },
+      });
+
+      expect(emailService.sendCoHostDemoted).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/domain/usecases/__tests__/helpers/mock-circle-repository.ts
+++ b/src/domain/usecases/__tests__/helpers/mock-circle-repository.ts
@@ -19,6 +19,7 @@ export function createMockCircleRepository(
     findAllByUserIdWithStats: vi.fn<CircleRepository["findAllByUserIdWithStats"]>().mockResolvedValue([]),
     findMembership: vi.fn<CircleRepository["findMembership"]>().mockResolvedValue(null),
     findMembersByRole: vi.fn<CircleRepository["findMembersByRole"]>().mockResolvedValue([]),
+    findOrganizers: vi.fn<CircleRepository["findOrganizers"]>().mockResolvedValue([]),
     countMembers: vi.fn<CircleRepository["countMembers"]>().mockResolvedValue(0),
     countMoments: vi.fn<CircleRepository["countMoments"]>().mockResolvedValue(0),
     findPublic: vi.fn<CircleRepository["findPublic"]>().mockResolvedValue([]),

--- a/src/domain/usecases/__tests__/helpers/mock-circle-repository.ts
+++ b/src/domain/usecases/__tests__/helpers/mock-circle-repository.ts
@@ -28,6 +28,7 @@ export function createMockCircleRepository(
     getPublicCirclesForUser: vi.fn<CircleRepository["getPublicCirclesForUser"]>().mockResolvedValue([]),
     findFeatured: vi.fn<CircleRepository["findFeatured"]>().mockResolvedValue([]),
     updateMembershipStatus: vi.fn<CircleRepository["updateMembershipStatus"]>().mockResolvedValue(makeMembership()),
+    updateMembershipRole: vi.fn<CircleRepository["updateMembershipRole"]>().mockResolvedValue(makeMembership()),
     findPendingMemberships: vi.fn<CircleRepository["findPendingMemberships"]>().mockResolvedValue([]),
     countPendingMemberships: vi.fn<CircleRepository["countPendingMemberships"]>().mockResolvedValue(0),
     ...overrides,

--- a/src/domain/usecases/__tests__/helpers/mock-email-service.ts
+++ b/src/domain/usecases/__tests__/helpers/mock-email-service.ts
@@ -28,6 +28,8 @@ export function createMockEmailService(
     sendApprovalNotification: vi.fn().mockResolvedValue(undefined),
     sendHostPaidCancellation: vi.fn().mockResolvedValue(undefined),
     sendOnboardingWelcome: vi.fn().mockResolvedValue(undefined),
+    sendCoHostPromoted: vi.fn().mockResolvedValue(undefined),
+    sendCoHostDemoted: vi.fn().mockResolvedValue(undefined),
     ...overrides,
   };
 }

--- a/src/domain/usecases/__tests__/promote-to-co-host.test.ts
+++ b/src/domain/usecases/__tests__/promote-to-co-host.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect, vi } from "vitest";
+import { promoteToCoHost } from "@/domain/usecases/promote-to-co-host";
+import {
+  createMockCircleRepository,
+  makeCircle,
+  makeMembership,
+} from "./helpers/mock-circle-repository";
+import { createMockUserRepository, makeUser } from "./helpers/mock-user-repository";
+import { createMockEmailService } from "./helpers/mock-email-service";
+import {
+  UnauthorizedCircleActionError,
+  NotMemberOfCircleError,
+  CannotPromotePendingMemberError,
+  InvalidPromotionTargetError,
+} from "@/domain/errors";
+
+const CIRCLE_ID = "circle-1";
+const HOST_ID = "host-user-1";
+const TARGET_ID = "target-user-2";
+
+function makeInput() {
+  return { circleId: CIRCLE_ID, hostUserId: HOST_ID, targetUserId: TARGET_ID };
+}
+
+describe("promoteToCoHost", () => {
+  describe("given the caller is not the HOST of the Circle", () => {
+    it("should throw UnauthorizedCircleActionError when caller is a CO_HOST", async () => {
+      const circleRepo = createMockCircleRepository({
+        findMembership: vi.fn().mockResolvedValue(
+          makeMembership({ userId: HOST_ID, role: "CO_HOST", status: "ACTIVE" })
+        ),
+      });
+
+      await expect(
+        promoteToCoHost(makeInput(), {
+          circleRepository: circleRepo,
+          userRepository: createMockUserRepository(),
+        })
+      ).rejects.toThrow(UnauthorizedCircleActionError);
+    });
+
+    it("should throw UnauthorizedCircleActionError when caller is a PLAYER", async () => {
+      const circleRepo = createMockCircleRepository({
+        findMembership: vi.fn().mockResolvedValue(
+          makeMembership({ userId: HOST_ID, role: "PLAYER", status: "ACTIVE" })
+        ),
+      });
+
+      await expect(
+        promoteToCoHost(makeInput(), {
+          circleRepository: circleRepo,
+          userRepository: createMockUserRepository(),
+        })
+      ).rejects.toThrow(UnauthorizedCircleActionError);
+    });
+
+    it("should throw UnauthorizedCircleActionError when caller HOST is PENDING", async () => {
+      const circleRepo = createMockCircleRepository({
+        findMembership: vi.fn().mockResolvedValue(
+          makeMembership({ userId: HOST_ID, role: "HOST", status: "PENDING" })
+        ),
+      });
+
+      await expect(
+        promoteToCoHost(makeInput(), {
+          circleRepository: circleRepo,
+          userRepository: createMockUserRepository(),
+        })
+      ).rejects.toThrow(UnauthorizedCircleActionError);
+    });
+  });
+
+  describe("given the target is not a member", () => {
+    it("should throw NotMemberOfCircleError", async () => {
+      const circleRepo = createMockCircleRepository({
+        findMembership: vi
+          .fn()
+          .mockResolvedValueOnce(makeMembership({ role: "HOST", status: "ACTIVE" }))
+          .mockResolvedValueOnce(null),
+      });
+
+      await expect(
+        promoteToCoHost(makeInput(), {
+          circleRepository: circleRepo,
+          userRepository: createMockUserRepository(),
+        })
+      ).rejects.toThrow(NotMemberOfCircleError);
+    });
+  });
+
+  describe("given the target membership is PENDING", () => {
+    it("should throw CannotPromotePendingMemberError (D22)", async () => {
+      const circleRepo = createMockCircleRepository({
+        findMembership: vi
+          .fn()
+          .mockResolvedValueOnce(makeMembership({ role: "HOST", status: "ACTIVE" }))
+          .mockResolvedValueOnce(
+            makeMembership({ userId: TARGET_ID, role: "PLAYER", status: "PENDING" })
+          ),
+      });
+
+      await expect(
+        promoteToCoHost(makeInput(), {
+          circleRepository: circleRepo,
+          userRepository: createMockUserRepository(),
+        })
+      ).rejects.toThrow(CannotPromotePendingMemberError);
+    });
+  });
+
+  describe("given the target is already a CO_HOST or HOST", () => {
+    it("should throw InvalidPromotionTargetError when target is CO_HOST", async () => {
+      const circleRepo = createMockCircleRepository({
+        findMembership: vi
+          .fn()
+          .mockResolvedValueOnce(makeMembership({ role: "HOST", status: "ACTIVE" }))
+          .mockResolvedValueOnce(
+            makeMembership({ userId: TARGET_ID, role: "CO_HOST", status: "ACTIVE" })
+          ),
+      });
+
+      await expect(
+        promoteToCoHost(makeInput(), {
+          circleRepository: circleRepo,
+          userRepository: createMockUserRepository(),
+        })
+      ).rejects.toThrow(InvalidPromotionTargetError);
+    });
+
+    it("should throw InvalidPromotionTargetError when target is HOST", async () => {
+      const circleRepo = createMockCircleRepository({
+        findMembership: vi
+          .fn()
+          .mockResolvedValueOnce(makeMembership({ role: "HOST", status: "ACTIVE" }))
+          .mockResolvedValueOnce(
+            makeMembership({ userId: TARGET_ID, role: "HOST", status: "ACTIVE" })
+          ),
+      });
+
+      await expect(
+        promoteToCoHost(makeInput(), {
+          circleRepository: circleRepo,
+          userRepository: createMockUserRepository(),
+        })
+      ).rejects.toThrow(InvalidPromotionTargetError);
+    });
+  });
+
+  describe("given a valid promotion (HOST caller, ACTIVE PLAYER target)", () => {
+    it("should update the role to CO_HOST", async () => {
+      const updateRoleMock = vi
+        .fn()
+        .mockResolvedValue(
+          makeMembership({ userId: TARGET_ID, role: "CO_HOST", status: "ACTIVE" })
+        );
+      const circleRepo = createMockCircleRepository({
+        findMembership: vi
+          .fn()
+          .mockResolvedValueOnce(makeMembership({ role: "HOST", status: "ACTIVE" }))
+          .mockResolvedValueOnce(
+            makeMembership({ userId: TARGET_ID, role: "PLAYER", status: "ACTIVE" })
+          ),
+        updateMembershipRole: updateRoleMock,
+      });
+
+      const result = await promoteToCoHost(makeInput(), {
+        circleRepository: circleRepo,
+        userRepository: createMockUserRepository(),
+      });
+
+      expect(updateRoleMock).toHaveBeenCalledWith(CIRCLE_ID, TARGET_ID, "CO_HOST");
+      expect(result.role).toBe("CO_HOST");
+    });
+
+    it("should send a promotion email when emailService is provided (D19)", async () => {
+      const emailService = createMockEmailService();
+      const circleRepo = createMockCircleRepository({
+        findById: vi.fn().mockResolvedValue(makeCircle()),
+        findMembership: vi
+          .fn()
+          .mockResolvedValueOnce(makeMembership({ role: "HOST", status: "ACTIVE" }))
+          .mockResolvedValueOnce(
+            makeMembership({ userId: TARGET_ID, role: "PLAYER", status: "ACTIVE" })
+          ),
+        updateMembershipRole: vi.fn().mockResolvedValue(
+          makeMembership({ userId: TARGET_ID, role: "CO_HOST", status: "ACTIVE" })
+        ),
+      });
+      const userRepo = createMockUserRepository({
+        findById: vi.fn()
+          .mockResolvedValueOnce(makeUser({ id: TARGET_ID, email: "target@example.com" }))
+          .mockResolvedValueOnce(makeUser({ id: HOST_ID, firstName: "Alice", lastName: "Martin" })),
+      });
+
+      const promotedBy = vi.fn().mockResolvedValue({
+        subject: "s", heading: "h", intro: "i",
+        rightsTitle: "t", rightCreateEvents: "r1", rightManageRegistrations: "r2",
+        rightUpdateCircle: "r3", rightBroadcast: "r4", rightReceiveNotifications: "r5",
+        limitsNote: "l", ctaLabel: "c", footer: "f", leaveLink: "ll",
+      });
+
+      await promoteToCoHost(makeInput(), {
+        circleRepository: circleRepo,
+        userRepository: userRepo,
+        emailService,
+        emailStrings: { promotedBy },
+      });
+
+      expect(emailService.sendCoHostPromoted).toHaveBeenCalledTimes(1);
+      expect(promotedBy).toHaveBeenCalledWith("Alice Martin");
+    });
+
+    it("should not throw when email sending fails (best-effort)", async () => {
+      const emailService = createMockEmailService({
+        sendCoHostPromoted: vi.fn().mockRejectedValue(new Error("email down")),
+      });
+      const circleRepo = createMockCircleRepository({
+        findById: vi.fn().mockResolvedValue(makeCircle()),
+        findMembership: vi
+          .fn()
+          .mockResolvedValueOnce(makeMembership({ role: "HOST", status: "ACTIVE" }))
+          .mockResolvedValueOnce(
+            makeMembership({ userId: TARGET_ID, role: "PLAYER", status: "ACTIVE" })
+          ),
+        updateMembershipRole: vi.fn().mockResolvedValue(
+          makeMembership({ userId: TARGET_ID, role: "CO_HOST", status: "ACTIVE" })
+        ),
+      });
+      const userRepo = createMockUserRepository({
+        findById: vi.fn().mockResolvedValue(makeUser()),
+      });
+
+      await expect(
+        promoteToCoHost(makeInput(), {
+          circleRepository: circleRepo,
+          userRepository: userRepo,
+          emailService,
+          emailStrings: {
+            promotedBy: async () => ({
+              subject: "s", heading: "h", intro: "i",
+              rightsTitle: "t", rightCreateEvents: "r1", rightManageRegistrations: "r2",
+              rightUpdateCircle: "r3", rightBroadcast: "r4", rightReceiveNotifications: "r5",
+              limitsNote: "l", ctaLabel: "c", footer: "f", leaveLink: "ll",
+            }),
+          },
+        })
+      ).resolves.toBeDefined();
+    });
+  });
+});

--- a/src/domain/usecases/__tests__/promote-to-co-host.test.ts
+++ b/src/domain/usecases/__tests__/promote-to-co-host.test.ts
@@ -192,12 +192,12 @@ describe("promoteToCoHost", () => {
           .mockResolvedValueOnce(makeUser({ id: HOST_ID, firstName: "Alice", lastName: "Martin" })),
       });
 
-      const promotedBy = vi.fn().mockResolvedValue({
+      const promotedBy = vi.fn(async ({ inviterName: _n }: { inviterName: string; circleName: string }) => ({
         subject: "s", heading: "h", intro: "i",
         rightsTitle: "t", rightCreateEvents: "r1", rightManageRegistrations: "r2",
         rightUpdateCircle: "r3", rightBroadcast: "r4", rightReceiveNotifications: "r5",
         limitsNote: "l", ctaLabel: "c", footer: "f", leaveLink: "ll",
-      });
+      }));
 
       await promoteToCoHost(makeInput(), {
         circleRepository: circleRepo,
@@ -207,7 +207,10 @@ describe("promoteToCoHost", () => {
       });
 
       expect(emailService.sendCoHostPromoted).toHaveBeenCalledTimes(1);
-      expect(promotedBy).toHaveBeenCalledWith("Alice Martin");
+      expect(promotedBy).toHaveBeenCalledWith({
+        inviterName: "Alice Martin",
+        circleName: "My Circle",
+      });
     });
 
     it("should not throw when email sending fails (best-effort)", async () => {

--- a/src/domain/usecases/__tests__/security/authorization.test.ts
+++ b/src/domain/usecases/__tests__/security/authorization.test.ts
@@ -26,7 +26,7 @@ import {
   UnauthorizedCircleActionError,
   UnauthorizedMomentActionError,
   UnauthorizedRegistrationActionError,
-  HostCannotCancelRegistrationError,
+  OrganizerCannotCancelRegistrationError,
   UnauthorizedCommentDeletionError,
   MomentNotFoundError,
 } from "@/domain/errors";
@@ -363,7 +363,7 @@ describe("Security — RBAC", () => {
       ).rejects.toThrow(UnauthorizedRegistrationActionError);
     });
 
-    it("should throw HostCannotCancelRegistrationError when a HOST tries to cancel their own registration", async () => {
+    it("should throw OrganizerCannotCancelRegistrationError when a HOST tries to cancel their own registration", async () => {
       const registrationRepo = createMockRegistrationRepository({
         findById: vi.fn().mockResolvedValue(
           makeRegistration({ userId: "host-user", status: "REGISTERED" })
@@ -387,7 +387,7 @@ describe("Security — RBAC", () => {
             circleRepository: circleRepo,
           }
         )
-      ).rejects.toThrow(HostCannotCancelRegistrationError);
+      ).rejects.toThrow(OrganizerCannotCancelRegistrationError);
     });
 
     it("should allow a PLAYER to cancel their own registration", async () => {

--- a/src/domain/usecases/__tests__/security/co-host-authorization.test.ts
+++ b/src/domain/usecases/__tests__/security/co-host-authorization.test.ts
@@ -1,0 +1,381 @@
+/**
+ * Tests de sécurité RBAC — feature co-organisateurs (CO_HOST)
+ *
+ * Vérifie la matrice d'autorisation introduite par la feature co-organisateurs :
+ * - Un CO_HOST a les droits de gestion étendus (créer/éditer événements, approuver inscriptions...)
+ * - Un CO_HOST ne peut pas supprimer la Communauté (D3), gérer Stripe (D15),
+ *   annuler sa propre inscription (D16), ni promouvoir/rétrograder d'autres membres (D3)
+ * - Un membre PENDING n'a pas les droits d'Organisateur même avec rôle CO_HOST (D17)
+ * - Un PLAYER PENDING ne peut pas être promu (D22)
+ * - La promotion/rétrogradation modifie immédiatement les droits effectifs
+ */
+
+import { describe, it, expect, vi } from "vitest";
+
+import { createMoment } from "@/domain/usecases/create-moment";
+import { updateMoment } from "@/domain/usecases/update-moment";
+import { publishMoment } from "@/domain/usecases/publish-moment";
+import { deleteCircle } from "@/domain/usecases/delete-circle";
+import { onboardStripeConnect } from "@/domain/usecases/onboard-stripe-connect";
+import { cancelRegistration } from "@/domain/usecases/cancel-registration";
+import { promoteToCoHost } from "@/domain/usecases/promote-to-co-host";
+import { demoteFromCoHost } from "@/domain/usecases/demote-from-co-host";
+import { approveMomentRegistration } from "@/domain/usecases/approve-moment-registration";
+import { updateCircle } from "@/domain/usecases/update-circle";
+
+import {
+  UnauthorizedCircleActionError,
+  UnauthorizedMomentActionError,
+  OrganizerCannotCancelRegistrationError,
+  CannotPromotePendingMemberError,
+} from "@/domain/errors";
+
+import {
+  createMockCircleRepository,
+  makeCircle,
+  makeMembership,
+} from "../helpers/mock-circle-repository";
+import {
+  createMockMomentRepository,
+  makeMoment,
+} from "../helpers/mock-moment-repository";
+import {
+  createMockRegistrationRepository,
+  makeRegistration,
+} from "../helpers/mock-registration-repository";
+import { createMockUserRepository } from "../helpers/mock-user-repository";
+import { createMockPaymentService } from "../helpers/mock-payment-service";
+
+const CIRCLE_ID = "circle-1";
+const MOMENT_ID = "moment-1";
+const HOST_ID = "host-user";
+const CO_HOST_ID = "co-host-user";
+const PLAYER_ID = "player-user";
+
+// ─────────────────────────────────────────────────────────────
+// CO_HOST a les mêmes droits qu'un HOST sur les actions standard
+// ─────────────────────────────────────────────────────────────
+
+describe("CO_HOST security — actions autorisées (D13)", () => {
+  it("should allow a CO_HOST ACTIVE to create a Moment", async () => {
+    const circleRepo = createMockCircleRepository({
+      findMembership: vi.fn().mockResolvedValue(
+        makeMembership({ userId: CO_HOST_ID, role: "CO_HOST", status: "ACTIVE" })
+      ),
+      findById: vi.fn().mockResolvedValue(makeCircle()),
+    });
+    const momentRepo = createMockMomentRepository({
+      slugExists: vi.fn().mockResolvedValue(false),
+    });
+
+    await expect(
+      createMoment(
+        {
+          circleId: CIRCLE_ID,
+          userId: CO_HOST_ID,
+          title: "Test",
+          description: "d",
+          startsAt: new Date(Date.now() + 3600_000),
+          endsAt: null,
+          locationType: "ONLINE",
+          locationName: null,
+          locationAddress: null,
+          videoLink: "https://meet.example.com",
+          capacity: null,
+          price: 0,
+          currency: "EUR",
+          refundable: true,
+          requiresApproval: false,
+        },
+        {
+          momentRepository: momentRepo,
+          circleRepository: circleRepo,
+          registrationRepository: createMockRegistrationRepository(),
+        }
+      )
+    ).resolves.toBeDefined();
+  });
+
+  it("should allow a CO_HOST ACTIVE to approve a moment registration", async () => {
+    const circleRepo = createMockCircleRepository({
+      findById: vi.fn().mockResolvedValue(makeCircle()),
+      findMembership: vi.fn().mockResolvedValue(
+        makeMembership({ userId: CO_HOST_ID, role: "CO_HOST", status: "ACTIVE" })
+      ),
+    });
+    const registration = makeRegistration({
+      status: "PENDING_APPROVAL",
+      userId: PLAYER_ID,
+      momentId: MOMENT_ID,
+    });
+    const momentRepo = createMockMomentRepository({
+      findById: vi.fn().mockResolvedValue(makeMoment({ id: MOMENT_ID })),
+    });
+    const registrationRepo = createMockRegistrationRepository({
+      findById: vi.fn().mockResolvedValue(registration),
+      countByMomentIdAndStatus: vi.fn().mockResolvedValue(0),
+      update: vi.fn().mockResolvedValue({ ...registration, status: "REGISTERED" }),
+    });
+
+    await expect(
+      approveMomentRegistration(
+        { registrationId: registration.id, hostUserId: CO_HOST_ID },
+        {
+          registrationRepository: registrationRepo,
+          momentRepository: momentRepo,
+          circleRepository: circleRepo,
+        }
+      )
+    ).resolves.toBeDefined();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// CO_HOST — actions refusées
+// ─────────────────────────────────────────────────────────────
+
+describe("CO_HOST security — actions réservées au HOST (D3, D15)", () => {
+  it("should throw when a CO_HOST tries to delete the Circle (D3)", async () => {
+    const circleRepo = createMockCircleRepository({
+      findById: vi.fn().mockResolvedValue(makeCircle()),
+      findMembership: vi.fn().mockResolvedValue(
+        makeMembership({ userId: CO_HOST_ID, role: "CO_HOST", status: "ACTIVE" })
+      ),
+    });
+
+    await expect(
+      deleteCircle(
+        { circleId: CIRCLE_ID, userId: CO_HOST_ID },
+        { circleRepository: circleRepo }
+      )
+    ).rejects.toThrow(UnauthorizedCircleActionError);
+  });
+
+  it("should throw when a CO_HOST tries to onboard Stripe Connect (D15)", async () => {
+    const circleRepo = createMockCircleRepository({
+      findById: vi.fn().mockResolvedValue(makeCircle()),
+      findMembership: vi.fn().mockResolvedValue(
+        makeMembership({ userId: CO_HOST_ID, role: "CO_HOST", status: "ACTIVE" })
+      ),
+    });
+
+    await expect(
+      onboardStripeConnect(
+        { circleId: CIRCLE_ID, userId: CO_HOST_ID, returnUrl: "https://example.com/r", refreshUrl: "https://example.com/rf" },
+        {
+          circleRepository: circleRepo,
+          paymentService: createMockPaymentService(),
+        }
+      )
+    ).rejects.toThrow(UnauthorizedCircleActionError);
+  });
+
+  it("should throw when a CO_HOST tries to cancel their own registration (D16)", async () => {
+    const registration = makeRegistration({
+      userId: CO_HOST_ID,
+      momentId: MOMENT_ID,
+      status: "REGISTERED",
+    });
+    const momentRepo = createMockMomentRepository({
+      findById: vi.fn().mockResolvedValue(makeMoment({ circleId: CIRCLE_ID })),
+    });
+    const circleRepo = createMockCircleRepository({
+      findMembership: vi.fn().mockResolvedValue(
+        makeMembership({ userId: CO_HOST_ID, role: "CO_HOST", status: "ACTIVE" })
+      ),
+    });
+    const registrationRepo = createMockRegistrationRepository({
+      findById: vi.fn().mockResolvedValue(registration),
+    });
+
+    await expect(
+      cancelRegistration(
+        { registrationId: registration.id, userId: CO_HOST_ID },
+        {
+          registrationRepository: registrationRepo,
+          momentRepository: momentRepo,
+          circleRepository: circleRepo,
+        }
+      )
+    ).rejects.toThrow(OrganizerCannotCancelRegistrationError);
+  });
+
+  it("should throw when a CO_HOST tries to promote another PLAYER", async () => {
+    const circleRepo = createMockCircleRepository({
+      findMembership: vi.fn().mockResolvedValue(
+        makeMembership({ userId: CO_HOST_ID, role: "CO_HOST", status: "ACTIVE" })
+      ),
+    });
+
+    await expect(
+      promoteToCoHost(
+        { circleId: CIRCLE_ID, hostUserId: CO_HOST_ID, targetUserId: PLAYER_ID },
+        {
+          circleRepository: circleRepo,
+          userRepository: createMockUserRepository(),
+        }
+      )
+    ).rejects.toThrow(UnauthorizedCircleActionError);
+  });
+
+  it("should throw when a CO_HOST tries to demote another CO_HOST", async () => {
+    const circleRepo = createMockCircleRepository({
+      findMembership: vi.fn().mockResolvedValue(
+        makeMembership({ userId: CO_HOST_ID, role: "CO_HOST", status: "ACTIVE" })
+      ),
+    });
+
+    await expect(
+      demoteFromCoHost(
+        { circleId: CIRCLE_ID, hostUserId: CO_HOST_ID, targetUserId: "other-co-host" },
+        {
+          circleRepository: circleRepo,
+          userRepository: createMockUserRepository(),
+        }
+      )
+    ).rejects.toThrow(UnauthorizedCircleActionError);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// Statut PENDING — aucun droit (D17)
+// ─────────────────────────────────────────────────────────────
+
+describe("CO_HOST security — statut PENDING (D17)", () => {
+  it("should throw when a PENDING CO_HOST tries to create a Moment", async () => {
+    const circleRepo = createMockCircleRepository({
+      findMembership: vi.fn().mockResolvedValue(
+        makeMembership({ userId: CO_HOST_ID, role: "CO_HOST", status: "PENDING" })
+      ),
+    });
+
+    await expect(
+      createMoment(
+        {
+          circleId: CIRCLE_ID,
+          userId: CO_HOST_ID,
+          title: "Test",
+          description: "d",
+          startsAt: new Date(Date.now() + 3600_000),
+          endsAt: null,
+          locationType: "ONLINE",
+          locationName: null,
+          locationAddress: null,
+          videoLink: "https://meet.example.com",
+          capacity: null,
+          price: 0,
+          currency: "EUR",
+          refundable: true,
+          requiresApproval: false,
+        },
+        {
+          momentRepository: createMockMomentRepository(),
+          circleRepository: circleRepo,
+          registrationRepository: createMockRegistrationRepository(),
+        }
+      )
+    ).rejects.toThrow(UnauthorizedMomentActionError);
+  });
+
+  it("should throw when a PENDING CO_HOST tries to update the Circle", async () => {
+    const circleRepo = createMockCircleRepository({
+      findById: vi.fn().mockResolvedValue(makeCircle()),
+      findMembership: vi.fn().mockResolvedValue(
+        makeMembership({ userId: CO_HOST_ID, role: "CO_HOST", status: "PENDING" })
+      ),
+    });
+
+    await expect(
+      updateCircle(
+        { circleId: CIRCLE_ID, userId: CO_HOST_ID, name: "Updated" },
+        { circleRepository: circleRepo }
+      )
+    ).rejects.toThrow(UnauthorizedCircleActionError);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// Promotion d'un PENDING refusée (D22)
+// ─────────────────────────────────────────────────────────────
+
+describe("CO_HOST security — D22 (promotion d'un PENDING refusée)", () => {
+  it("should throw CannotPromotePendingMemberError", async () => {
+    const circleRepo = createMockCircleRepository({
+      findMembership: vi
+        .fn()
+        .mockResolvedValueOnce(
+          makeMembership({ userId: HOST_ID, role: "HOST", status: "ACTIVE" })
+        )
+        .mockResolvedValueOnce(
+          makeMembership({ userId: PLAYER_ID, role: "PLAYER", status: "PENDING" })
+        ),
+    });
+
+    await expect(
+      promoteToCoHost(
+        { circleId: CIRCLE_ID, hostUserId: HOST_ID, targetUserId: PLAYER_ID },
+        {
+          circleRepository: circleRepo,
+          userRepository: createMockUserRepository(),
+        }
+      )
+    ).rejects.toThrow(CannotPromotePendingMemberError);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// Acquisition / perte immédiate des droits
+// ─────────────────────────────────────────────────────────────
+
+describe("CO_HOST security — transition de rôle", () => {
+  it("should grant management rights immediately after promotion", async () => {
+    // Simule le state APRÈS promotion : le membre est désormais CO_HOST ACTIVE
+    const circleRepo = createMockCircleRepository({
+      findMembership: vi.fn().mockResolvedValue(
+        makeMembership({ userId: PLAYER_ID, role: "CO_HOST", status: "ACTIVE" })
+      ),
+      findById: vi.fn().mockResolvedValue(makeCircle()),
+    });
+    const momentRepo = createMockMomentRepository({
+      findById: vi.fn().mockResolvedValue(makeMoment({ status: "DRAFT" })),
+    });
+
+    // L'ancien PLAYER peut désormais publier un événement
+    await expect(
+      publishMoment(
+        { momentId: MOMENT_ID, userId: PLAYER_ID },
+        {
+          momentRepository: momentRepo,
+          circleRepository: circleRepo,
+        }
+      )
+    ).resolves.toBeDefined();
+  });
+
+  it("should revoke management rights immediately after demotion", async () => {
+    // Simule le state APRÈS rétrogradation : le membre est redevenu PLAYER
+    const circleRepo = createMockCircleRepository({
+      findMembership: vi.fn().mockResolvedValue(
+        makeMembership({ userId: CO_HOST_ID, role: "PLAYER", status: "ACTIVE" })
+      ),
+    });
+    const momentRepo = createMockMomentRepository({
+      findById: vi.fn().mockResolvedValue(makeMoment({ status: "DRAFT" })),
+    });
+
+    await expect(
+      updateMoment(
+        {
+          momentId: MOMENT_ID,
+          userId: CO_HOST_ID,
+          title: "Updated",
+        },
+        {
+          momentRepository: momentRepo,
+          circleRepository: circleRepo,
+          registrationRepository: createMockRegistrationRepository(),
+        }
+      )
+    ).rejects.toThrow(UnauthorizedMomentActionError);
+  });
+});

--- a/src/domain/usecases/__tests__/security/co-host-authorization.test.ts
+++ b/src/domain/usecases/__tests__/security/co-host-authorization.test.ts
@@ -161,7 +161,7 @@ describe("CO_HOST security — actions réservées au HOST (D3, D15)", () => {
 
     await expect(
       onboardStripeConnect(
-        { circleId: CIRCLE_ID, userId: CO_HOST_ID, returnUrl: "https://example.com/r", refreshUrl: "https://example.com/rf" },
+        { circleId: CIRCLE_ID, userId: CO_HOST_ID, returnUrl: "https://example.com/r" },
         {
           circleRepository: circleRepo,
           paymentService: createMockPaymentService(),

--- a/src/domain/usecases/add-moment-attachment.ts
+++ b/src/domain/usecases/add-moment-attachment.ts
@@ -4,6 +4,7 @@ import {
   MAX_ATTACHMENT_SIZE_BYTES,
   ALLOWED_ATTACHMENT_CONTENT_TYPES,
 } from "@/domain/models/moment-attachment";
+import { isActiveOrganizer } from "@/domain/models/circle";
 import type { MomentAttachmentRepository } from "@/domain/ports/repositories/moment-attachment-repository";
 import type { MomentRepository } from "@/domain/ports/repositories/moment-repository";
 import type { CircleRepository } from "@/domain/ports/repositories/circle-repository";
@@ -60,7 +61,7 @@ export async function addMomentAttachment(
     attachmentRepository.countByMoment(input.momentId),
   ]);
 
-  if (!membership || membership.role !== "HOST") {
+  if (!isActiveOrganizer(membership)) {
     throw new UnauthorizedMomentActionError();
   }
   if (count >= MAX_ATTACHMENTS_PER_MOMENT) {

--- a/src/domain/usecases/approve-circle-membership.ts
+++ b/src/domain/usecases/approve-circle-membership.ts
@@ -1,4 +1,5 @@
 import type { CircleMembership } from "@/domain/models/circle";
+import { isActiveOrganizer } from "@/domain/models/circle";
 import type { CircleRepository } from "@/domain/ports/repositories/circle-repository";
 import {
   UnauthorizedCircleActionError,
@@ -22,12 +23,12 @@ export async function approveCircleMembership(
 ): Promise<CircleMembership> {
   const { circleRepository } = deps;
 
-  // 1. Vérifier que l'appelant est HOST du Circle
-  const hostMembership = await circleRepository.findMembership(
+  // 1. Vérifier que l'appelant est Organisateur ACTIF du Circle (HOST ou CO_HOST)
+  const callerMembership = await circleRepository.findMembership(
     input.circleId,
     input.hostUserId
   );
-  if (!hostMembership || hostMembership.role !== "HOST" || hostMembership.status !== "ACTIVE") {
+  if (!isActiveOrganizer(callerMembership)) {
     throw new UnauthorizedCircleActionError(input.hostUserId, input.circleId);
   }
 

--- a/src/domain/usecases/approve-moment-registration.ts
+++ b/src/domain/usecases/approve-moment-registration.ts
@@ -1,4 +1,5 @@
 import type { Registration } from "@/domain/models/registration";
+import { isActiveOrganizer } from "@/domain/models/circle";
 import type { RegistrationRepository } from "@/domain/ports/repositories/registration-repository";
 import type { MomentRepository } from "@/domain/ports/repositories/moment-repository";
 import type { CircleRepository } from "@/domain/ports/repositories/circle-repository";
@@ -48,11 +49,11 @@ export async function approveMomentRegistration(
     throw new RegistrationNotFoundError(input.registrationId);
   }
 
-  const hostMembership = await circleRepository.findMembership(
+  const callerMembership = await circleRepository.findMembership(
     moment.circleId,
     input.hostUserId
   );
-  if (!hostMembership || hostMembership.role !== "HOST" || hostMembership.status !== "ACTIVE") {
+  if (!isActiveOrganizer(callerMembership)) {
     throw new UnauthorizedCircleActionError(input.hostUserId, moment.circleId);
   }
 

--- a/src/domain/usecases/cancel-registration.ts
+++ b/src/domain/usecases/cancel-registration.ts
@@ -1,4 +1,5 @@
 import type { Registration } from "@/domain/models/registration";
+import { isOrganizerRole } from "@/domain/models/circle";
 import type { RegistrationRepository } from "@/domain/ports/repositories/registration-repository";
 import type { MomentRepository } from "@/domain/ports/repositories/moment-repository";
 import type { CircleRepository } from "@/domain/ports/repositories/circle-repository";
@@ -7,7 +8,7 @@ import { refundRegistration } from "./refund-registration";
 import {
   RegistrationNotFoundError,
   UnauthorizedRegistrationActionError,
-  HostCannotCancelRegistrationError,
+  OrganizerCannotCancelRegistrationError,
 } from "@/domain/errors";
 
 type CancelRegistrationInput = {
@@ -44,15 +45,16 @@ export async function cancelRegistration(
     throw new UnauthorizedRegistrationActionError();
   }
 
-  // A Host cannot cancel their own registration
+  // An organizer (Host or Co-Host) cannot cancel their own registration
+  // to an event of the Community they organize (D16)
   const moment = await momentRepository.findById(registration.momentId);
   if (moment) {
     const membership = await circleRepository.findMembership(
       moment.circleId,
       input.userId
     );
-    if (membership?.role === "HOST") {
-      throw new HostCannotCancelRegistrationError();
+    if (membership && isOrganizerRole(membership.role)) {
+      throw new OrganizerCannotCancelRegistrationError();
     }
   }
 

--- a/src/domain/usecases/create-moment.ts
+++ b/src/domain/usecases/create-moment.ts
@@ -1,4 +1,5 @@
 import type { Moment, LocationType, CoverImageAttribution } from "@/domain/models/moment";
+import { isActiveOrganizer } from "@/domain/models/circle";
 import type { MomentRepository } from "@/domain/ports/repositories/moment-repository";
 import type { CircleRepository } from "@/domain/ports/repositories/circle-repository";
 import type { RegistrationRepository } from "@/domain/ports/repositories/registration-repository";
@@ -53,7 +54,7 @@ export async function createMoment(
     input.userId
   );
 
-  if (!membership || membership.role !== "HOST") {
+  if (!isActiveOrganizer(membership)) {
     throw new UnauthorizedMomentActionError();
   }
 

--- a/src/domain/usecases/delete-comment.ts
+++ b/src/domain/usecases/delete-comment.ts
@@ -1,3 +1,4 @@
+import { isActiveOrganizer } from "@/domain/models/circle";
 import type { CommentRepository } from "@/domain/ports/repositories/comment-repository";
 import type { MomentRepository } from "@/domain/ports/repositories/moment-repository";
 import type { CircleRepository } from "@/domain/ports/repositories/circle-repository";
@@ -32,7 +33,7 @@ export async function deleteComment(
     throw new CommentNotFoundError(input.commentId);
   }
 
-  // Check authorization: author or host can delete
+  // Check authorization: author or organizer (HOST or CO_HOST, ACTIVE) can delete
   const isAuthor = comment.userId === input.userId;
   if (!isAuthor) {
     const moment = await momentRepository.findById(comment.momentId);
@@ -43,7 +44,7 @@ export async function deleteComment(
       moment.circleId,
       input.userId
     );
-    if (membership?.role !== "HOST") {
+    if (!isActiveOrganizer(membership)) {
       throw new UnauthorizedCommentDeletionError();
     }
   }

--- a/src/domain/usecases/delete-moment.ts
+++ b/src/domain/usecases/delete-moment.ts
@@ -1,4 +1,5 @@
 import type { MomentRepository } from "@/domain/ports/repositories/moment-repository";
+import { isActiveOrganizer } from "@/domain/models/circle";
 import type { CircleRepository } from "@/domain/ports/repositories/circle-repository";
 import type { RegistrationRepository } from "@/domain/ports/repositories/registration-repository";
 import type { PaymentService } from "@/domain/ports/services/payment-service";
@@ -37,7 +38,7 @@ export async function deleteMoment(
     input.userId
   );
 
-  if (!membership || membership.role !== "HOST") {
+  if (!isActiveOrganizer(membership)) {
     throw new UnauthorizedMomentActionError();
   }
 

--- a/src/domain/usecases/demote-from-co-host.ts
+++ b/src/domain/usecases/demote-from-co-host.ts
@@ -20,7 +20,7 @@ type DemoteFromCoHostDeps = {
   userRepository: UserRepository;
   emailService?: EmailService;
   emailStrings?: {
-    demoted: () => Promise<{
+    demoted: (args: { circleName: string }) => Promise<{
       subject: string;
       heading: string;
       intro: string;
@@ -84,7 +84,7 @@ export async function demoteFromCoHost(
       if (!targetUser || !circle) {
         if (!circle) throw new CircleNotFoundError(input.circleId);
       } else {
-        const strings = await emailStrings.demoted();
+        const strings = await emailStrings.demoted({ circleName: circle.name });
         await emailService.sendCoHostDemoted({
           to: targetUser.email,
           recipientName: targetUser.firstName ?? targetUser.email,

--- a/src/domain/usecases/demote-from-co-host.ts
+++ b/src/domain/usecases/demote-from-co-host.ts
@@ -1,0 +1,103 @@
+import type { CircleMembership } from "@/domain/models/circle";
+import type { CircleRepository } from "@/domain/ports/repositories/circle-repository";
+import type { UserRepository } from "@/domain/ports/repositories/user-repository";
+import type { EmailService } from "@/domain/ports/services/email-service";
+import {
+  UnauthorizedCircleActionError,
+  NotMemberOfCircleError,
+  InvalidDemotionTargetError,
+  CircleNotFoundError,
+} from "@/domain/errors";
+
+type DemoteFromCoHostInput = {
+  circleId: string;
+  hostUserId: string;
+  targetUserId: string;
+};
+
+type DemoteFromCoHostDeps = {
+  circleRepository: CircleRepository;
+  userRepository: UserRepository;
+  emailService?: EmailService;
+  emailStrings?: {
+    demoted: () => Promise<{
+      subject: string;
+      heading: string;
+      intro: string;
+      newRoleLabel: string;
+      registrationsNote: string;
+      ctaLabel: string;
+      footer: string;
+      preferencesLink: string;
+    }>;
+  };
+};
+
+export async function demoteFromCoHost(
+  input: DemoteFromCoHostInput,
+  deps: DemoteFromCoHostDeps
+): Promise<CircleMembership> {
+  const { circleRepository, userRepository, emailService, emailStrings } = deps;
+
+  // 1. Seul le HOST principal peut rétrograder (D3)
+  const callerMembership = await circleRepository.findMembership(
+    input.circleId,
+    input.hostUserId
+  );
+  if (
+    !callerMembership ||
+    callerMembership.role !== "HOST" ||
+    callerMembership.status !== "ACTIVE"
+  ) {
+    throw new UnauthorizedCircleActionError(input.hostUserId, input.circleId);
+  }
+
+  // 2. Charger la membership de la cible
+  const targetMembership = await circleRepository.findMembership(
+    input.circleId,
+    input.targetUserId
+  );
+  if (!targetMembership) {
+    throw new NotMemberOfCircleError(input.circleId);
+  }
+
+  // 3. Seul un CO_HOST peut être rétrogradé
+  if (targetMembership.role !== "CO_HOST") {
+    throw new InvalidDemotionTargetError(targetMembership.role);
+  }
+
+  // 4. Rétrogradation
+  const updated = await circleRepository.updateMembershipRole(
+    input.circleId,
+    input.targetUserId,
+    "PLAYER"
+  );
+
+  // 5. Email de rétrogradation (D19) — best-effort
+  if (emailService && emailStrings) {
+    try {
+      const [targetUser, circle] = await Promise.all([
+        userRepository.findById(input.targetUserId),
+        circleRepository.findById(input.circleId),
+      ]);
+
+      if (!targetUser || !circle) {
+        if (!circle) throw new CircleNotFoundError(input.circleId);
+      } else {
+        const strings = await emailStrings.demoted();
+        await emailService.sendCoHostDemoted({
+          to: targetUser.email,
+          recipientName: targetUser.firstName ?? targetUser.email,
+          circleName: circle.name,
+          circleSlug: circle.slug,
+          circleCoverImage: circle.coverImage,
+          strings,
+        });
+      }
+    } catch {
+      // L'échec d'envoi d'email ne bloque pas la rétrogradation en base.
+    }
+  }
+
+  return updated;
+}

--- a/src/domain/usecases/get-moment-registrations.ts
+++ b/src/domain/usecases/get-moment-registrations.ts
@@ -1,4 +1,5 @@
 import type { RegistrationWithUser } from "@/domain/models/registration";
+import { isActiveOrganizer } from "@/domain/models/circle";
 import type { MomentRepository } from "@/domain/ports/repositories/moment-repository";
 import type { CircleRepository } from "@/domain/ports/repositories/circle-repository";
 import type { RegistrationRepository } from "@/domain/ports/repositories/registration-repository";
@@ -39,7 +40,7 @@ export async function getMomentRegistrations(
     moment.circleId,
     input.userId
   );
-  if (!membership || membership.role !== "HOST") {
+  if (!isActiveOrganizer(membership)) {
     throw new UnauthorizedMomentActionError();
   }
 

--- a/src/domain/usecases/promote-to-co-host.ts
+++ b/src/domain/usecases/promote-to-co-host.ts
@@ -1,0 +1,119 @@
+import type { CircleMembership } from "@/domain/models/circle";
+import type { CircleRepository } from "@/domain/ports/repositories/circle-repository";
+import type { UserRepository } from "@/domain/ports/repositories/user-repository";
+import type { EmailService } from "@/domain/ports/services/email-service";
+import {
+  UnauthorizedCircleActionError,
+  NotMemberOfCircleError,
+  CannotPromotePendingMemberError,
+  InvalidPromotionTargetError,
+  CircleNotFoundError,
+} from "@/domain/errors";
+
+type PromoteToCoHostInput = {
+  circleId: string;
+  hostUserId: string;
+  targetUserId: string;
+};
+
+type PromoteToCoHostDeps = {
+  circleRepository: CircleRepository;
+  userRepository: UserRepository;
+  emailService?: EmailService;
+  emailStrings?: {
+    promotedBy: (inviterName: string) => Promise<{
+      subject: string;
+      heading: string;
+      intro: string;
+      rightsTitle: string;
+      rightCreateEvents: string;
+      rightManageRegistrations: string;
+      rightUpdateCircle: string;
+      rightBroadcast: string;
+      rightReceiveNotifications: string;
+      limitsNote: string;
+      ctaLabel: string;
+      footer: string;
+      leaveLink: string;
+    }>;
+  };
+};
+
+export async function promoteToCoHost(
+  input: PromoteToCoHostInput,
+  deps: PromoteToCoHostDeps
+): Promise<CircleMembership> {
+  const { circleRepository, userRepository, emailService, emailStrings } = deps;
+
+  // 1. Seul le HOST principal peut promouvoir (D3)
+  const callerMembership = await circleRepository.findMembership(
+    input.circleId,
+    input.hostUserId
+  );
+  if (
+    !callerMembership ||
+    callerMembership.role !== "HOST" ||
+    callerMembership.status !== "ACTIVE"
+  ) {
+    throw new UnauthorizedCircleActionError(input.hostUserId, input.circleId);
+  }
+
+  // 2. Charger la membership de la cible
+  const targetMembership = await circleRepository.findMembership(
+    input.circleId,
+    input.targetUserId
+  );
+  if (!targetMembership) {
+    throw new NotMemberOfCircleError(input.circleId);
+  }
+
+  // 3. Guard D22 : uniquement les membres ACTIVE peuvent être promus
+  if (targetMembership.status !== "ACTIVE") {
+    throw new CannotPromotePendingMemberError();
+  }
+
+  // 4. Seul un PLAYER peut être promu en CO_HOST
+  if (targetMembership.role !== "PLAYER") {
+    throw new InvalidPromotionTargetError(targetMembership.role);
+  }
+
+  // 5. Promotion
+  const updated = await circleRepository.updateMembershipRole(
+    input.circleId,
+    input.targetUserId,
+    "CO_HOST"
+  );
+
+  // 6. Email de promotion (D19) — best-effort, n'annule pas la promotion en cas d'échec
+  if (emailService && emailStrings) {
+    try {
+      const [targetUser, inviter, circle] = await Promise.all([
+        userRepository.findById(input.targetUserId),
+        userRepository.findById(input.hostUserId),
+        circleRepository.findById(input.circleId),
+      ]);
+
+      if (!targetUser || !inviter || !circle) {
+        if (!circle) throw new CircleNotFoundError(input.circleId);
+      } else {
+        const inviterName =
+          [inviter.firstName, inviter.lastName].filter(Boolean).join(" ") ||
+          inviter.email;
+        const strings = await emailStrings.promotedBy(inviterName);
+        await emailService.sendCoHostPromoted({
+          to: targetUser.email,
+          recipientName: targetUser.firstName ?? targetUser.email,
+          inviterName,
+          circleName: circle.name,
+          circleSlug: circle.slug,
+          circleCoverImage: circle.coverImage,
+          strings,
+        });
+      }
+    } catch {
+      // L'échec d'envoi d'email ne bloque pas la promotion en base.
+    }
+  }
+
+  return updated;
+}

--- a/src/domain/usecases/promote-to-co-host.ts
+++ b/src/domain/usecases/promote-to-co-host.ts
@@ -21,7 +21,10 @@ type PromoteToCoHostDeps = {
   userRepository: UserRepository;
   emailService?: EmailService;
   emailStrings?: {
-    promotedBy: (inviterName: string) => Promise<{
+    promotedBy: (args: {
+      inviterName: string;
+      circleName: string;
+    }) => Promise<{
       subject: string;
       heading: string;
       intro: string;
@@ -99,7 +102,10 @@ export async function promoteToCoHost(
         const inviterName =
           [inviter.firstName, inviter.lastName].filter(Boolean).join(" ") ||
           inviter.email;
-        const strings = await emailStrings.promotedBy(inviterName);
+        const strings = await emailStrings.promotedBy({
+          inviterName,
+          circleName: circle.name,
+        });
         await emailService.sendCoHostPromoted({
           to: targetUser.email,
           recipientName: targetUser.firstName ?? targetUser.email,

--- a/src/domain/usecases/publish-moment.ts
+++ b/src/domain/usecases/publish-moment.ts
@@ -1,4 +1,5 @@
 import type { Moment } from "@/domain/models/moment";
+import { isActiveOrganizer } from "@/domain/models/circle";
 import type { MomentRepository } from "@/domain/ports/repositories/moment-repository";
 import type { CircleRepository } from "@/domain/ports/repositories/circle-repository";
 import {
@@ -36,7 +37,7 @@ export async function publishMoment(
     existing.circleId,
     input.userId
   );
-  if (!membership || membership.role !== "HOST") {
+  if (!isActiveOrganizer(membership)) {
     throw new UnauthorizedMomentActionError();
   }
 

--- a/src/domain/usecases/reject-circle-membership.ts
+++ b/src/domain/usecases/reject-circle-membership.ts
@@ -1,3 +1,4 @@
+import { isActiveOrganizer } from "@/domain/models/circle";
 import type { CircleRepository } from "@/domain/ports/repositories/circle-repository";
 import {
   UnauthorizedCircleActionError,
@@ -21,12 +22,12 @@ export async function rejectCircleMembership(
 ): Promise<void> {
   const { circleRepository } = deps;
 
-  // 1. Vérifier que l'appelant est HOST du Circle
-  const hostMembership = await circleRepository.findMembership(
+  // 1. Vérifier que l'appelant est Organisateur ACTIF du Circle (HOST ou CO_HOST)
+  const callerMembership = await circleRepository.findMembership(
     input.circleId,
     input.hostUserId
   );
-  if (!hostMembership || hostMembership.role !== "HOST" || hostMembership.status !== "ACTIVE") {
+  if (!isActiveOrganizer(callerMembership)) {
     throw new UnauthorizedCircleActionError(input.hostUserId, input.circleId);
   }
 

--- a/src/domain/usecases/reject-moment-registration.ts
+++ b/src/domain/usecases/reject-moment-registration.ts
@@ -1,4 +1,5 @@
 import type { Registration } from "@/domain/models/registration";
+import { isActiveOrganizer } from "@/domain/models/circle";
 import type { RegistrationRepository } from "@/domain/ports/repositories/registration-repository";
 import type { MomentRepository } from "@/domain/ports/repositories/moment-repository";
 import type { CircleRepository } from "@/domain/ports/repositories/circle-repository";
@@ -42,11 +43,11 @@ export async function rejectMomentRegistration(
     throw new RegistrationNotFoundError(input.registrationId);
   }
 
-  const hostMembership = await circleRepository.findMembership(
+  const callerMembership = await circleRepository.findMembership(
     moment.circleId,
     input.hostUserId
   );
-  if (!hostMembership || hostMembership.role !== "HOST" || hostMembership.status !== "ACTIVE") {
+  if (!isActiveOrganizer(callerMembership)) {
     throw new UnauthorizedCircleActionError(input.hostUserId, moment.circleId);
   }
 

--- a/src/domain/usecases/remove-circle-member.ts
+++ b/src/domain/usecases/remove-circle-member.ts
@@ -1,3 +1,4 @@
+import { isActiveOrganizer, isOrganizerRole } from "@/domain/models/circle";
 import type { CircleRepository } from "@/domain/ports/repositories/circle-repository";
 import type { RegistrationRepository } from "@/domain/ports/repositories/registration-repository";
 import {
@@ -29,12 +30,12 @@ export async function removeCircleMember(
 ): Promise<RemoveCircleMemberResult> {
   const { circleRepository, registrationRepository } = deps;
 
-  // 1. Vérifie que l'appelant est HOST
+  // 1. Vérifie que l'appelant est Organisateur ACTIF (HOST ou CO_HOST)
   const callerMembership = await circleRepository.findMembership(
     input.circleId,
     input.hostUserId
   );
-  if (!callerMembership || callerMembership.role !== "HOST") {
+  if (!isActiveOrganizer(callerMembership)) {
     throw new UnauthorizedCircleActionError(input.hostUserId, input.circleId);
   }
 
@@ -52,9 +53,16 @@ export async function removeCircleMember(
     throw new NotMemberOfCircleError(input.circleId);
   }
 
-  // 4. On ne peut pas retirer un HOST via cette action
-  if (targetMembership.role === "HOST") {
-    throw new CannotRemoveHostError();
+  // 4. Matrice de retrait (D10 / D11) :
+  //    - HOST peut retirer un CO_HOST et un PLAYER (pas un autre HOST — impossible par contrainte DB)
+  //    - CO_HOST peut retirer uniquement un PLAYER (pas un autre CO_HOST ni un HOST)
+  if (isOrganizerRole(targetMembership.role)) {
+    if (callerMembership!.role !== "HOST") {
+      throw new CannotRemoveHostError();
+    }
+    if (targetMembership.role === "HOST") {
+      throw new CannotRemoveHostError();
+    }
   }
 
   // 5. Annule les inscriptions actives à venir (REGISTERED + WAITLIST)

--- a/src/domain/usecases/remove-moment-attachment.ts
+++ b/src/domain/usecases/remove-moment-attachment.ts
@@ -1,3 +1,4 @@
+import { isActiveOrganizer } from "@/domain/models/circle";
 import type { MomentAttachmentRepository } from "@/domain/ports/repositories/moment-attachment-repository";
 import type { MomentRepository } from "@/domain/ports/repositories/moment-repository";
 import type { CircleRepository } from "@/domain/ports/repositories/circle-repository";
@@ -41,7 +42,7 @@ export async function removeMomentAttachment(
     moment.circleId,
     input.userId
   );
-  if (!membership || membership.role !== "HOST") {
+  if (!isActiveOrganizer(membership)) {
     throw new UnauthorizedMomentActionError();
   }
 

--- a/src/domain/usecases/remove-registration-by-host.ts
+++ b/src/domain/usecases/remove-registration-by-host.ts
@@ -1,4 +1,5 @@
 import type { Registration } from "@/domain/models/registration";
+import { isActiveOrganizer, isOrganizerRole } from "@/domain/models/circle";
 import type { RegistrationRepository } from "@/domain/ports/repositories/registration-repository";
 import type { MomentRepository } from "@/domain/ports/repositories/moment-repository";
 import type { CircleRepository } from "@/domain/ports/repositories/circle-repository";
@@ -51,14 +52,17 @@ export async function removeRegistrationByHost(
     circleRepository.findMembership(moment.circleId, registration.userId),
   ]);
 
-  // 3a. Vérifie que l'appelant est HOST du Circle
-  if (!callerMembership || callerMembership.role !== "HOST") {
+  // 3a. Vérifie que l'appelant est Organisateur ACTIF (HOST ou CO_HOST)
+  if (!isActiveOrganizer(callerMembership)) {
     throw new UnauthorizedCircleActionError(input.hostUserId, moment.circleId);
   }
 
-  // 3b. Empêche de retirer l'inscription d'un autre HOST
-  if (targetMembership?.role === "HOST") {
-    throw new CannotRemoveHostRegistrationError();
+  // 3b. Empêche un CO_HOST de retirer l'inscription d'un autre Organisateur (D11)
+  // Un HOST peut retirer un CO_HOST. La contrainte DB empêche de toute façon deux HOSTs.
+  if (targetMembership && isOrganizerRole(targetMembership.role)) {
+    if (callerMembership!.role !== "HOST") {
+      throw new CannotRemoveHostRegistrationError();
+    }
   }
 
   const wasRegistered = registration.status === "REGISTERED";

--- a/src/domain/usecases/remove-registration-by-host.ts
+++ b/src/domain/usecases/remove-registration-by-host.ts
@@ -1,5 +1,5 @@
 import type { Registration } from "@/domain/models/registration";
-import { isActiveOrganizer, isOrganizerRole } from "@/domain/models/circle";
+import { isActiveOrganizer } from "@/domain/models/circle";
 import type { RegistrationRepository } from "@/domain/ports/repositories/registration-repository";
 import type { MomentRepository } from "@/domain/ports/repositories/moment-repository";
 import type { CircleRepository } from "@/domain/ports/repositories/circle-repository";
@@ -57,12 +57,17 @@ export async function removeRegistrationByHost(
     throw new UnauthorizedCircleActionError(input.hostUserId, moment.circleId);
   }
 
-  // 3b. Empêche un CO_HOST de retirer l'inscription d'un autre Organisateur (D11)
-  // Un HOST peut retirer un CO_HOST. La contrainte DB empêche de toute façon deux HOSTs.
-  if (targetMembership && isOrganizerRole(targetMembership.role)) {
-    if (callerMembership!.role !== "HOST") {
-      throw new CannotRemoveHostRegistrationError();
-    }
+  // 3b. Matrice de protection (D3, D11) :
+  //  - L'inscription d'un HOST est intouchable (contrainte DB = un seul HOST par Circle)
+  //  - L'inscription d'un CO_HOST ne peut être retirée que par le HOST principal
+  if (targetMembership?.role === "HOST") {
+    throw new CannotRemoveHostRegistrationError();
+  }
+  if (
+    targetMembership?.role === "CO_HOST" &&
+    callerMembership!.role !== "HOST"
+  ) {
+    throw new CannotRemoveHostRegistrationError();
   }
 
   const wasRegistered = registration.status === "REGISTERED";

--- a/src/domain/usecases/update-circle.ts
+++ b/src/domain/usecases/update-circle.ts
@@ -1,4 +1,5 @@
 import type { Circle, CircleVisibility, CircleCategory, CoverImageAttribution } from "@/domain/models/circle";
+import { isActiveOrganizer } from "@/domain/models/circle";
 import type { CircleRepository } from "@/domain/ports/repositories/circle-repository";
 import { CircleNotFoundError, UnauthorizedCircleActionError } from "@/domain/errors";
 
@@ -40,7 +41,7 @@ export async function updateCircle(
     input.circleId,
     input.userId
   );
-  if (!membership || membership.role !== "HOST") {
+  if (!isActiveOrganizer(membership)) {
     throw new UnauthorizedCircleActionError(input.userId, input.circleId);
   }
 

--- a/src/domain/usecases/update-moment.ts
+++ b/src/domain/usecases/update-moment.ts
@@ -1,4 +1,5 @@
 import type { Moment, LocationType, MomentStatus, CoverImageAttribution } from "@/domain/models/moment";
+import { isActiveOrganizer } from "@/domain/models/circle";
 import type { MomentRepository } from "@/domain/ports/repositories/moment-repository";
 import type { CircleRepository } from "@/domain/ports/repositories/circle-repository";
 import type { RegistrationRepository } from "@/domain/ports/repositories/registration-repository";
@@ -64,7 +65,7 @@ export async function updateMoment(
     input.userId
   );
 
-  if (!membership || membership.role !== "HOST") {
+  if (!isActiveOrganizer(membership)) {
     throw new UnauthorizedMomentActionError();
   }
 

--- a/src/infrastructure/repositories/prisma-circle-repository.ts
+++ b/src/infrastructure/repositories/prisma-circle-repository.ts
@@ -184,6 +184,18 @@ export const prismaCircleRepository: CircleRepository = {
     return toDomainMembership(record);
   },
 
+  async updateMembershipRole(
+    circleId: string,
+    userId: string,
+    role: CircleMemberRole
+  ): Promise<CircleMembership> {
+    const record = await prisma.circleMembership.update({
+      where: { userId_circleId: { userId, circleId } },
+      data: { role },
+    });
+    return toDomainMembership(record);
+  },
+
   async findPendingMemberships(circleId: string): Promise<CircleMemberWithUser[]> {
     const records = await prisma.circleMembership.findMany({
       where: { circleId, status: "PENDING" },

--- a/src/infrastructure/repositories/prisma-circle-repository.ts
+++ b/src/infrastructure/repositories/prisma-circle-repository.ts
@@ -577,9 +577,10 @@ export const prismaCircleRepository: CircleRepository = {
       orderBy: { joinedAt: "asc" },
     });
 
-    // Tri : HOSTs d'abord, puis PLAYERs — alpha dans chaque groupe
+    // Tri : HOST d'abord, puis CO_HOST, puis PLAYER — alpha dans chaque groupe
+    const roleOrder: Record<string, number> = { HOST: 0, CO_HOST: 1, PLAYER: 2 };
     memberships.sort((a, b) => {
-      if (a.role !== b.role) return a.role === "HOST" ? -1 : 1;
+      if (a.role !== b.role) return roleOrder[a.role] - roleOrder[b.role];
       return a.circle.name.localeCompare(b.circle.name);
     });
 
@@ -587,7 +588,7 @@ export const prismaCircleRepository: CircleRepository = {
       circleSlug: m.circle.slug,
       circleName: m.circle.name,
       circleCover: m.circle.coverImage,
-      role: m.role as "HOST" | "PLAYER",
+      role: m.role,
     }));
   },
 };

--- a/src/infrastructure/repositories/prisma-circle-repository.ts
+++ b/src/infrastructure/repositories/prisma-circle-repository.ts
@@ -368,6 +368,27 @@ export const prismaCircleRepository: CircleRepository = {
     }));
   },
 
+  async findOrganizers(circleId: string): Promise<CircleMemberWithUser[]> {
+    const records = await prisma.circleMembership.findMany({
+      where: { circleId, role: { in: ["HOST", "CO_HOST"] }, status: "ACTIVE" },
+      include: {
+        user: {
+          select: { id: true, firstName: true, lastName: true, email: true, image: true, publicId: true },
+        },
+      },
+      orderBy: { joinedAt: "asc" },
+    });
+    // Tri HOST > CO_HOST (par ordre d'arrivée dans chaque groupe)
+    records.sort((a, b) => {
+      if (a.role === b.role) return 0;
+      return a.role === "HOST" ? -1 : 1;
+    });
+    return records.map((r) => ({
+      ...toDomainMembership(r),
+      user: r.user,
+    }));
+  },
+
   async countMembers(circleId: string): Promise<number> {
     return prisma.circleMembership.count({ where: { circleId, status: "ACTIVE" } });
   },

--- a/src/infrastructure/services/email/resend-email-service.ts
+++ b/src/infrastructure/services/email/resend-email-service.ts
@@ -24,6 +24,8 @@ import type {
   ApprovalNotificationEmailData,
   HostPaidCancellationEmailData,
   OnboardingWelcomeEmailData,
+  CoHostPromotedEmailData,
+  CoHostDemotedEmailData,
 } from "@/domain/ports/services/email-service";
 import { RegistrationConfirmationEmail } from "./templates/registration-confirmation";
 import { WaitlistPromotionEmail } from "./templates/waitlist-promotion";
@@ -44,6 +46,8 @@ import { RegistrationRemovedByHostEmail } from "./templates/registration-removed
 import { ApprovalNotificationEmail } from "./templates/approval-notification";
 import { HostPaidCancellationEmail } from "./templates/host-paid-cancellation";
 import { OnboardingWelcomeEmail } from "./templates/onboarding-welcome";
+import { CoHostPromotedEmail } from "./templates/co-host-promoted";
+import { CoHostDemotedEmail } from "./templates/co-host-demoted";
 
 function getBaseUrl(): string {
   return process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
@@ -413,6 +417,24 @@ export function createResendEmailService(): EmailService {
         replyTo: onboardingWelcomeContent.replyTo,
         subject: onboardingWelcomeContent.subject,
         react: OnboardingWelcomeEmail({ firstName: data.firstName, baseUrl }),
+      });
+    },
+
+    async sendCoHostPromoted(data: CoHostPromotedEmailData): Promise<void> {
+      await send({
+        from,
+        to: data.to,
+        subject: data.strings.subject,
+        react: CoHostPromotedEmail({ ...data, baseUrl }),
+      });
+    },
+
+    async sendCoHostDemoted(data: CoHostDemotedEmailData): Promise<void> {
+      await send({
+        from,
+        to: data.to,
+        subject: data.strings.subject,
+        react: CoHostDemotedEmail({ ...data, baseUrl }),
       });
     },
   };

--- a/src/infrastructure/services/email/templates/co-host-demoted.tsx
+++ b/src/infrastructure/services/email/templates/co-host-demoted.tsx
@@ -1,0 +1,100 @@
+import { Button, Hr, Link, Section, Text } from "@react-email/components";
+import * as React from "react";
+import { EmailLayout } from "./components/email-layout";
+import type { CoHostDemotedEmailData } from "@/domain/ports/services/email-service";
+import { ctaButton, title, headingLg as heading } from "./components/email-styles";
+
+type Props = CoHostDemotedEmailData & {
+  baseUrl: string;
+};
+
+export function CoHostDemotedEmail({
+  circleName,
+  circleSlug,
+  baseUrl,
+  strings,
+}: Props) {
+  const circleUrl = `${baseUrl}/circles/${circleSlug}`;
+
+  return (
+    <EmailLayout preview={strings.subject} footer={strings.footer}>
+      <Text style={title}>{circleName}</Text>
+
+      <Text style={heading}>{strings.heading}</Text>
+      <Text style={paragraph}>{strings.intro}</Text>
+
+      <Section style={roleBox}>
+        <Text style={roleText}>{strings.newRoleLabel}</Text>
+      </Section>
+
+      <Text style={note}>{strings.registrationsNote}</Text>
+
+      <Section style={ctaSection}>
+        <Button
+          style={{ ...ctaButton, background: "transparent", color: "#18181b", border: "1px solid #e4e4e7", backgroundImage: "none" }}
+          href={circleUrl}
+        >
+          {strings.ctaLabel}
+        </Button>
+      </Section>
+
+      <Hr style={divider} />
+      <Text style={preferencesNote}>
+        <Link href={`${baseUrl}/profile`} style={preferencesLink}>
+          {strings.preferencesLink}
+        </Link>
+      </Text>
+    </EmailLayout>
+  );
+}
+
+const paragraph: React.CSSProperties = {
+  fontSize: "14px",
+  color: "#52525b",
+  margin: "0 0 20px 0",
+  lineHeight: "22px",
+};
+
+const roleBox: React.CSSProperties = {
+  backgroundColor: "#f4f4f5",
+  borderRadius: "10px",
+  padding: "14px 20px",
+  marginBottom: "20px",
+  textAlign: "center" as const,
+};
+
+const roleText: React.CSSProperties = {
+  fontSize: "14px",
+  color: "#18181b",
+  fontWeight: 500,
+  margin: 0,
+};
+
+const note: React.CSSProperties = {
+  fontSize: "13px",
+  color: "#71717a",
+  margin: "0 0 24px 0",
+  lineHeight: "20px",
+};
+
+const ctaSection: React.CSSProperties = {
+  textAlign: "center" as const,
+  marginBottom: "16px",
+};
+
+const divider: React.CSSProperties = {
+  borderTop: "1px solid #e4e4e7",
+  margin: "24px 0 16px 0",
+};
+
+const preferencesNote: React.CSSProperties = {
+  fontSize: "12px",
+  color: "#a1a1aa",
+  textAlign: "center" as const,
+  margin: 0,
+};
+
+const preferencesLink: React.CSSProperties = {
+  color: "#a1a1aa",
+  textDecoration: "underline",
+};

--- a/src/infrastructure/services/email/templates/co-host-demoted.tsx
+++ b/src/infrastructure/services/email/templates/co-host-demoted.tsx
@@ -30,10 +30,7 @@ export function CoHostDemotedEmail({
       <Text style={note}>{strings.registrationsNote}</Text>
 
       <Section style={ctaSection}>
-        <Button
-          style={{ ...ctaButton, background: "transparent", color: "#18181b", border: "1px solid #e4e4e7", backgroundImage: "none" }}
-          href={circleUrl}
-        >
+        <Button style={ctaButton} href={circleUrl}>
           {strings.ctaLabel}
         </Button>
       </Section>

--- a/src/infrastructure/services/email/templates/co-host-promoted.tsx
+++ b/src/infrastructure/services/email/templates/co-host-promoted.tsx
@@ -1,0 +1,112 @@
+import { Button, Hr, Link, Section, Text } from "@react-email/components";
+import * as React from "react";
+import { EmailLayout } from "./components/email-layout";
+import type { CoHostPromotedEmailData } from "@/domain/ports/services/email-service";
+import { ctaButton, title, headingLg as heading } from "./components/email-styles";
+
+type Props = CoHostPromotedEmailData & {
+  baseUrl: string;
+};
+
+export function CoHostPromotedEmail({
+  circleName,
+  circleSlug,
+  baseUrl,
+  strings,
+}: Props) {
+  const dashboardUrl = `${baseUrl}/dashboard/circles/${circleSlug}`;
+
+  return (
+    <EmailLayout preview={strings.subject} footer={strings.footer}>
+      <Text style={title}>{circleName}</Text>
+
+      <Text style={heading}>{strings.heading}</Text>
+      <Text style={paragraph}>{strings.intro}</Text>
+
+      <Section style={rightsBox}>
+        <Text style={rightsTitle}>{strings.rightsTitle}</Text>
+        <Text style={rightsItem}>· {strings.rightCreateEvents}</Text>
+        <Text style={rightsItem}>· {strings.rightManageRegistrations}</Text>
+        <Text style={rightsItem}>· {strings.rightUpdateCircle}</Text>
+        <Text style={rightsItem}>· {strings.rightBroadcast}</Text>
+        <Text style={rightsItem}>· {strings.rightReceiveNotifications}</Text>
+      </Section>
+
+      <Text style={limitsNote}>{strings.limitsNote}</Text>
+
+      <Section style={ctaSection}>
+        <Button style={ctaButton} href={dashboardUrl}>
+          {strings.ctaLabel}
+        </Button>
+      </Section>
+
+      <Hr style={divider} />
+      <Text style={leaveNote}>
+        <Link href={`${baseUrl}/circles/${circleSlug}`} style={leaveLink}>
+          {strings.leaveLink}
+        </Link>
+      </Text>
+    </EmailLayout>
+  );
+}
+
+const paragraph: React.CSSProperties = {
+  fontSize: "14px",
+  color: "#52525b",
+  margin: "0 0 20px 0",
+  lineHeight: "22px",
+};
+
+const rightsBox: React.CSSProperties = {
+  backgroundColor: "#f0fdfa",
+  border: "1px solid #99f6e4",
+  borderRadius: "10px",
+  padding: "16px 20px",
+  marginBottom: "20px",
+};
+
+const rightsTitle: React.CSSProperties = {
+  fontSize: "12px",
+  fontWeight: 700,
+  letterSpacing: "0.06em",
+  textTransform: "uppercase" as const,
+  color: "#0d9488",
+  margin: "0 0 10px 0",
+};
+
+const rightsItem: React.CSSProperties = {
+  fontSize: "14px",
+  color: "#18181b",
+  margin: "4px 0",
+  lineHeight: "20px",
+};
+
+const limitsNote: React.CSSProperties = {
+  fontSize: "13px",
+  color: "#71717a",
+  margin: "0 0 24px 0",
+  lineHeight: "20px",
+  fontStyle: "italic",
+};
+
+const ctaSection: React.CSSProperties = {
+  textAlign: "center" as const,
+  marginBottom: "16px",
+};
+
+const divider: React.CSSProperties = {
+  borderTop: "1px solid #e4e4e7",
+  margin: "24px 0 16px 0",
+};
+
+const leaveNote: React.CSSProperties = {
+  fontSize: "12px",
+  color: "#a1a1aa",
+  textAlign: "center" as const,
+  margin: 0,
+};
+
+const leaveLink: React.CSSProperties = {
+  color: "#a1a1aa",
+  textDecoration: "underline",
+};

--- a/tests/e2e/co-host.spec.ts
+++ b/tests/e2e/co-host.spec.ts
@@ -48,12 +48,12 @@ test.describe("Co-organisateurs — UI HOST", () => {
     await expect(page.getByText("Promouvoir en co-organisateur")).toBeVisible();
   });
 
-  test("should show the Propriétaire badge on the Circle HOST", async ({ page }) => {
+  test("should show the single Organisateur badge on the Circle HOST", async ({ page }) => {
     await page.goto(`/fr/dashboard/circles/${SLUGS.CIRCLE}`);
 
     const membersSection = page.locator("#members-section");
-    // Dans le dashboard (variant = "host"), le HOST voit "Propriétaire"
-    await expect(membersSection).toContainText(/Propriétaire/);
+    // Badge unique "Organisateur" pour HOST et CO_HOST, partout (D8 simplifié)
+    await expect(membersSection).toContainText(/Organisateur/);
   });
 });
 
@@ -61,10 +61,7 @@ test.describe("Co-organisateurs — UI public", () => {
   test("should show a single Organisateur badge on the public Circle page", async ({ page }) => {
     await page.goto(`/fr/circles/${SLUGS.CIRCLE}`);
 
-    // D8 : côté public, pas de distinction HOST / CO_HOST — badge unique
-    // L'utilisation de toContainText vérifie que la page affiche bien "Organisateur"
+    // Badge unique "Organisateur" côté public comme dashboard — HOST et CO_HOST confondus
     await expect(page.locator("body")).toContainText(/Organisateur/);
-    // Et ne doit PAS afficher "Propriétaire" côté public
-    await expect(page.locator("body")).not.toContainText(/Propriétaire/);
   });
 });

--- a/tests/e2e/co-host.spec.ts
+++ b/tests/e2e/co-host.spec.ts
@@ -1,0 +1,70 @@
+import { test, expect } from "@playwright/test";
+import { SLUGS, AUTH } from "./fixtures";
+
+/**
+ * Tests E2E — Feature co-organisateurs
+ *
+ * Couvre les parcours UI introduits par la feature CO_HOST, côté HOST :
+ *   - Accès à la liste des membres du Circle côté dashboard
+ *   - Présence du menu contextuel avec l'action "Promouvoir en co-organisateur"
+ *     sur un membre PLAYER ACTIVE
+ *   - Le bouton ne permet pas d'actionner le HOST principal lui-même
+ *
+ * Les scénarios de promotion / rétrogradation avec transition d'état sont
+ * couverts par les tests unitaires (promote-to-co-host.test.ts,
+ * demote-from-co-host.test.ts) et les tests RBAC (co-host-authorization.test.ts).
+ * Les tests E2E se concentrent sur la surface UI.
+ */
+
+test.describe("Co-organisateurs — UI HOST", () => {
+  test.use({ storageState: AUTH.HOST });
+
+  test("should display the members section on the Circle dashboard", async ({ page }) => {
+    await page.goto(`/fr/dashboard/circles/${SLUGS.CIRCLE}`);
+
+    // La section membres est accessible
+    const membersSection = page.locator("#members-section");
+    await expect(membersSection).toBeVisible();
+    await expect(membersSection).toContainText(/Membres/i);
+  });
+
+  test("should show the contextual menu trigger for PLAYER members", async ({ page }) => {
+    await page.goto(`/fr/dashboard/circles/${SLUGS.CIRCLE}`);
+
+    const membersSection = page.locator("#members-section");
+    // Au moins un bouton d'actions doit être présent pour les PLAYERs de la Communauté seed
+    const actionButtons = membersSection.locator('button[aria-label="Actions"]');
+    await expect(actionButtons.first()).toBeVisible();
+  });
+
+  test("should expose the Promote to co-organizer action in the menu", async ({ page }) => {
+    await page.goto(`/fr/dashboard/circles/${SLUGS.CIRCLE}`);
+
+    const membersSection = page.locator("#members-section");
+    const firstActionButton = membersSection.locator('button[aria-label="Actions"]').first();
+    await firstActionButton.click();
+
+    // Le menu ouvre et contient l'action Promouvoir
+    await expect(page.getByText("Promouvoir en co-organisateur")).toBeVisible();
+  });
+
+  test("should show the Propriétaire badge on the Circle HOST", async ({ page }) => {
+    await page.goto(`/fr/dashboard/circles/${SLUGS.CIRCLE}`);
+
+    const membersSection = page.locator("#members-section");
+    // Dans le dashboard (variant = "host"), le HOST voit "Propriétaire"
+    await expect(membersSection).toContainText(/Propriétaire/);
+  });
+});
+
+test.describe("Co-organisateurs — UI public", () => {
+  test("should show a single Organisateur badge on the public Circle page", async ({ page }) => {
+    await page.goto(`/fr/circles/${SLUGS.CIRCLE}`);
+
+    // D8 : côté public, pas de distinction HOST / CO_HOST — badge unique
+    // L'utilisation de toContainText vérifie que la page affiche bien "Organisateur"
+    await expect(page.locator("body")).toContainText(/Organisateur/);
+    // Et ne doit PAS afficher "Propriétaire" côté public
+    await expect(page.locator("body")).not.toContainText(/Propriétaire/);
+  });
+});


### PR DESCRIPTION
## Summary

Implémentation complète de la feature **co-organisateurs** (rôle `CO_HOST` entre HOST et PLAYER) conformément à la spec `spec/features/co-organisateurs.md` (23 décisions figées D1-D23, PR #399).

Un `CO_HOST` peut créer/éditer/publier/supprimer des événements, gérer les inscriptions, modifier la Communauté et diffuser des messages. Les actions propriétaire (supprimer la Communauté, gérer Stripe Connect, promouvoir/rétrograder, retirer un autre organisateur) restent réservées au HOST.

**18 commits** structurés par étapes du plan d'implémentation.

## Changements clés

**Domaine**
- Enum `CircleMemberRole` étendu à `"HOST" | "CO_HOST" | "PLAYER"`
- Helpers `isOrganizerRole` et `isActiveOrganizer` (D17 — check rôle + status ACTIVE unifié)
- 17+ checks d'autorisation adaptés via `isActiveOrganizer`
- Nouveaux usecases `promoteToCoHost` (guard D22 : PENDING refusé) et `demoteFromCoHost`
- Matrice de retrait D10/D11 : HOST retire n'importe qui sauf un autre HOST, CO_HOST retire uniquement des PLAYER

**Infrastructure**
- `findOrganizers(circleId)` au port `CircleRepository` — 11 appels migrés depuis `findMembersByRole("HOST")`
- Emails D19 `co-host-promoted` et `co-host-demoted` (templates React + clés i18n FR/EN)

**UI**
- Badge unique **Organisateur** (Crown rose) pour HOST et CO_HOST, partout (dashboard + public)
- Menu contextuel étendu dans `circle-members-list.tsx` : Promouvoir / Rétrograder / Retirer selon la matrice
- Rename prop `isHost` → `isOrganizer` (85 occurrences, 15 fichiers — TypeScript a attrapé)
- "Organisé par" : **HOST principal** sur la page Communauté, **créateur de l'événement** sur la page événement (fallback HOST si créateur n'est plus organisateur)
- Bouton Supprimer la Communauté masqué aux CO_HOST
- Section Stripe Connect de l'édition Communauté masquée aux CO_HOST
- Page Aide : nouvelle section dédiée Co-organisateurs (sidebar Organisateur)

**Tests**
- 17 tests unitaires pour les 2 nouveaux usecases
- 12 tests RBAC dédiés (`co-host-authorization.test.ts`)
- 5 tests E2E Playwright (smoke UI)
- 967 tests passent au total (88 fichiers)

## Test plan

- [ ] Attendre CI vert
- [ ] **`pnpm db:push:prod`** avant merge (schema Prisma modifié — enum `CircleMemberRole` étendu, règle absolue N°1-BIS)
- [ ] Merge après CI + db:push:prod

## Décisions implémentées

D1 (nom `CO_HOST`), D2 (mêmes droits que HOST), D3 (exceptions HOST), D4 (affichage), D5 (`createdById` trace historique), D6 (visibilité UI), D7 (pas de limite nb CO_HOST), D8 (badge unique public), D9 (CO_HOST peut quitter), D10 (HOST retire CO_HOST directement), D11 (CO_HOST ne retire pas un autre CO_HOST), D12 (promotion uniquement, pas d'invitation directe), D13 (toutes les notifs organisateur au CO_HOST), D14 (CO_HOST peut broadcast), D15 (Stripe HOST-only), D16 (CO_HOST ne peut pas annuler sa propre inscription), D17 (check `isActiveOrganizer` uniformisé), D18 (transferOwnership reporté), D19 (emails promotion/rétrogradation), D20 (rename `isHost`), D21 (inscriptions indépendantes du rôle), D22 (pas de promotion d'un PENDING), D23 (profil public badge unifié).

🤖 Generated with [Claude Code](https://claude.com/claude-code)