### PR TITLE
fix(auth): valider l'email et gérer proprement les erreurs Resend

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -138,6 +138,7 @@
       "or": "or",
       "linkedin": "Continue with LinkedIn",
       "invalidEmail": "Invalid email address. Please check your input.",
+      "sendFailed": "Couldn't send the email. Check your address or try again in a moment.",
       "webviewNotice": "You're using an in-app browser (LinkedIn, Instagram...). Use the email sign-in below — it works everywhere.",
       "webviewTooltip": "Not available from an in-app browser. Use the email sign-in."
     },

--- a/messages/en.json
+++ b/messages/en.json
@@ -138,7 +138,7 @@
       "or": "or",
       "linkedin": "Continue with LinkedIn",
       "invalidEmail": "Invalid email address. Please check your input.",
-      "sendFailed": "Couldn't send the email. Check your address or try again in a moment.",
+      "sendFailed": "Couldn't send the email right now. Please try again in a moment.",
       "webviewNotice": "You're using an in-app browser (LinkedIn, Instagram...). Use the email sign-in below — it works everywhere.",
       "webviewTooltip": "Not available from an in-app browser. Use the email sign-in."
     },

--- a/messages/en.json
+++ b/messages/en.json
@@ -137,6 +137,7 @@
       "magicLink": "Send a magic link",
       "or": "or",
       "linkedin": "Continue with LinkedIn",
+      "invalidEmail": "Invalid email address. Please check your input.",
       "webviewNotice": "You're using an in-app browser (LinkedIn, Instagram...). Use the email sign-in below — it works everywhere.",
       "webviewTooltip": "Not available from an in-app browser. Use the email sign-in."
     },

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -137,6 +137,7 @@
       "magicLink": "Envoyer un lien magique",
       "or": "ou",
       "linkedin": "Continuer avec LinkedIn",
+      "invalidEmail": "Adresse email invalide. Vérifiez votre saisie.",
       "webviewNotice": "Vous utilisez un navigateur intégré (LinkedIn, Instagram...). Utilisez la connexion par email ci-dessous — elle fonctionne partout.",
       "webviewTooltip": "Non disponible depuis un navigateur intégré. Utilisez la connexion par email."
     },

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -138,6 +138,7 @@
       "or": "ou",
       "linkedin": "Continuer avec LinkedIn",
       "invalidEmail": "Adresse email invalide. Vérifiez votre saisie.",
+      "sendFailed": "Impossible d'envoyer l'email. Vérifiez votre adresse ou réessayez dans un instant.",
       "webviewNotice": "Vous utilisez un navigateur intégré (LinkedIn, Instagram...). Utilisez la connexion par email ci-dessous — elle fonctionne partout.",
       "webviewTooltip": "Non disponible depuis un navigateur intégré. Utilisez la connexion par email."
     },

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -138,7 +138,7 @@
       "or": "ou",
       "linkedin": "Continuer avec LinkedIn",
       "invalidEmail": "Adresse email invalide. Vérifiez votre saisie.",
-      "sendFailed": "Impossible d'envoyer l'email. Vérifiez votre adresse ou réessayez dans un instant.",
+      "sendFailed": "Impossible d'envoyer l'email pour le moment. Réessayez dans un instant.",
       "webviewNotice": "Vous utilisez un navigateur intégré (LinkedIn, Instagram...). Utilisez la connexion par email ci-dessous — elle fonctionne partout.",
       "webviewTooltip": "Non disponible depuis un navigateur intégré. Utilisez la connexion par email."
     },

--- a/src/app/actions/auth.ts
+++ b/src/app/actions/auth.ts
@@ -2,6 +2,7 @@
 
 import { cookies } from "next/headers";
 import { signIn, signOut } from "@/infrastructure/auth/auth.config";
+import { isValidEmail } from "@/lib/email";
 import { safeCallbackUrl } from "@/lib/url";
 
 async function setCallbackCookie(callbackUrl: string) {
@@ -26,11 +27,20 @@ export async function signInWithGoogle(formData: FormData) {
   await signIn("google", { redirectTo: "/dashboard/profile/setup" });
 }
 
-export async function signInWithEmail(formData: FormData) {
-  const email = formData.get("email") as string;
+export type SignInWithEmailState = { error: "INVALID_EMAIL" } | null;
+
+export async function signInWithEmail(
+  _prev: SignInWithEmailState,
+  formData: FormData
+): Promise<SignInWithEmailState> {
+  const email = ((formData.get("email") as string | null) ?? "").trim();
+  if (!isValidEmail(email)) {
+    return { error: "INVALID_EMAIL" };
+  }
   const callbackUrl = safeCallbackUrl(formData.get("callbackUrl") as string);
   if (callbackUrl) await setCallbackCookie(callbackUrl);
   await signIn("resend", { email, redirectTo: "/dashboard/profile/setup" });
+  return null;
 }
 
 export async function signOutAction() {

--- a/src/app/actions/auth.ts
+++ b/src/app/actions/auth.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { cookies } from "next/headers";
+import { unstable_rethrow } from "next/navigation";
 import { signIn, signOut } from "@/infrastructure/auth/auth.config";
 import { isValidEmail } from "@/lib/email";
 import { safeCallbackUrl } from "@/lib/url";
@@ -27,7 +28,9 @@ export async function signInWithGoogle(formData: FormData) {
   await signIn("google", { redirectTo: "/dashboard/profile/setup" });
 }
 
-export type SignInWithEmailState = { error: "INVALID_EMAIL" } | null;
+export type SignInWithEmailState =
+  | { error: "INVALID_EMAIL" | "SEND_FAILED" }
+  | null;
 
 export async function signInWithEmail(
   _prev: SignInWithEmailState,
@@ -39,7 +42,13 @@ export async function signInWithEmail(
   }
   const callbackUrl = safeCallbackUrl(formData.get("callbackUrl") as string);
   if (callbackUrl) await setCallbackCookie(callbackUrl);
-  await signIn("resend", { email, redirectTo: "/dashboard/profile/setup" });
+  try {
+    await signIn("resend", { email, redirectTo: "/dashboard/profile/setup" });
+  } catch (error) {
+    // Relance les erreurs spéciales Next.js (redirect, notFound) pour préserver le flow nominal.
+    unstable_rethrow(error);
+    return { error: "SEND_FAILED" };
+  }
   return null;
 }
 

--- a/src/app/actions/contact.ts
+++ b/src/app/actions/contact.ts
@@ -3,6 +3,7 @@
 import { headers } from "next/headers";
 import { Resend } from "resend";
 import { prismaRateLimiter } from "@/infrastructure/services/rate-limiter/prisma-rate-limiter";
+import { isValidEmail } from "@/lib/email";
 import type { ActionResult } from "./types";
 
 const CONTACT_MAX_REQUESTS = 5;
@@ -40,8 +41,7 @@ export async function sendContactMessageAction(
     return { success: false, error: "MISSING_FIELDS", code: "VALIDATION_ERROR" };
   }
 
-  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-  if (!emailRegex.test(email)) {
+  if (!isValidEmail(email)) {
     return { success: false, error: "INVALID_EMAIL", code: "INVALID_EMAIL" };
   }
 

--- a/src/components/auth/sign-in-form.tsx
+++ b/src/components/auth/sign-in-form.tsx
@@ -141,12 +141,14 @@ export function SignInForm({ callbackUrl }: SignInFormProps) {
             type="email"
             placeholder={t("signIn.emailPlaceholder")}
             aria-invalid={emailState?.error === "INVALID_EMAIL" || undefined}
-            aria-describedby={emailState?.error === "INVALID_EMAIL" ? "email-error" : undefined}
+            aria-describedby={emailState?.error ? "email-error" : undefined}
             required
           />
-          {emailState?.error === "INVALID_EMAIL" && (
+          {emailState?.error && (
             <p id="email-error" className="text-sm text-destructive">
-              {t("signIn.invalidEmail")}
+              {emailState.error === "INVALID_EMAIL"
+                ? t("signIn.invalidEmail")
+                : t("signIn.sendFailed")}
             </p>
           )}
           <SubmitButton label={t("signIn.magicLink")} />

--- a/src/components/auth/sign-in-form.tsx
+++ b/src/components/auth/sign-in-form.tsx
@@ -134,7 +134,7 @@ export function SignInForm({ callbackUrl }: SignInFormProps) {
           <Separator className="flex-1" />
         </div>
 
-        <form action={emailAction} className="space-y-3" noValidate>
+        <form action={emailAction} className="space-y-3">
           {callbackUrl && <input type="hidden" name="callbackUrl" value={callbackUrl} />}
           <Input
             name="email"

--- a/src/components/auth/sign-in-form.tsx
+++ b/src/components/auth/sign-in-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { type ReactNode, useEffect, useState } from "react";
+import { type ReactNode, useActionState, useEffect, useState } from "react";
 import { useTranslations } from "next-intl";
 import { useFormStatus } from "react-dom";
 import { Button } from "@/components/ui/button";
@@ -13,7 +13,12 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { Github, Loader2, Mail } from "lucide-react";
-import { signInWithGitHub, signInWithGoogle, signInWithEmail } from "@/app/actions/auth";
+import {
+  signInWithGitHub,
+  signInWithGoogle,
+  signInWithEmail,
+  type SignInWithEmailState,
+} from "@/app/actions/auth";
 import { isInAppBrowser } from "@/lib/detect-webview";
 
 function GoogleIcon() {
@@ -76,6 +81,10 @@ type SignInFormProps = {
 export function SignInForm({ callbackUrl }: SignInFormProps) {
   const t = useTranslations("Auth");
   const [webview, setWebview] = useState(false);
+  const [emailState, emailAction] = useActionState<SignInWithEmailState, FormData>(
+    signInWithEmail,
+    null
+  );
 
   useEffect(() => {
     setWebview(isInAppBrowser());
@@ -125,14 +134,21 @@ export function SignInForm({ callbackUrl }: SignInFormProps) {
           <Separator className="flex-1" />
         </div>
 
-        <form action={signInWithEmail} className="space-y-3">
+        <form action={emailAction} className="space-y-3" noValidate>
           {callbackUrl && <input type="hidden" name="callbackUrl" value={callbackUrl} />}
           <Input
             name="email"
             type="email"
             placeholder={t("signIn.emailPlaceholder")}
+            aria-invalid={emailState?.error === "INVALID_EMAIL" || undefined}
+            aria-describedby={emailState?.error === "INVALID_EMAIL" ? "email-error" : undefined}
             required
           />
+          {emailState?.error === "INVALID_EMAIL" && (
+            <p id="email-error" className="text-sm text-destructive">
+              {t("signIn.invalidEmail")}
+            </p>
+          )}
           <SubmitButton label={t("signIn.magicLink")} />
         </form>
       </div>

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,0 +1,5 @@
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function isValidEmail(email: string): boolean {
+  return EMAIL_REGEX.test(email);
+}

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,8 +1,4 @@
-// Local part : caractères non-espace et non-@, sans point en tête, fin, ou consécutifs.
-// Domaine : une ou plusieurs parties séparées par `.`, chaque partie sans point interne,
-// donc rejette les points terminaux (coco@google.com.) et consécutifs (a@b..c).
-const EMAIL_REGEX =
-  /^[^\s@.](?:[^\s@]*[^\s@.])?@[^\s@.]+(?:\.[^\s@.]+)+$/;
+const EMAIL_REGEX = /^[^\s@.](?:[^\s@]*[^\s@.])?@[^\s@.]+(?:\.[^\s@.]+)+$/;
 
 export function isValidEmail(email: string): boolean {
   return EMAIL_REGEX.test(email);

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,4 +1,8 @@
-const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+// Local part : caractères non-espace et non-@, sans point en tête, fin, ou consécutifs.
+// Domaine : une ou plusieurs parties séparées par `.`, chaque partie sans point interne,
+// donc rejette les points terminaux (coco@google.com.) et consécutifs (a@b..c).
+const EMAIL_REGEX =
+  /^[^\s@.](?:[^\s@]*[^\s@.])?@[^\s@.]+(?:\.[^\s@.]+)+$/;
 
 export function isValidEmail(email: string): boolean {
   return EMAIL_REGEX.test(email);


### PR DESCRIPTION
## Summary

Fait suite à la PR #405 (remontée Sentry des erreurs auth) : plutôt que de laisser un utilisateur avec un email malformé tomber sur `/auth/error?error=Configuration` sans feedback, on intercepte côté formulaire.

Trois améliorations sur le flow magic link :
- **Validation serveur de l'email** avant d'appeler Resend. `coco@google.com.`, `foo@bar`, points consécutifs, etc. sont rejetés en amont avec un message clair sous le champ. Helper `isValidEmail` extrait dans `src/lib/email.ts` et réutilisé dans l'action contact (factorisation d'une regex dupliquée).
- **Catch des erreurs Auth.js** post-Resend : quota dépassé, panne, clé invalide, email refusé par Resend malgré regex OK → message *"Impossible d'envoyer l'email pour le moment. Réessayez dans un instant."* au lieu de rediriger vers `/auth/error`. `unstable_rethrow` relance les `NEXT_REDIRECT` du flow succès.
- **Formulaire** : `useActionState` (aligné sur `contact-form.tsx`, `moment-form.tsx`), `aria-invalid` + `aria-describedby` conditionnels.

## Test plan

- [ ] `foo@bar` → message « Adresse email invalide », pas d'appel Resend, pas de remontée Sentry `magic_link`
- [ ] `coco@google.com.` (point final) → rejeté localement
- [ ] Email valide, `AUTH_RESEND_KEY` décommenté en local → magic link reçu, redirection vers `/auth/verify-request`
- [ ] Email valide, simuler échec Resend (clé invalide temporaire) → message « Impossible d'envoyer l'email pour le moment », reste sur la page sign-in
- [ ] UI FR et EN vérifiées

## Notes

- `ActionResult<T>` (pattern `contact.ts`) non utilisé ici : pas de state succès visible côté form (redirect Next), `{ error } | null` est plus direct.
- Capture Sentry existante dans `auth.config.ts:38-45` conservée : la supervision prod garde le contexte riche (`email_domain`, `resend_message`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)