### PR TITLE
feat(circle): paginer la liste des événements sur la page Communauté

### DIFF
--- a/src/app/[locale]/(routes)/circles/[slug]/page.tsx
+++ b/src/app/[locale]/(routes)/circles/[slug]/page.tsx
@@ -27,6 +27,7 @@ import { HostLink } from "@/components/circles/host-link";
 import { LeaveCircleDialog } from "@/components/circles/leave-circle-dialog";
 import { MomentTimelineItem } from "@/components/circles/moment-timeline-item";
 import { CircleMomentTabs } from "@/components/circles/circle-moment-tabs";
+import { PaginatedMomentList } from "@/components/circles/paginated-moment-list";
 import type { CircleMemberWithUser } from "@/domain/models/circle";
 import { DemoBadge } from "@/components/badges/demo-badge";
 import Image from "next/image";
@@ -574,7 +575,7 @@ export default async function PublicCirclePage({
                   </p>
                 </div>
               ) : (
-                <div>
+                <PaginatedMomentList>
                   {upcomingMoments.map((moment, i) => (
                     <MomentTimelineItem
                       key={moment.id}
@@ -588,7 +589,7 @@ export default async function PublicCirclePage({
                       topAttendees={(topAttendeesByMomentId.get(moment.id) ?? []).map((r) => ({ user: { firstName: r.user.firstName, lastName: r.user.lastName, email: r.user.email, image: r.user.image } }))}
                     />
                   ))}
-                </div>
+                </PaginatedMomentList>
               )
             }
             pastContent={
@@ -599,7 +600,7 @@ export default async function PublicCirclePage({
                   </p>
                 </div>
               ) : (
-                <div>
+                <PaginatedMomentList>
                   {pastMoments.map((moment, i) => (
                     <MomentTimelineItem
                       key={moment.id}
@@ -613,7 +614,7 @@ export default async function PublicCirclePage({
                       topAttendees={(topAttendeesByMomentId.get(moment.id) ?? []).map((r) => ({ user: { firstName: r.user.firstName, lastName: r.user.lastName, email: r.user.email, image: r.user.image } }))}
                     />
                   ))}
-                </div>
+                </PaginatedMomentList>
               )
             }
           />

--- a/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/page.tsx
+++ b/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/page.tsx
@@ -18,6 +18,7 @@ import { DeleteCircleDialog } from "@/components/circles/delete-circle-dialog";
 import { LeaveCircleDialog } from "@/components/circles/leave-circle-dialog";
 import { CircleMomentTabs } from "@/components/circles/circle-moment-tabs";
 import { MomentTimelineItem } from "@/components/circles/moment-timeline-item";
+import { PaginatedMomentList } from "@/components/circles/paginated-moment-list";
 import { CircleMembersList } from "@/components/circles/circle-members-list";
 import { CircleShareInviteCard } from "@/components/circles/circle-share-invite-card";
 import { PendingMembershipsList } from "@/components/circles/pending-requests-list";
@@ -485,7 +486,7 @@ export default async function CircleDetailPage({
                   </p>
                 </div>
               ) : (
-                <div>
+                <PaginatedMomentList>
                   {upcomingMoments.map((moment, i) => (
                     <MomentTimelineItem
                       key={moment.id}
@@ -497,7 +498,7 @@ export default async function CircleDetailPage({
                       isLast={i === upcomingMoments.length - 1}
                     />
                   ))}
-                </div>
+                </PaginatedMomentList>
               )
             }
             pastContent={
@@ -508,7 +509,7 @@ export default async function CircleDetailPage({
                   </p>
                 </div>
               ) : (
-                <div>
+                <PaginatedMomentList>
                   {pastMoments.map((moment, i) => (
                     <MomentTimelineItem
                       key={moment.id}
@@ -520,7 +521,7 @@ export default async function CircleDetailPage({
                       isLast={i === pastMoments.length - 1}
                     />
                   ))}
-                </div>
+                </PaginatedMomentList>
               )
             }
           />

--- a/src/components/circles/paginated-moment-list.tsx
+++ b/src/components/circles/paginated-moment-list.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useState, Children, type ReactNode } from "react";
+import { useTranslations } from "next-intl";
+import { Button } from "@/components/ui/button";
+
+type Props = {
+  children: ReactNode;
+  initialCount?: number;
+  step?: number;
+};
+
+export function PaginatedMomentList({
+  children,
+  initialCount = 10,
+  step = 5,
+}: Props) {
+  const t = useTranslations("Common");
+  const items = Children.toArray(children);
+  const [visibleCount, setVisibleCount] = useState(initialCount);
+
+  if (items.length === 0) return null;
+
+  const hasMore = visibleCount < items.length;
+
+  return (
+    <>
+      {items.slice(0, visibleCount)}
+      {hasMore && (
+        <div className="flex justify-center pt-4">
+          <Button
+            variant="outline"
+            onClick={() => setVisibleCount((v) => v + step)}
+            className="min-w-32"
+          >
+            {t("showMore")}
+          </Button>
+        </div>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

- Ajoute un bouton « Voir plus » sur les listes d'événements (à venir et passés) des pages Communauté.
- Affiche les 10 premiers événements par défaut, révèle +5 par clic.
- Appliqué sur la page publique (`/circles/[slug]`) et sur la page dashboard (`/dashboard/circles/[slug]`).

## Pourquoi

Sur les Communautés actives (ex: Le Club de Mont-Saint-Léger avec 13 événements), la liste pouvait devenir très longue et rendre la page difficile à scanner. La pagination client-side évite ça sans ajouter de route ni de requête : les données sont déjà chargées côté serveur via `getCircleMoments`.

## Implémentation

- Nouveau composant client `PaginatedMomentList` dans `src/components/circles/paginated-moment-list.tsx`
- Pattern identique à `PastEventsList` du dashboard : `React.Children.toArray` + slice + state `visibleCount`
- Clé i18n existante réutilisée (`Common.showMore`), zéro nouvelle traduction

## Test plan

- [ ] Page publique `/circles/le-club-de-mont-saint-leger` : tab « à venir » affiche 10 events + bouton « Voir plus » → clic → +5 events révélés
- [ ] Même comportement sur tab « passés »
- [ ] Page dashboard `/dashboard/circles/le-club-de-mont-saint-leger` : idem
- [ ] Communauté avec ≤10 events : pas de bouton « Voir plus »
- [ ] Communauté sans event : empty state inchangé

🤖 Generated with [Claude Code](https://claude.com/claude-code)