### PR TITLE
fix(auth): brancher Sentry sur les erreurs d'authentification

### DIFF
--- a/src/app/[locale]/auth/error/page.tsx
+++ b/src/app/[locale]/auth/error/page.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
+import * as Sentry from "@sentry/nextjs";
 import { Button } from "@/components/ui/button";
 import { Link } from "@/i18n/navigation";
 import { ExternalLink } from "lucide-react";
@@ -13,10 +14,21 @@ export default function AuthErrorPage() {
   const error = searchParams.get("error");
   const t = useTranslations("Auth");
   const [webview, setWebview] = useState(false);
+  const capturedRef = useRef<string | null>(null);
 
   useEffect(() => {
     setWebview(isInAppBrowser());
   }, []);
+
+  useEffect(() => {
+    if (error && capturedRef.current !== error) {
+      capturedRef.current = error;
+      Sentry.captureMessage(`auth-error-page: ${error}`, {
+        level: "warning",
+        tags: { context: "auth", error_code: error },
+      });
+    }
+  }, [error]);
 
   const errorMessage = error
     ? t(`errors.${error}`, { defaultValue: t("errors.Default") })

--- a/src/infrastructure/auth/auth.config.ts
+++ b/src/infrastructure/auth/auth.config.ts
@@ -35,6 +35,14 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         });
 
         if (error) {
+          Sentry.captureException(error, {
+            tags: { context: "magic_link" },
+            extra: {
+              email_domain: identifier.split("@")[1] ?? "unknown",
+              resend_message: error.message,
+              resend_name: error.name,
+            },
+          });
           throw new Error(`[AUTH] Magic link email failed: ${error.message}`);
         }
       },
@@ -48,6 +56,14 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
   logger: {
     error(error) {
       console.error("[AUTH ERROR]", error);
+      Sentry.captureException(error, { tags: { context: "auth" } });
+    },
+    warn(code) {
+      console.warn("[AUTH WARN]", code);
+      Sentry.captureMessage(`auth:${code}`, {
+        level: "warning",
+        tags: { context: "auth" },
+      });
     },
   },
   callbacks: {


### PR DESCRIPTION
## Summary

- Un utilisateur a vu la page "Erreur d'authentification — Erreur de configuration du serveur" sans aucun log Sentry associé, rendant le diagnostic impossible.
- Root cause : le `logger.error` d'Auth.js (`auth.config.ts:48-52`) faisait uniquement `console.error`, sans remonter dans Sentry. Les throw du magic link Resend subissaient le même traitement.
- Trois points de capture ajoutés pour couvrir tous les cas futurs.

## Changements

- **`logger.error` + `logger.warn` d'Auth.js** → `Sentry.captureException` / `Sentry.captureMessage` avec tag `context=auth`. Couvre toutes les erreurs internes Auth.js (Configuration, OAuthCallback, JWT, etc.).
- **`sendVerificationRequest` (ResendProvider)** : capture l'erreur Resend avant le throw, avec `email_domain` (pas de PII complet), `resend_message`, `resend_name` en extra, tag `context=magic_link`.
- **Page `/auth/error`** : `captureMessage` côté client quand un utilisateur atterrit sur la page, avec le code d'erreur en tag. `useRef` anti-doublon pour éviter les captures multiples au rafraîchissement.

## Pourquoi ces 3 points

Redondance utile : la capture Resend a le contexte le plus riche (code erreur Resend exact, domaine email), `logger.error` confirme la remontée vers Auth.js, et la page /auth/error confirme que l'utilisateur a bien vu l'écran d'erreur. Les 3 events sont corrélables par timestamp dans Sentry.

## Test plan

- [ ] Typecheck vert
- [ ] En prod : forcer une erreur magic link (API key Resend invalide temporairement) → vérifier que Sentry reçoit l'event `context=magic_link` avec `email_domain` + `resend_message`
- [ ] Visiter `/auth/error?error=Configuration` → vérifier l'event Sentry `auth-error-page: Configuration`
- [ ] Monitorer le volume de warns Auth.js sur 24-48h post-merge (pour vérifier que `logger.warn` ne génère pas trop de bruit)

## Notes

- Sentry côté client actif uniquement en production (`instrumentation-client.ts`), donc pas de bruit en dev.
- Pattern Sentry identique à celui utilisé dans `src/app/api/cron/*` et `global-error.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)