### PR TITLE
chore(cron): passer transition-past-moments de 5 min à 30 min

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -23,7 +23,7 @@
     },
     {
       "path": "/api/cron/transition-past-moments",
-      "schedule": "*/5 * * * *"
+      "schedule": "*/30 * * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Les événements sont créés par tranches de 30 min, donc exécuter le job `transitionPastMoments` toutes les 5 min est surdimensionné. Latence maximale de 30 min est acceptable pour faire basculer un événement en statut `PAST`.

Changement de cadence : `*/5 * * * *` → `*/30 * * * *` (aligné sur les minutes 0 et 30).

Réduit la charge des crons Vercel d'un facteur ~6 sur ce job.

## Test plan

- [ ] CI vert (typecheck + tests unitaires)
- [ ] Vérifier le prochain run du cron après merge (via Vercel ou logs Sentry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)