### PR TITLE
refactor(co-host): simplifications suite /simplify post-merge

### DIFF
--- a/src/app/[locale]/(routes)/circles/[slug]/page.tsx
+++ b/src/app/[locale]/(routes)/circles/[slug]/page.tsx
@@ -157,6 +157,7 @@ export default async function PublicCirclePage({
     ? hosts.some((h) => h.user.id === session.user!.id)
     : false;
   const isConnected = !!session?.user?.id;
+  const primaryHosts = hosts.filter((h) => h.role === "HOST");
   // Membres visibles : connecté + (circle public OU membre/organisateur)
   const canSeeMembers = isConnected && (circle.visibility === "PUBLIC" || isMember || isOrganizer);
   const showJoinButton = isConnected && !isMember && !isPendingMember;
@@ -273,36 +274,33 @@ export default async function PublicCirclePage({
           )}
 
           {/* Hosts — affiche uniquement le HOST principal (les CO_HOST figurent dans la liste des membres avec leur badge) */}
-          {(() => {
-            const primaryHosts = hosts.filter((h) => h.role === "HOST");
-            return primaryHosts.length > 0 ? (
-              <div className="space-y-2 px-1">
-                <p className="text-muted-foreground text-xs font-semibold uppercase tracking-wider">
-                  {t("detail.hosts")}
-                </p>
-                <div className="flex flex-wrap items-center gap-1.5">
-                  {primaryHosts.map((host) => (
-                    <div
-                      key={host.id}
-                      className="flex size-8 shrink-0 items-center justify-center rounded-full text-xs font-semibold text-white"
-                      style={{ background: getMomentGradient(host.user.email) }}
-                      title={host.user.firstName ?? host.user.email}
-                    >
-                      {getCircleUserInitials(host.user)}
-                    </div>
-                  ))}
-                </div>
-                <p className="flex flex-wrap gap-x-1 text-sm font-medium leading-snug">
-                  {primaryHosts.map((h, i) => (
-                    <span key={h.user.id}>
-                      <HostLink user={h.user} linkDisabled={!isConnected} />
-                      {i < primaryHosts.length - 1 && ", "}
-                    </span>
-                  ))}
-                </p>
+          {primaryHosts.length > 0 && (
+            <div className="space-y-2 px-1">
+              <p className="text-muted-foreground text-xs font-semibold uppercase tracking-wider">
+                {t("detail.hosts")}
+              </p>
+              <div className="flex flex-wrap items-center gap-1.5">
+                {primaryHosts.map((host) => (
+                  <div
+                    key={host.id}
+                    className="flex size-8 shrink-0 items-center justify-center rounded-full text-xs font-semibold text-white"
+                    style={{ background: getMomentGradient(host.user.email) }}
+                    title={host.user.firstName ?? host.user.email}
+                  >
+                    {getCircleUserInitials(host.user)}
+                  </div>
+                ))}
               </div>
-            ) : null;
-          })()}
+              <p className="flex flex-wrap gap-x-1 text-sm font-medium leading-snug">
+                {primaryHosts.map((h, i) => (
+                  <span key={h.user.id}>
+                    <HostLink user={h.user} linkDisabled={!isConnected} />
+                    {i < primaryHosts.length - 1 && ", "}
+                  </span>
+                ))}
+              </p>
+            </div>
+          )}
 
           {/* Stats */}
           <div className="flex gap-6 px-1">
@@ -384,20 +382,17 @@ export default async function PublicCirclePage({
 
           {/* "Organisé par" : affiche uniquement le HOST principal ; les CO_HOST sont visibles dans la liste des membres avec leur badge */}
           <div className="flex items-center justify-between gap-4">
-            {(() => {
-              const primaryHosts = hosts.filter((h) => h.role === "HOST");
-              return primaryHosts.length > 0 ? (
-                <p className="text-muted-foreground flex flex-wrap items-center gap-x-1 gap-y-1 text-sm">
-                  {t("detail.hostedBy")}
-                  {primaryHosts.map((h, i) => (
-                    <span key={h.user.id} className="flex items-center gap-1">
-                      <HostLink user={h.user} className="text-foreground font-medium" linkDisabled={!isConnected} />
-                      {i < primaryHosts.length - 1 && <span>,</span>}
-                    </span>
-                  ))}
-                </p>
-              ) : null;
-            })()}
+            {primaryHosts.length > 0 && (
+              <p className="text-muted-foreground flex flex-wrap items-center gap-x-1 gap-y-1 text-sm">
+                {t("detail.hostedBy")}
+                {primaryHosts.map((h, i) => (
+                  <span key={h.user.id} className="flex items-center gap-1">
+                    <HostLink user={h.user} className="text-foreground font-medium" linkDisabled={!isConnected} />
+                    {i < primaryHosts.length - 1 && <span>,</span>}
+                  </span>
+                ))}
+              </p>
+            )}
             {isOrganizer && (
               <Button asChild variant="ghost" size="sm" className="shrink-0 gap-1.5">
                 <Link href={`/dashboard/circles/${circle.slug}`}>

--- a/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/edit/page.tsx
+++ b/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/edit/page.tsx
@@ -9,6 +9,7 @@ import { CircleNotFoundError } from "@/domain/errors";
 import { CircleForm } from "@/components/circles/circle-form";
 import { updateCircleAction } from "@/app/actions/circle";
 import { resolveCircleRepository } from "@/lib/admin-host-mode";
+import { isActivePrimaryHost } from "@/domain/models/circle";
 import { Link } from "@/i18n/navigation";
 import { ChevronRight } from "lucide-react";
 
@@ -39,10 +40,10 @@ export default async function EditCirclePage({
   const membership = session?.user?.id
     ? await circleRepo.findMembership(circle.id, session.user.id)
     : null;
-  const isOrganizer = membership?.role === "HOST";
+  const canManageStripe = isActivePrimaryHost(membership);
 
   let stripeConnect;
-  if (isOrganizer) {
+  if (canManageStripe) {
     // Default: no account (shows "Activer les paiements" button)
     let hasAccount = false;
     let status = null as import("@/domain/ports/services/payment-service").ConnectAccountStatus | null;

--- a/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/moments/[momentSlug]/page.tsx
+++ b/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/moments/[momentSlug]/page.tsx
@@ -13,6 +13,7 @@ import { getMomentComments } from "@/domain/usecases/get-moment-comments";
 import { CircleNotFoundError, MomentNotFoundError } from "@/domain/errors";
 import { MomentDetailView } from "@/components/moments/moment-detail-view";
 import { resolveCircleRepository } from "@/lib/admin-host-mode";
+import { isActiveOrganizer } from "@/domain/models/circle";
 
 export default async function MomentDetailPage({
   params,
@@ -53,9 +54,7 @@ export default async function MomentDetailPage({
   const hasActiveRegistration = userRegistration && userRegistration.status !== "CANCELLED" && userRegistration.status !== "REJECTED";
   if (!hasActiveMembership && !hasActiveRegistration) notFound();
 
-  const isOrganizer =
-    hasActiveMembership &&
-    (membership!.role === "HOST" || membership!.role === "CO_HOST");
+  const isOrganizer = isActiveOrganizer(membership);
 
   const [allAttendees, comments, pendingRegistrations, attachments] = await Promise.all([
     prismaRegistrationRepository.findActiveWithUserByMomentId(moment.id),

--- a/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/page.tsx
+++ b/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/page.tsx
@@ -27,6 +27,7 @@ import { CollapsibleDescription } from "@/components/moments/collapsible-descrip
 import { HostLink } from "@/components/circles/host-link";
 import { resolveCircleRepository } from "@/lib/admin-host-mode";
 import type { CircleMemberWithUser } from "@/domain/models/circle";
+import { isActiveOrganizer } from "@/domain/models/circle";
 import Image from "next/image";
 import {
   Globe,
@@ -78,9 +79,8 @@ export default async function CircleDetailPage({
   const membership = await circleRepo.findMembership(circle.id, session.user.id);
   if (!membership) notFound();
 
-  const isOrganizer = membership.role === "HOST" || membership.role === "CO_HOST";
+  const isOrganizer = isActiveOrganizer(membership);
   const callerRole = membership.role;
-
 
   const [hosts, players, allMoments, pendingMemberships, circleNetworks] = await Promise.all([
     prismaCircleRepository.findOrganizers(circle.id),
@@ -96,6 +96,7 @@ export default async function CircleDetailPage({
   ]);
 
   const totalMembers = hosts.length + players.length;
+  const primaryHosts = hosts.filter((h) => h.role === "HOST");
   const upcomingMoments = allMoments.filter((m) => m.status === "PUBLISHED" || (m.status === "DRAFT" && isOrganizer));
   const pastMoments = allMoments.filter((m) => m.status === "PAST" || m.status === "CANCELLED");
 
@@ -192,9 +193,7 @@ export default async function CircleDetailPage({
           )}
 
           {/* Hosts bloc — affiche uniquement le HOST principal (les CO_HOST figurent dans la liste des membres) */}
-          {(() => {
-            const primaryHosts = hosts.filter((h) => h.role === "HOST");
-            return primaryHosts.length > 0 ? (
+          {primaryHosts.length > 0 && (
             <div className="space-y-2 px-1">
               <p className="text-muted-foreground text-xs font-semibold uppercase tracking-wider">
                 {t("detail.hosts")}
@@ -220,8 +219,7 @@ export default async function CircleDetailPage({
                 ))}
               </p>
             </div>
-            ) : null;
-          })()}
+          )}
 
           {/* Stats */}
           <div className="flex gap-6 px-1">
@@ -254,20 +252,17 @@ export default async function CircleDetailPage({
 
           {/* "Organisé par" : affiche uniquement le HOST principal ; les CO_HOST sont visibles dans la liste des membres */}
           <div className="flex items-center justify-between gap-4">
-            {(() => {
-              const primaryHosts = hosts.filter((h) => h.role === "HOST");
-              return primaryHosts.length > 0 ? (
-                <p className="text-muted-foreground flex flex-wrap items-center gap-x-1 gap-y-1 text-sm">
-                  {t("detail.hostedBy")}
-                  {primaryHosts.map((h, i) => (
-                    <span key={h.user.id} className="flex items-center gap-1">
-                      <HostLink user={h.user} className="text-foreground font-medium" />
-                      {i < primaryHosts.length - 1 && <span>,</span>}
-                    </span>
-                  ))}
-                </p>
-              ) : null;
-            })()}
+            {primaryHosts.length > 0 && (
+              <p className="text-muted-foreground flex flex-wrap items-center gap-x-1 gap-y-1 text-sm">
+                {t("detail.hostedBy")}
+                {primaryHosts.map((h, i) => (
+                  <span key={h.user.id} className="flex items-center gap-1">
+                    <HostLink user={h.user} className="text-foreground font-medium" />
+                    {i < primaryHosts.length - 1 && <span>,</span>}
+                  </span>
+                ))}
+              </p>
+            )}
             {isOrganizer && (
               <div className="flex shrink-0 gap-2">
                 <Button asChild size="sm">

--- a/src/app/actions/stripe.ts
+++ b/src/app/actions/stripe.ts
@@ -5,6 +5,7 @@ import { prismaCircleRepository } from "@/infrastructure/repositories";
 import { createStripePaymentService } from "@/infrastructure/services";
 import { onboardStripeConnect, getStripeConnectStatus } from "@/domain/usecases/onboard-stripe-connect";
 import { resolveCircleRepository } from "@/lib/admin-host-mode";
+import { isActivePrimaryHost } from "@/domain/models/circle";
 import type { ConnectAccountStatus } from "@/domain/ports/services/payment-service";
 import type { ActionResult } from "./types";
 import { toActionResult } from "./helpers/to-action-result";
@@ -64,7 +65,7 @@ export async function getStripeLoginLinkAction(
   }
 
   const membership = await circleRepo.findMembership(circleId, userId);
-  if (!membership || membership.role !== "HOST") {
+  if (!isActivePrimaryHost(membership)) {
     return { success: false, error: "Not authorized", code: "UNAUTHORIZED_CIRCLE_ACTION" };
   }
 
@@ -85,7 +86,7 @@ export async function cancelStripeConnectAction(
 
   const circleRepo = await resolveCircleRepository(session, prismaCircleRepository);
   const membership = await circleRepo.findMembership(circleId, userId);
-  if (!membership || membership.role !== "HOST") {
+  if (!isActivePrimaryHost(membership)) {
     return { success: false, error: "Not authorized", code: "UNAUTHORIZED_CIRCLE_ACTION" };
   }
 

--- a/src/components/circles/circle-members-list.tsx
+++ b/src/components/circles/circle-members-list.tsx
@@ -71,7 +71,6 @@ export function CircleMembersList({
           <MemberRow
             key={member.id}
             member={member}
-            isDashboardOrganizer={isDashboardOrganizer}
             callerRole={callerRole}
             showEmail={isDashboardOrganizer}
             circleId={circleId}
@@ -95,8 +94,6 @@ export function CircleMembersList({
 
 type MemberRowProps = {
   member: CircleMemberWithUser;
-  /** True quand on est dans le dashboard et que l'appelant peut potentiellement agir. */
-  isDashboardOrganizer: boolean;
   callerRole: CircleMemberRole | undefined;
   showEmail: boolean;
   circleId: string | undefined;
@@ -104,7 +101,6 @@ type MemberRowProps = {
 
 function MemberRow({
   member,
-  isDashboardOrganizer,
   callerRole,
   showEmail,
   circleId,
@@ -185,7 +181,7 @@ function MemberRow({
           )}
         </div>
 
-        <MemberBadge role={member.role} isDashboardView={isDashboardOrganizer} />
+        <MemberBadge role={member.role} />
 
         {hasMenuActions && circleId && (
           <DropdownMenu>
@@ -247,12 +243,9 @@ function MemberRow({
   );
 }
 
-function MemberBadge({ role }: { role: CircleMemberRole; isDashboardView: boolean }) {
+function MemberBadge({ role }: { role: CircleMemberRole }) {
   const t = useTranslations("Dashboard");
-
   if (role === "PLAYER") return null;
-
-  // Badge unique "Organisateur" pour HOST et CO_HOST, partout (dashboard + public).
   return (
     <Badge variant="outline" className="border-primary/40 text-primary shrink-0 gap-1">
       <Crown className="size-3" />

--- a/src/domain/models/circle.ts
+++ b/src/domain/models/circle.ts
@@ -22,6 +22,17 @@ export function isActiveOrganizer(
   return membership.status === "ACTIVE" && isOrganizerRole(membership.role);
 }
 
+/**
+ * Garde les actions réservées au propriétaire de la Communauté (delete, promote,
+ * demote, Stripe Connect, leaveCircle guard). Un CO_HOST ne passe pas ce check.
+ */
+export function isActivePrimaryHost(
+  membership: Pick<CircleMembership, "role" | "status"> | null | undefined
+): boolean {
+  if (!membership) return false;
+  return membership.status === "ACTIVE" && membership.role === "HOST";
+}
+
 export type CircleCategory =
   | "TECH"
   | "DESIGN"

--- a/src/domain/usecases/cancel-registration.ts
+++ b/src/domain/usecases/cancel-registration.ts
@@ -1,5 +1,5 @@
 import type { Registration } from "@/domain/models/registration";
-import { isOrganizerRole } from "@/domain/models/circle";
+import { isActiveOrganizer } from "@/domain/models/circle";
 import type { RegistrationRepository } from "@/domain/ports/repositories/registration-repository";
 import type { MomentRepository } from "@/domain/ports/repositories/moment-repository";
 import type { CircleRepository } from "@/domain/ports/repositories/circle-repository";
@@ -45,15 +45,15 @@ export async function cancelRegistration(
     throw new UnauthorizedRegistrationActionError();
   }
 
-  // An organizer (Host or Co-Host) cannot cancel their own registration
-  // to an event of the Community they organize (D16)
+  // D16 : un organisateur actif ne peut pas annuler sa propre inscription
+  // à un événement de sa Communauté.
   const moment = await momentRepository.findById(registration.momentId);
   if (moment) {
     const membership = await circleRepository.findMembership(
       moment.circleId,
       input.userId
     );
-    if (membership && isOrganizerRole(membership.role)) {
+    if (isActiveOrganizer(membership)) {
       throw new OrganizerCannotCancelRegistrationError();
     }
   }

--- a/src/domain/usecases/delete-circle.ts
+++ b/src/domain/usecases/delete-circle.ts
@@ -1,3 +1,4 @@
+import { isActivePrimaryHost } from "@/domain/models/circle";
 import type { CircleRepository } from "@/domain/ports/repositories/circle-repository";
 import { CircleNotFoundError, UnauthorizedCircleActionError } from "@/domain/errors";
 
@@ -25,7 +26,7 @@ export async function deleteCircle(
     input.circleId,
     input.userId
   );
-  if (!membership || membership.role !== "HOST") {
+  if (!isActivePrimaryHost(membership)) {
     throw new UnauthorizedCircleActionError(input.userId, input.circleId);
   }
 

--- a/src/domain/usecases/demote-from-co-host.ts
+++ b/src/domain/usecases/demote-from-co-host.ts
@@ -1,4 +1,5 @@
 import type { CircleMembership } from "@/domain/models/circle";
+import { isActivePrimaryHost } from "@/domain/models/circle";
 import type { CircleRepository } from "@/domain/ports/repositories/circle-repository";
 import type { UserRepository } from "@/domain/ports/repositories/user-repository";
 import type { EmailService } from "@/domain/ports/services/email-service";
@@ -6,7 +7,6 @@ import {
   UnauthorizedCircleActionError,
   NotMemberOfCircleError,
   InvalidDemotionTargetError,
-  CircleNotFoundError,
 } from "@/domain/errors";
 
 type DemoteFromCoHostInput = {
@@ -39,51 +39,35 @@ export async function demoteFromCoHost(
 ): Promise<CircleMembership> {
   const { circleRepository, userRepository, emailService, emailStrings } = deps;
 
-  // 1. Seul le HOST principal peut rétrograder (D3)
-  const callerMembership = await circleRepository.findMembership(
-    input.circleId,
-    input.hostUserId
-  );
-  if (
-    !callerMembership ||
-    callerMembership.role !== "HOST" ||
-    callerMembership.status !== "ACTIVE"
-  ) {
+  // D3 : seul le HOST principal peut rétrograder.
+  const [callerMembership, targetMembership] = await Promise.all([
+    circleRepository.findMembership(input.circleId, input.hostUserId),
+    circleRepository.findMembership(input.circleId, input.targetUserId),
+  ]);
+  if (!isActivePrimaryHost(callerMembership)) {
     throw new UnauthorizedCircleActionError(input.hostUserId, input.circleId);
   }
-
-  // 2. Charger la membership de la cible
-  const targetMembership = await circleRepository.findMembership(
-    input.circleId,
-    input.targetUserId
-  );
   if (!targetMembership) {
     throw new NotMemberOfCircleError(input.circleId);
   }
-
-  // 3. Seul un CO_HOST peut être rétrogradé
   if (targetMembership.role !== "CO_HOST") {
     throw new InvalidDemotionTargetError(targetMembership.role);
   }
 
-  // 4. Rétrogradation
   const updated = await circleRepository.updateMembershipRole(
     input.circleId,
     input.targetUserId,
     "PLAYER"
   );
 
-  // 5. Email de rétrogradation (D19) — best-effort
+  // D19 : email de rétrogradation best-effort.
   if (emailService && emailStrings) {
     try {
       const [targetUser, circle] = await Promise.all([
         userRepository.findById(input.targetUserId),
         circleRepository.findById(input.circleId),
       ]);
-
-      if (!targetUser || !circle) {
-        if (!circle) throw new CircleNotFoundError(input.circleId);
-      } else {
+      if (targetUser && circle) {
         const strings = await emailStrings.demoted({ circleName: circle.name });
         await emailService.sendCoHostDemoted({
           to: targetUser.email,
@@ -95,7 +79,7 @@ export async function demoteFromCoHost(
         });
       }
     } catch {
-      // L'échec d'envoi d'email ne bloque pas la rétrogradation en base.
+      // Swallowed on purpose — see D19.
     }
   }
 

--- a/src/domain/usecases/onboard-stripe-connect.ts
+++ b/src/domain/usecases/onboard-stripe-connect.ts
@@ -1,3 +1,4 @@
+import { isActivePrimaryHost } from "@/domain/models/circle";
 import type { CircleRepository } from "@/domain/ports/repositories/circle-repository";
 import type { PaymentService, ConnectAccountStatus } from "@/domain/ports/services/payment-service";
 import { CircleNotFoundError, UnauthorizedCircleActionError } from "@/domain/errors";
@@ -30,7 +31,7 @@ export async function onboardStripeConnect(
     input.circleId,
     input.userId
   );
-  if (!membership || membership.role !== "HOST") {
+  if (!isActivePrimaryHost(membership)) {
     throw new UnauthorizedCircleActionError(input.userId, input.circleId);
   }
 
@@ -91,7 +92,7 @@ export async function getStripeConnectStatus(
     input.circleId,
     input.userId
   );
-  if (!membership || membership.role !== "HOST") {
+  if (!isActivePrimaryHost(membership)) {
     throw new UnauthorizedCircleActionError(input.userId, input.circleId);
   }
 

--- a/src/domain/usecases/promote-to-co-host.ts
+++ b/src/domain/usecases/promote-to-co-host.ts
@@ -1,4 +1,5 @@
 import type { CircleMembership } from "@/domain/models/circle";
+import { isActivePrimaryHost } from "@/domain/models/circle";
 import type { CircleRepository } from "@/domain/ports/repositories/circle-repository";
 import type { UserRepository } from "@/domain/ports/repositories/user-repository";
 import type { EmailService } from "@/domain/ports/services/email-service";
@@ -7,7 +8,6 @@ import {
   NotMemberOfCircleError,
   CannotPromotePendingMemberError,
   InvalidPromotionTargetError,
-  CircleNotFoundError,
 } from "@/domain/errors";
 
 type PromoteToCoHostInput = {
@@ -48,46 +48,32 @@ export async function promoteToCoHost(
 ): Promise<CircleMembership> {
   const { circleRepository, userRepository, emailService, emailStrings } = deps;
 
-  // 1. Seul le HOST principal peut promouvoir (D3)
-  const callerMembership = await circleRepository.findMembership(
-    input.circleId,
-    input.hostUserId
-  );
-  if (
-    !callerMembership ||
-    callerMembership.role !== "HOST" ||
-    callerMembership.status !== "ACTIVE"
-  ) {
+  // D3 : seul le HOST principal peut promouvoir (garde strict HOST, pas CO_HOST).
+  const [callerMembership, targetMembership] = await Promise.all([
+    circleRepository.findMembership(input.circleId, input.hostUserId),
+    circleRepository.findMembership(input.circleId, input.targetUserId),
+  ]);
+  if (!isActivePrimaryHost(callerMembership)) {
     throw new UnauthorizedCircleActionError(input.hostUserId, input.circleId);
   }
-
-  // 2. Charger la membership de la cible
-  const targetMembership = await circleRepository.findMembership(
-    input.circleId,
-    input.targetUserId
-  );
   if (!targetMembership) {
     throw new NotMemberOfCircleError(input.circleId);
   }
-
-  // 3. Guard D22 : uniquement les membres ACTIVE peuvent être promus
+  // D22 : uniquement les membres ACTIVE peuvent être promus.
   if (targetMembership.status !== "ACTIVE") {
     throw new CannotPromotePendingMemberError();
   }
-
-  // 4. Seul un PLAYER peut être promu en CO_HOST
   if (targetMembership.role !== "PLAYER") {
     throw new InvalidPromotionTargetError(targetMembership.role);
   }
 
-  // 5. Promotion
   const updated = await circleRepository.updateMembershipRole(
     input.circleId,
     input.targetUserId,
     "CO_HOST"
   );
 
-  // 6. Email de promotion (D19) — best-effort, n'annule pas la promotion en cas d'échec
+  // D19 : email de promotion best-effort — un échec ne bloque pas la promotion.
   if (emailService && emailStrings) {
     try {
       const [targetUser, inviter, circle] = await Promise.all([
@@ -95,10 +81,7 @@ export async function promoteToCoHost(
         userRepository.findById(input.hostUserId),
         circleRepository.findById(input.circleId),
       ]);
-
-      if (!targetUser || !inviter || !circle) {
-        if (!circle) throw new CircleNotFoundError(input.circleId);
-      } else {
+      if (targetUser && inviter && circle) {
         const inviterName =
           [inviter.firstName, inviter.lastName].filter(Boolean).join(" ") ||
           inviter.email;
@@ -117,7 +100,7 @@ export async function promoteToCoHost(
         });
       }
     } catch {
-      // L'échec d'envoi d'email ne bloque pas la promotion en base.
+      // Swallowed on purpose — see D19.
     }
   }
 


### PR DESCRIPTION
## Summary

Cleanup pass du code de la PR #400 (co-organisateurs) suite à `/simplify`. Résultats des 3 agents review aggrégés et appliqués.

Zéro changement de comportement utilisateur. Typecheck vert, 967 tests unitaires passent.

## Changements

**Helper ajouté**
- `isActivePrimaryHost(membership)` dans `domain/models/circle.ts` : check `role === "HOST" && status === "ACTIVE"`. Remplace 5 sites qui inlinaient le pattern.

**Adoption `isActiveOrganizer`**
- `dashboard/.../circles/[slug]/page.tsx` et `.../moments/[momentSlug]/page.tsx` : `isOrganizer` dérivé via le helper au lieu du check inline
- `cancel-registration.ts` : passe de `isOrganizerRole` à `isActiveOrganizer` (défensif — D17)

**Parallélisation**
- `promoteToCoHost` et `demoteFromCoHost` : les 2 `findMembership` étaient sequentiels → `Promise.all`. Économise 1 round-trip DB par action.

**Code mort retiré**
- `MemberBadge` / `MemberRow` : props `isDashboardView` et `isDashboardOrganizer` déclarées mais jamais consommées (vestiges du design "Propriétaire vs Organisateur" abandonné)
- `promote-to-co-host` / `demote-from-co-host` : throw `CircleNotFoundError` à l'intérieur d'un try/catch vide — dead code retiré

**Renommage de clarification**
- `edit/page.tsx` : `isOrganizer` (misleading — checkait HOST strict) → `canManageStripe`

**Hoisting**
- 4 IIFE `(() => { const primaryHosts = ... })()` dans 2 pages Circle hoistés en variable locale unique au top du composant

## Test plan

- [x] Typecheck vert
- [x] 967 tests unitaires verts (88 fichiers)
- [ ] CI vert
- [ ] Pas de changement schema Prisma → merge direct

🤖 Generated with [Claude Code](https://claude.com/claude-code)