### PR TITLE
feat(sentry): analyse d'erreur orientee fonctionnel (declencheur, consequence, impact)

### DIFF
--- a/src/infrastructure/services/sentry/analysis-meta.ts
+++ b/src/infrastructure/services/sentry/analysis-meta.ts
@@ -1,0 +1,33 @@
+export type Urgency = "critical" | "high" | "medium" | "low" | "noise";
+export type UserImpactLevel = "none" | "silent" | "degraded" | "blocking";
+
+export type UserImpact = {
+  level: UserImpactLevel;
+  description: string;
+};
+
+export type AnalysisResult = {
+  urgency: Urgency;
+  trigger: string;
+  functionalConsequence: string;
+  userImpact: UserImpact;
+  technical: string;
+};
+
+export const URGENCY_META: Record<Urgency, { label: string; color: string }> = {
+  critical: { label: "CRITIQUE", color: "#dc2626" },
+  high: { label: "HAUTE", color: "#ea580c" },
+  medium: { label: "MOYENNE", color: "#ca8a04" },
+  low: { label: "BASSE", color: "#2563eb" },
+  noise: { label: "BRUIT", color: "#71717a" },
+};
+
+export const USER_IMPACT_META: Record<
+  UserImpactLevel,
+  { label: string; color: string; emoji: string }
+> = {
+  none: { label: "AUCUN IMPACT UTILISATEUR", color: "#16a34a", emoji: "🟢" },
+  silent: { label: "IMPACT SILENCIEUX", color: "#71717a", emoji: "⚪" },
+  degraded: { label: "EXPÉRIENCE DÉGRADÉE", color: "#ea580c", emoji: "🟠" },
+  blocking: { label: "UTILISATEUR BLOQUÉ", color: "#dc2626", emoji: "🔴" },
+};

--- a/src/infrastructure/services/sentry/analyze-issue.ts
+++ b/src/infrastructure/services/sentry/analyze-issue.ts
@@ -3,11 +3,15 @@ import { Resend } from "resend";
 import { getSender } from "@/infrastructure/services/email/resend-email-service";
 import { notifySlackSentryIssue, isAdminEmailEnabled } from "@/infrastructure/services/slack/slack-notification-service";
 import { SentryIssueAnalysisEmail } from "./sentry-issue-analysis-email";
+import { URGENCY_META, type AnalysisResult, type UserImpact, type UserImpactLevel } from "./analysis-meta";
+import { buildAnalysisPrompt } from "./build-prompt";
+
+export type { UserImpact, UserImpactLevel } from "./analysis-meta";
 
 const SENTRY_REGION = "https://de.sentry.io";
 const ANTHROPIC_MODEL = "claude-haiku-4-5-20251001";
 
-type IssueInput = {
+export type IssueInput = {
   issueId: string;
   issueShortId: string;
   issueTitle: string;
@@ -103,29 +107,20 @@ function extractEventContext(event: SentryEvent): EventContext {
   };
 }
 
-export type UserImpactLevel = "none" | "silent" | "degraded" | "blocking";
-
-export type UserImpact = {
-  level: UserImpactLevel;
-  description: string;
-};
-
-type AnalysisResult = {
-  urgency: "critical" | "high" | "medium" | "low" | "noise";
-  trigger: string;
-  functionalConsequence: string;
-  userImpact: UserImpact;
-  technical: string;
-};
-
 const FALLBACK_USER_IMPACT: UserImpact = {
   level: "silent",
   description: "Impact utilisateur non évalué, à vérifier manuellement dans Sentry",
 };
 
-const FALLBACK_TRIGGER = "Déclencheur non identifié — vérifier les tags Sentry (cron, url, action)";
-const FALLBACK_CONSEQUENCE = "Conséquence fonctionnelle non identifiée — inspecter le handler concerné";
-const FALLBACK_TECHNICAL = "Analyse technique indisponible — ouvrir l'issue dans Sentry";
+function fallbackResult(issue: IssueInput, rawText?: string): AnalysisResult {
+  return {
+    urgency: "medium",
+    trigger: "Déclencheur non identifié — vérifier les tags Sentry (cron, url, action)",
+    functionalConsequence: "Conséquence fonctionnelle non identifiée — inspecter le handler concerné",
+    userImpact: FALLBACK_USER_IMPACT,
+    technical: rawText?.slice(0, 300) ?? `${issue.issueTitle} — analyse technique indisponible, ouvrir l'issue dans Sentry`,
+  };
+}
 
 function isValidUserImpact(value: unknown): value is UserImpact {
   if (!value || typeof value !== "object") return false;
@@ -139,24 +134,17 @@ function isValidUserImpact(value: unknown): value is UserImpact {
   );
 }
 
-function formatTagsForPrompt(tags: Record<string, string>): string {
-  const keysOfInterest = [
-    "cron",
-    "environment",
-    "release",
-    "url",
-    "transaction",
-    "route",
-    "server_action",
-    "runtime",
-    "handled",
-    "mechanism",
-  ];
-  const pairs = keysOfInterest
-    .filter((k) => tags[k])
-    .map((k) => `${k}=${tags[k]}`);
-  if (pairs.length === 0) return "(aucun tag utile)";
-  return pairs.join(", ");
+function isValidAnalysisResult(value: unknown): value is AnalysisResult {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Partial<AnalysisResult>;
+  const validUrgencies: AnalysisResult["urgency"][] = ["critical", "high", "medium", "low", "noise"];
+  return (
+    typeof v.urgency === "string" && validUrgencies.includes(v.urgency as AnalysisResult["urgency"]) &&
+    typeof v.trigger === "string" && v.trigger.length > 0 &&
+    typeof v.functionalConsequence === "string" && v.functionalConsequence.length > 0 &&
+    typeof v.technical === "string" && v.technical.length > 0 &&
+    isValidUserImpact(v.userImpact)
+  );
 }
 
 async function analyzeWithClaude(
@@ -166,111 +154,13 @@ async function analyzeWithClaude(
   const apiKey = process.env.ANTHROPIC_API_KEY;
   if (!apiKey) {
     return {
-      urgency: "medium",
-      trigger: FALLBACK_TRIGGER,
-      functionalConsequence: FALLBACK_CONSEQUENCE,
+      ...fallbackResult(issue),
       userImpact: { level: "silent", description: "Impossible d'analyser (ANTHROPIC_API_KEY manquante)" },
-      technical: issue.issueTitle,
     };
   }
 
   const client = new Anthropic({ apiKey });
-
-  const tagsLine = formatTagsForPrompt(context.tags);
-  const requestLine = context.requestUrl
-    ? `${context.requestMethod ?? "?"} ${context.requestUrl}`
-    : "(aucune request HTTP — probablement un job background, cron ou server action)";
-
-  const prompt = `Analyse cette erreur Sentry d'une application Next.js (The Playground - plateforme de communautés/événements).
-
-Tu produis une analyse LISIBLE PAR UN NON-TECHNICIEN. Ton objectif : expliquer QUI a déclenché l'erreur, QUOI est cassé côté produit, et COMMENT l'utilisateur le ressent. Les détails techniques viennent en dernier, condensés.
-
-## Contexte de l'erreur
-
-Issue: ${issue.issueShortId}
-Titre: ${issue.issueTitle}
-Culprit: ${issue.culprit}
-Level: ${issue.level}
-Platform: ${issue.platform}
-Metadata: type=${issue.metadata.type}, filename=${issue.metadata.filename}, function=${issue.metadata.function}
-Tags pertinents: ${tagsLine}
-Request: ${requestLine}
-
-Stacktrace et contexte:
-${context.stacktrace || "(aucune stacktrace disponible)"}
-
-## Réponds UNIQUEMENT avec un JSON valide
-
-{
-  "urgency": "critical|high|medium|low|noise",
-  "trigger": "Phrase courte (1-2) qui répond à : qu'est-ce qui a provoqué cette erreur ? Précise le contexte d'activité (page, action utilisateur, cron, webhook, job). Langage métier, pas technique.",
-  "functionalConsequence": "Phrase courte (1-2) qui répond à : qu'est-ce qui est cassé côté produit ? En termes métier (inscription, paiement, création d'événement, rappel, check-in, commentaire, affichage). PAS de jargon DB/framework.",
-  "userImpact": {
-    "level": "none|silent|degraded|blocking",
-    "description": "Phrase courte (1-2) qui commence par le rôle concerné (un participant, un organisateur, un visiteur anonyme, aucun utilisateur). Décrit CE QUE RESSENT l'utilisateur : écran d'erreur, email pas reçu, bouton qui ne répond pas, etc. PAS de jargon."
-  },
-  "technical": "Bloc condensé (3 phrases max) réservé aux devs : cause probable + fichier/fonction à investiguer + piste de correction. Peut contenir du jargon."
-}
-
-## Heuristiques pour le TRIGGER
-
-Ordre de priorité :
-1. Si tag \`cron\` présent → "Le cron automatique <nom> (<fréquence si connue>). Aucune action utilisateur."
-2. Si request URL présente :
-   - \`/api/cron/*\` → cron
-   - \`/api/webhook/*\` ou \`/api/*/webhook\` → "Un webhook <service> reçu par la plateforme"
-   - \`/api/*\` → "Un appel API depuis le frontend"
-   - \`/m/[slug]\` → "Un visiteur/participant consulte une page événement"
-   - \`/c/[slug]\` → "Un visiteur consulte une page Communauté"
-   - \`/dashboard/*\` → "Un organisateur utilise son dashboard"
-   - \`/explorer\` → "Un visiteur parcourt la page Découvrir"
-   - Autre → cite le chemin
-3. Si la stack contient une server action nommée (\`createMoment\`, \`registerToMoment\`, etc.) → "Un utilisateur a lancé l'action <nom> (<ce que ça fait en clair>)"
-4. Sinon, regarder les noms de fichiers inApp pour déduire le contexte (email/, stripe/, auth/...)
-
-Ne JAMAIS dire "Une erreur s'est produite". Sois spécifique.
-
-## Heuristiques pour la FUNCTIONAL CONSEQUENCE
-
-Traduire la partie technique en impact produit concret :
-- Query DB qui timeout pendant envoi rappels → "Les rappels email n'ont pas pu être envoyés pour ce run"
-- Erreur Stripe webhook → "Un paiement n'a pas été confirmé côté plateforme"
-- Erreur dans server action \`registerToMoment\` → "Une inscription à un événement n'a pas pu aboutir"
-- Erreur OG image generation → "L'aperçu social (OG image) d'un événement n'est pas généré"
-- Erreur auth magic link → "L'envoi du magic link de connexion a échoué"
-
-Ne PAS dire "la query findMany a échoué" — dire ce que ça représente produit.
-
-## Heuristiques pour USER IMPACT
-
-Niveau (\`level\`) :
-- "none" = l'utilisateur ne perçoit absolument rien (script tiers, handler pagehide/unload, erreur silencieuse, bot, cron sans conséquence visible immédiate)
-- "silent" = erreur visible uniquement en devtools, aucune gêne fonctionnelle
-- "degraded" = expérience dégradée mais utilisable (feature secondaire cassée, notification manquante, fallback, latence)
-- "blocking" = l'utilisateur est bloqué et ne peut pas accomplir son action
-
-Checklist :
-1. Script tiers (PostHog, GA, Stripe.js, extension) ? → level ≤ silent
-2. Pendant pagehide/unload/visibilitychange/beforeunload ? → level = none
-3. Handled (try/catch, mechanism.handled=true) ? → level ≤ silent dans la plupart des cas, SAUF si l'utilisateur voit une page 500 ou un message d'erreur
-4. Crash visuel prouvé par la stack ou le contexte ? → degraded ou blocking
-
-Description (\`userImpact.description\`) :
-- Commence par le rôle : "Un participant...", "Un organisateur...", "Un visiteur anonyme...", "Aucun utilisateur..."
-- Décrit CE QU'IL VOIT OU NE VOIT PAS : "verra un écran 500", "ne recevra pas son email de rappel", "ne pourra pas cliquer sur Publier", "reste sur la page blanche quelques secondes puis réessaye"
-- Dans le doute, préfère "none"/"silent" et dis-le franchement ("aucun utilisateur affecté directement pour ce run")
-
-## Heuristiques pour URGENCY
-
-- "critical" = perte de données, paiement cassé, auth cassée
-- "high" = fonctionnalité principale cassée pour de vrais utilisateurs
-- "medium" = bug visible mais contournable
-- "low" = cosmétique, edge case rare
-- "noise" = extension navigateur, bot, erreur non-actionnable
-
-## Règle d'or
-
-Si tu hésites à mettre du jargon, demande-toi : est-ce qu'un organisateur non-tech comprendrait ? Si non → reformule. Les seules sections où le jargon est permis sont \`technical\` et le culprit implicite.`;
+  const prompt = buildAnalysisPrompt(issue, context);
 
   const resp = await client.messages.create({
     model: ANTHROPIC_MODEL,
@@ -279,46 +169,19 @@ Si tu hésites à mettre du jargon, demande-toi : est-ce qu'un organisateur non-
   });
 
   const tb = resp.content.find((b): b is Anthropic.Messages.TextBlock => b.type === "text");
-  if (!tb) {
-    return fallbackResult(issue);
-  }
+  if (!tb) return fallbackResult(issue);
 
   try {
     const raw = tb.text.trim();
-    const jsonStr = raw.startsWith("{") ? raw : raw.slice(raw.indexOf("{"), raw.lastIndexOf("}") + 1);
-    const parsed = JSON.parse(jsonStr) as Partial<AnalysisResult>;
-    if (
-      !parsed.urgency ||
-      typeof parsed.trigger !== "string" || parsed.trigger.length === 0 ||
-      typeof parsed.functionalConsequence !== "string" || parsed.functionalConsequence.length === 0 ||
-      typeof parsed.technical !== "string" || parsed.technical.length === 0 ||
-      !isValidUserImpact(parsed.userImpact)
-    ) {
-      return { ...fallbackResult(issue), technical: tb.text.slice(0, 300) };
-    }
-    return parsed as AnalysisResult;
+    const openBrace = raw.indexOf("{");
+    const closeBrace = raw.lastIndexOf("}");
+    const jsonStr = openBrace >= 0 && closeBrace > openBrace ? raw.slice(openBrace, closeBrace + 1) : raw;
+    const parsed = JSON.parse(jsonStr);
+    return isValidAnalysisResult(parsed) ? parsed : fallbackResult(issue, tb.text);
   } catch {
-    return { ...fallbackResult(issue), technical: tb.text.slice(0, 300) };
+    return fallbackResult(issue, tb.text);
   }
 }
-
-function fallbackResult(issue: IssueInput): AnalysisResult {
-  return {
-    urgency: "medium",
-    trigger: FALLBACK_TRIGGER,
-    functionalConsequence: FALLBACK_CONSEQUENCE,
-    userImpact: FALLBACK_USER_IMPACT,
-    technical: `${issue.issueTitle} — ${FALLBACK_TECHNICAL}`,
-  };
-}
-
-const URGENCY_LABELS: Record<string, string> = {
-  critical: "CRITIQUE",
-  high: "HAUTE",
-  medium: "MOYENNE",
-  low: "BASSE",
-  noise: "BRUIT",
-};
 
 async function sendAnalysisEmail(
   issue: IssueInput,
@@ -330,23 +193,13 @@ async function sendAnalysisEmail(
 
   const resend = new Resend(resendKey);
   const adminEmail = process.env.SENTRY_ALERT_EMAIL ?? "ddreptate@gmail.com";
-  const urgencyLabel = URGENCY_LABELS[analysis.urgency] ?? "INCONNUE";
+  const urgencyLabel = URGENCY_META[analysis.urgency].label;
 
   await resend.emails.send({
     from: getSender(),
     to: adminEmail,
     subject: `[Sentry ${urgencyLabel}] ${issue.issueShortId} — ${issue.issueTitle.slice(0, 80)}`,
-    react: SentryIssueAnalysisEmail({
-      issueShortId: issue.issueShortId,
-      issueTitle: issue.issueTitle,
-      urgency: analysis.urgency,
-      urgencyLabel,
-      trigger: analysis.trigger,
-      functionalConsequence: analysis.functionalConsequence,
-      userImpact: analysis.userImpact,
-      technical: analysis.technical,
-      sentryUrl,
-    }),
+    react: SentryIssueAnalysisEmail({ issue, analysis, sentryUrl }),
   });
 }
 
@@ -356,29 +209,16 @@ export async function analyzeSentryIssue(issue: IssueInput): Promise<void> {
 
   const sentryOrg = process.env.SENTRY_ORG ?? "the-playground-id";
 
-  // 1. Fetch latest event with stacktrace + tags + request
   const event = await fetchLatestEvent(issue.issueId, token);
   const context: EventContext = event
     ? extractEventContext(event)
     : { stacktrace: "", tags: {} };
 
-  // 2. Analyze with Claude
   const analysis = await analyzeWithClaude(issue, context);
-
-  // 3. Send Slack + email (if enabled)
   const sentryUrl = `https://${sentryOrg}.sentry.io/issues/${issue.issueId}/`;
-  const urgencyLabel = URGENCY_LABELS[analysis.urgency] ?? "INCONNUE";
+
   await Promise.all([
     isAdminEmailEnabled() ? sendAnalysisEmail(issue, analysis, sentryUrl) : Promise.resolve(),
-    notifySlackSentryIssue({
-      issueShortId: issue.issueShortId,
-      issueTitle: issue.issueTitle,
-      urgencyLabel,
-      trigger: analysis.trigger,
-      functionalConsequence: analysis.functionalConsequence,
-      userImpact: analysis.userImpact,
-      technical: analysis.technical,
-      sentryUrl,
-    }),
+    notifySlackSentryIssue({ issue, analysis, sentryUrl }),
   ]);
 }

--- a/src/infrastructure/services/sentry/analyze-issue.ts
+++ b/src/infrastructure/services/sentry/analyze-issue.ts
@@ -36,6 +36,7 @@ type SentryEvent = {
   eventID: string;
   title: string;
   tags: { key: string; value: string }[];
+  request?: { url?: string; method?: string };
   entries: {
     type: string;
     data: {
@@ -65,7 +66,14 @@ async function fetchLatestEvent(issueId: string, token: string): Promise<SentryE
   }
 }
 
-function extractStacktraceSummary(event: SentryEvent): string {
+type EventContext = {
+  stacktrace: string;
+  tags: Record<string, string>;
+  requestUrl?: string;
+  requestMethod?: string;
+};
+
+function extractEventContext(event: SentryEvent): EventContext {
   const lines: string[] = [];
 
   for (const entry of event.entries) {
@@ -82,14 +90,17 @@ function extractStacktraceSummary(event: SentryEvent): string {
     }
   }
 
-  const url = event.tags.find((t) => t.key === "url")?.value;
-  const browser = event.tags.find((t) => t.key === "browser")?.value;
-  const os = event.tags.find((t) => t.key === "os")?.value;
-  if (url) lines.push(`URL: ${url}`);
-  if (browser) lines.push(`Browser: ${browser}`);
-  if (os) lines.push(`OS: ${os}`);
+  const tags: Record<string, string> = {};
+  for (const t of event.tags ?? []) {
+    tags[t.key] = t.value;
+  }
 
-  return lines.join("\n");
+  return {
+    stacktrace: lines.join("\n"),
+    tags,
+    requestUrl: event.request?.url,
+    requestMethod: event.request?.method,
+  };
 }
 
 export type UserImpactLevel = "none" | "silent" | "degraded" | "blocking";
@@ -101,15 +112,20 @@ export type UserImpact = {
 
 type AnalysisResult = {
   urgency: "critical" | "high" | "medium" | "low" | "noise";
+  trigger: string;
+  functionalConsequence: string;
   userImpact: UserImpact;
-  diagnosis: string;
-  remediation: string;
+  technical: string;
 };
 
 const FALLBACK_USER_IMPACT: UserImpact = {
   level: "silent",
   description: "Impact utilisateur non évalué, à vérifier manuellement dans Sentry",
 };
+
+const FALLBACK_TRIGGER = "Déclencheur non identifié — vérifier les tags Sentry (cron, url, action)";
+const FALLBACK_CONSEQUENCE = "Conséquence fonctionnelle non identifiée — inspecter le handler concerné";
+const FALLBACK_TECHNICAL = "Analyse technique indisponible — ouvrir l'issue dans Sentry";
 
 function isValidUserImpact(value: unknown): value is UserImpact {
   if (!value || typeof value !== "object") return false;
@@ -123,23 +139,53 @@ function isValidUserImpact(value: unknown): value is UserImpact {
   );
 }
 
+function formatTagsForPrompt(tags: Record<string, string>): string {
+  const keysOfInterest = [
+    "cron",
+    "environment",
+    "release",
+    "url",
+    "transaction",
+    "route",
+    "server_action",
+    "runtime",
+    "handled",
+    "mechanism",
+  ];
+  const pairs = keysOfInterest
+    .filter((k) => tags[k])
+    .map((k) => `${k}=${tags[k]}`);
+  if (pairs.length === 0) return "(aucun tag utile)";
+  return pairs.join(", ");
+}
+
 async function analyzeWithClaude(
   issue: IssueInput,
-  stacktrace: string
+  context: EventContext
 ): Promise<AnalysisResult> {
   const apiKey = process.env.ANTHROPIC_API_KEY;
   if (!apiKey) {
     return {
       urgency: "medium",
+      trigger: FALLBACK_TRIGGER,
+      functionalConsequence: FALLBACK_CONSEQUENCE,
       userImpact: { level: "silent", description: "Impossible d'analyser (ANTHROPIC_API_KEY manquante)" },
-      diagnosis: issue.issueTitle,
-      remediation: "Vérifier manuellement dans Sentry",
+      technical: issue.issueTitle,
     };
   }
 
   const client = new Anthropic({ apiKey });
 
+  const tagsLine = formatTagsForPrompt(context.tags);
+  const requestLine = context.requestUrl
+    ? `${context.requestMethod ?? "?"} ${context.requestUrl}`
+    : "(aucune request HTTP — probablement un job background, cron ou server action)";
+
   const prompt = `Analyse cette erreur Sentry d'une application Next.js (The Playground - plateforme de communautés/événements).
+
+Tu produis une analyse LISIBLE PAR UN NON-TECHNICIEN. Ton objectif : expliquer QUI a déclenché l'erreur, QUOI est cassé côté produit, et COMMENT l'utilisateur le ressent. Les détails techniques viennent en dernier, condensés.
+
+## Contexte de l'erreur
 
 Issue: ${issue.issueShortId}
 Titre: ${issue.issueTitle}
@@ -147,64 +193,123 @@ Culprit: ${issue.culprit}
 Level: ${issue.level}
 Platform: ${issue.platform}
 Metadata: type=${issue.metadata.type}, filename=${issue.metadata.filename}, function=${issue.metadata.function}
+Tags pertinents: ${tagsLine}
+Request: ${requestLine}
 
 Stacktrace et contexte:
-${stacktrace || "(aucune stacktrace disponible)"}
+${context.stacktrace || "(aucune stacktrace disponible)"}
 
-Réponds UNIQUEMENT avec un JSON valide:
+## Réponds UNIQUEMENT avec un JSON valide
+
 {
   "urgency": "critical|high|medium|low|noise",
+  "trigger": "Phrase courte (1-2) qui répond à : qu'est-ce qui a provoqué cette erreur ? Précise le contexte d'activité (page, action utilisateur, cron, webhook, job). Langage métier, pas technique.",
+  "functionalConsequence": "Phrase courte (1-2) qui répond à : qu'est-ce qui est cassé côté produit ? En termes métier (inscription, paiement, création d'événement, rappel, check-in, commentaire, affichage). PAS de jargon DB/framework.",
   "userImpact": {
     "level": "none|silent|degraded|blocking",
-    "description": "Ce que l'utilisateur voit ou fait concrètement. Commence par 'L'utilisateur...'. 1 à 2 phrases."
+    "description": "Phrase courte (1-2) qui commence par le rôle concerné (un participant, un organisateur, un visiteur anonyme, aucun utilisateur). Décrit CE QUE RESSENT l'utilisateur : écran d'erreur, email pas reçu, bouton qui ne répond pas, etc. PAS de jargon."
   },
-  "diagnosis": "explication technique de la cause (2-3 phrases max)",
-  "remediation": "plan de correction concret (fichier à modifier, approche, 2-3 phrases max)"
+  "technical": "Bloc condensé (3 phrases max) réservé aux devs : cause probable + fichier/fonction à investiguer + piste de correction. Peut contenir du jargon."
 }
 
-Règles de priorisation technique (urgency):
-- "noise" = erreur d'extension navigateur, bot, ou erreur non-actionnable
-- "critical" = perte de données, paiement échoué, auth cassée
-- "high" = fonctionnalité principale cassée pour les utilisateurs
-- "medium" = bug visible mais contournable
-- "low" = cosmétique, edge case rare
+## Heuristiques pour le TRIGGER
 
-Règles d'impact utilisateur (userImpact.level) — OBLIGATOIRE, s'évalue séparément de urgency:
-- "none" = l'utilisateur ne perçoit absolument rien (script tiers, handler pagehide/unload, erreur silencieuse, bot)
+Ordre de priorité :
+1. Si tag \`cron\` présent → "Le cron automatique <nom> (<fréquence si connue>). Aucune action utilisateur."
+2. Si request URL présente :
+   - \`/api/cron/*\` → cron
+   - \`/api/webhook/*\` ou \`/api/*/webhook\` → "Un webhook <service> reçu par la plateforme"
+   - \`/api/*\` → "Un appel API depuis le frontend"
+   - \`/m/[slug]\` → "Un visiteur/participant consulte une page événement"
+   - \`/c/[slug]\` → "Un visiteur consulte une page Communauté"
+   - \`/dashboard/*\` → "Un organisateur utilise son dashboard"
+   - \`/explorer\` → "Un visiteur parcourt la page Découvrir"
+   - Autre → cite le chemin
+3. Si la stack contient une server action nommée (\`createMoment\`, \`registerToMoment\`, etc.) → "Un utilisateur a lancé l'action <nom> (<ce que ça fait en clair>)"
+4. Sinon, regarder les noms de fichiers inApp pour déduire le contexte (email/, stripe/, auth/...)
+
+Ne JAMAIS dire "Une erreur s'est produite". Sois spécifique.
+
+## Heuristiques pour la FUNCTIONAL CONSEQUENCE
+
+Traduire la partie technique en impact produit concret :
+- Query DB qui timeout pendant envoi rappels → "Les rappels email n'ont pas pu être envoyés pour ce run"
+- Erreur Stripe webhook → "Un paiement n'a pas été confirmé côté plateforme"
+- Erreur dans server action \`registerToMoment\` → "Une inscription à un événement n'a pas pu aboutir"
+- Erreur OG image generation → "L'aperçu social (OG image) d'un événement n'est pas généré"
+- Erreur auth magic link → "L'envoi du magic link de connexion a échoué"
+
+Ne PAS dire "la query findMany a échoué" — dire ce que ça représente produit.
+
+## Heuristiques pour USER IMPACT
+
+Niveau (\`level\`) :
+- "none" = l'utilisateur ne perçoit absolument rien (script tiers, handler pagehide/unload, erreur silencieuse, bot, cron sans conséquence visible immédiate)
 - "silent" = erreur visible uniquement en devtools, aucune gêne fonctionnelle
-- "degraded" = expérience dégradée mais utilisable (feature secondaire cassée, fallback, latence)
+- "degraded" = expérience dégradée mais utilisable (feature secondaire cassée, notification manquante, fallback, latence)
 - "blocking" = l'utilisateur est bloqué et ne peut pas accomplir son action
 
-Avant de choisir le level, parcours cette checklist:
-1. L'erreur vient-elle d'un script tiers (PostHog, Google Analytics, Stripe.js, extension) sans notre code dans la stack ? → level ≤ silent
-2. L'erreur se déclenche-t-elle pendant pagehide, unload, visibilitychange, beforeunload ? → level = none (l'utilisateur a déjà quitté)
-3. L'erreur est-elle handled (try/catch, mécanisme handled:true) ? → level ≤ silent
-4. La stack ou le contexte prouvent-ils un crash visuel, un message d'erreur UI, ou une action bloquée ? → sinon level ≠ blocking
+Checklist :
+1. Script tiers (PostHog, GA, Stripe.js, extension) ? → level ≤ silent
+2. Pendant pagehide/unload/visibilitychange/beforeunload ? → level = none
+3. Handled (try/catch, mechanism.handled=true) ? → level ≤ silent dans la plupart des cas, SAUF si l'utilisateur voit une page 500 ou un message d'erreur
+4. Crash visuel prouvé par la stack ou le contexte ? → degraded ou blocking
 
-Règle d'or: "level" décrit ce que voit ou fait l'utilisateur, pas ce qui se passe en interne. Dans le doute, préfère "none" ou "silent". Ne jamais inventer un impact non prouvé par la stack.`;
+Description (\`userImpact.description\`) :
+- Commence par le rôle : "Un participant...", "Un organisateur...", "Un visiteur anonyme...", "Aucun utilisateur..."
+- Décrit CE QU'IL VOIT OU NE VOIT PAS : "verra un écran 500", "ne recevra pas son email de rappel", "ne pourra pas cliquer sur Publier", "reste sur la page blanche quelques secondes puis réessaye"
+- Dans le doute, préfère "none"/"silent" et dis-le franchement ("aucun utilisateur affecté directement pour ce run")
+
+## Heuristiques pour URGENCY
+
+- "critical" = perte de données, paiement cassé, auth cassée
+- "high" = fonctionnalité principale cassée pour de vrais utilisateurs
+- "medium" = bug visible mais contournable
+- "low" = cosmétique, edge case rare
+- "noise" = extension navigateur, bot, erreur non-actionnable
+
+## Règle d'or
+
+Si tu hésites à mettre du jargon, demande-toi : est-ce qu'un organisateur non-tech comprendrait ? Si non → reformule. Les seules sections où le jargon est permis sont \`technical\` et le culprit implicite.`;
 
   const resp = await client.messages.create({
     model: ANTHROPIC_MODEL,
-    max_tokens: 600,
+    max_tokens: 900,
     messages: [{ role: "user", content: prompt }],
   });
 
   const tb = resp.content.find((b): b is Anthropic.Messages.TextBlock => b.type === "text");
   if (!tb) {
-    return { urgency: "medium", userImpact: FALLBACK_USER_IMPACT, diagnosis: issue.issueTitle, remediation: "Vérifier manuellement" };
+    return fallbackResult(issue);
   }
 
   try {
     const raw = tb.text.trim();
     const jsonStr = raw.startsWith("{") ? raw : raw.slice(raw.indexOf("{"), raw.lastIndexOf("}") + 1);
     const parsed = JSON.parse(jsonStr) as Partial<AnalysisResult>;
-    if (!parsed.urgency || !parsed.diagnosis || !parsed.remediation || !isValidUserImpact(parsed.userImpact)) {
-      return { urgency: "medium", userImpact: FALLBACK_USER_IMPACT, diagnosis: tb.text.slice(0, 200), remediation: "Vérifier manuellement" };
+    if (
+      !parsed.urgency ||
+      typeof parsed.trigger !== "string" || parsed.trigger.length === 0 ||
+      typeof parsed.functionalConsequence !== "string" || parsed.functionalConsequence.length === 0 ||
+      typeof parsed.technical !== "string" || parsed.technical.length === 0 ||
+      !isValidUserImpact(parsed.userImpact)
+    ) {
+      return { ...fallbackResult(issue), technical: tb.text.slice(0, 300) };
     }
     return parsed as AnalysisResult;
   } catch {
-    return { urgency: "medium", userImpact: FALLBACK_USER_IMPACT, diagnosis: tb.text.slice(0, 200), remediation: "Vérifier manuellement" };
+    return { ...fallbackResult(issue), technical: tb.text.slice(0, 300) };
   }
+}
+
+function fallbackResult(issue: IssueInput): AnalysisResult {
+  return {
+    urgency: "medium",
+    trigger: FALLBACK_TRIGGER,
+    functionalConsequence: FALLBACK_CONSEQUENCE,
+    userImpact: FALLBACK_USER_IMPACT,
+    technical: `${issue.issueTitle} — ${FALLBACK_TECHNICAL}`,
+  };
 }
 
 const URGENCY_LABELS: Record<string, string> = {
@@ -234,12 +339,12 @@ async function sendAnalysisEmail(
     react: SentryIssueAnalysisEmail({
       issueShortId: issue.issueShortId,
       issueTitle: issue.issueTitle,
-      culprit: issue.culprit,
       urgency: analysis.urgency,
       urgencyLabel,
+      trigger: analysis.trigger,
+      functionalConsequence: analysis.functionalConsequence,
       userImpact: analysis.userImpact,
-      diagnosis: analysis.diagnosis,
-      remediation: analysis.remediation,
+      technical: analysis.technical,
       sentryUrl,
     }),
   });
@@ -251,12 +356,14 @@ export async function analyzeSentryIssue(issue: IssueInput): Promise<void> {
 
   const sentryOrg = process.env.SENTRY_ORG ?? "the-playground-id";
 
-  // 1. Fetch latest event with stacktrace
+  // 1. Fetch latest event with stacktrace + tags + request
   const event = await fetchLatestEvent(issue.issueId, token);
-  const stacktrace = event ? extractStacktraceSummary(event) : "";
+  const context: EventContext = event
+    ? extractEventContext(event)
+    : { stacktrace: "", tags: {} };
 
   // 2. Analyze with Claude
-  const analysis = await analyzeWithClaude(issue, stacktrace);
+  const analysis = await analyzeWithClaude(issue, context);
 
   // 3. Send Slack + email (if enabled)
   const sentryUrl = `https://${sentryOrg}.sentry.io/issues/${issue.issueId}/`;
@@ -266,11 +373,11 @@ export async function analyzeSentryIssue(issue: IssueInput): Promise<void> {
     notifySlackSentryIssue({
       issueShortId: issue.issueShortId,
       issueTitle: issue.issueTitle,
-      culprit: issue.culprit,
       urgencyLabel,
+      trigger: analysis.trigger,
+      functionalConsequence: analysis.functionalConsequence,
       userImpact: analysis.userImpact,
-      diagnosis: analysis.diagnosis,
-      remediation: analysis.remediation,
+      technical: analysis.technical,
       sentryUrl,
     }),
   ]);

--- a/src/infrastructure/services/sentry/build-prompt.ts
+++ b/src/infrastructure/services/sentry/build-prompt.ts
@@ -1,0 +1,128 @@
+type IssueForPrompt = {
+  issueShortId: string;
+  issueTitle: string;
+  culprit: string;
+  level: string;
+  platform: string;
+  metadata: { type?: string; value?: string; filename?: string; function?: string };
+};
+
+type ContextForPrompt = {
+  stacktrace: string;
+  tags: Record<string, string>;
+  requestUrl?: string;
+  requestMethod?: string;
+};
+
+const TAG_KEYS_OF_INTEREST = [
+  "cron",
+  "environment",
+  "release",
+  "url",
+  "transaction",
+  "route",
+  "server_action",
+  "runtime",
+];
+
+function formatTags(tags: Record<string, string>): string {
+  const pairs = TAG_KEYS_OF_INTEREST.filter((k) => tags[k]).map((k) => `${k}=${tags[k]}`);
+  return pairs.length === 0 ? "(aucun tag utile)" : pairs.join(", ");
+}
+
+export function buildAnalysisPrompt(issue: IssueForPrompt, context: ContextForPrompt): string {
+  const requestLine = context.requestUrl
+    ? `${context.requestMethod ?? "?"} ${context.requestUrl}`
+    : "(aucune request HTTP — probablement un job background, cron ou server action)";
+
+  return `Analyse cette erreur Sentry d'une application Next.js (The Playground - plateforme de communautés/événements).
+
+Tu produis une analyse LISIBLE PAR UN NON-TECHNICIEN. Ton objectif : expliquer QUI a déclenché l'erreur, QUOI est cassé côté produit, et COMMENT l'utilisateur le ressent. Les détails techniques viennent en dernier, condensés.
+
+## Contexte de l'erreur
+
+Issue: ${issue.issueShortId}
+Titre: ${issue.issueTitle}
+Culprit: ${issue.culprit}
+Level: ${issue.level}
+Platform: ${issue.platform}
+Metadata: type=${issue.metadata.type}, filename=${issue.metadata.filename}, function=${issue.metadata.function}
+Tags pertinents: ${formatTags(context.tags)}
+Request: ${requestLine}
+
+Stacktrace et contexte:
+${context.stacktrace || "(aucune stacktrace disponible)"}
+
+## Réponds UNIQUEMENT avec un JSON valide
+
+{
+  "urgency": "critical|high|medium|low|noise",
+  "trigger": "Phrase courte (1-2) qui répond à : qu'est-ce qui a provoqué cette erreur ? Précise le contexte d'activité (page, action utilisateur, cron, webhook, job). Langage métier, pas technique.",
+  "functionalConsequence": "Phrase courte (1-2) qui répond à : qu'est-ce qui est cassé côté produit ? En termes métier (inscription, paiement, création d'événement, rappel, check-in, commentaire, affichage). PAS de jargon DB/framework.",
+  "userImpact": {
+    "level": "none|silent|degraded|blocking",
+    "description": "Phrase courte (1-2) qui commence par le rôle concerné (un participant, un organisateur, un visiteur anonyme, aucun utilisateur). Décrit CE QUE RESSENT l'utilisateur : écran d'erreur, email pas reçu, bouton qui ne répond pas, etc. PAS de jargon."
+  },
+  "technical": "Bloc condensé (3 phrases max) réservé aux devs : cause probable + fichier/fonction à investiguer + piste de correction. Peut contenir du jargon."
+}
+
+## Heuristiques pour le TRIGGER
+
+Ordre de priorité :
+1. Si tag \`cron\` présent → "Le cron automatique <nom> (<fréquence si connue>). Aucune action utilisateur."
+2. Si request URL présente :
+   - \`/api/cron/*\` → cron
+   - \`/api/webhook/*\` ou \`/api/*/webhook\` → "Un webhook <service> reçu par la plateforme"
+   - \`/api/*\` → "Un appel API depuis le frontend"
+   - \`/m/[slug]\` → "Un visiteur/participant consulte une page événement"
+   - \`/c/[slug]\` → "Un visiteur consulte une page Communauté"
+   - \`/dashboard/*\` → "Un organisateur utilise son dashboard"
+   - \`/explorer\` → "Un visiteur parcourt la page Découvrir"
+   - Autre → cite le chemin
+3. Si la stack contient une server action nommée (\`createMoment\`, \`registerToMoment\`, etc.) → "Un utilisateur a lancé l'action <nom> (<ce que ça fait en clair>)"
+4. Sinon, regarder les noms de fichiers inApp pour déduire le contexte (email/, stripe/, auth/...)
+
+Ne JAMAIS dire "Une erreur s'est produite". Sois spécifique.
+
+## Heuristiques pour la FUNCTIONAL CONSEQUENCE
+
+Traduire la partie technique en impact produit concret :
+- Query DB qui timeout pendant envoi rappels → "Les rappels email n'ont pas pu être envoyés pour ce run"
+- Erreur Stripe webhook → "Un paiement n'a pas été confirmé côté plateforme"
+- Erreur dans server action \`registerToMoment\` → "Une inscription à un événement n'a pas pu aboutir"
+- Erreur OG image generation → "L'aperçu social (OG image) d'un événement n'est pas généré"
+- Erreur auth magic link → "L'envoi du magic link de connexion a échoué"
+
+Ne PAS dire "la query findMany a échoué" — dire ce que ça représente produit.
+
+## Heuristiques pour USER IMPACT
+
+Niveau (\`level\`) :
+- "none" = l'utilisateur ne perçoit absolument rien (script tiers, handler pagehide/unload, erreur silencieuse, bot, cron sans conséquence visible immédiate)
+- "silent" = erreur visible uniquement en devtools, aucune gêne fonctionnelle
+- "degraded" = expérience dégradée mais utilisable (feature secondaire cassée, notification manquante, fallback, latence)
+- "blocking" = l'utilisateur est bloqué et ne peut pas accomplir son action
+
+Checklist :
+1. Script tiers (PostHog, GA, Stripe.js, extension) ? → level ≤ silent
+2. Pendant pagehide/unload/visibilitychange/beforeunload ? → level = none
+3. Handled (try/catch, mechanism.handled=true) ? → level ≤ silent dans la plupart des cas, SAUF si l'utilisateur voit une page 500 ou un message d'erreur
+4. Crash visuel prouvé par la stack ou le contexte ? → degraded ou blocking
+
+Description (\`userImpact.description\`) :
+- Commence par le rôle : "Un participant...", "Un organisateur...", "Un visiteur anonyme...", "Aucun utilisateur..."
+- Décrit CE QU'IL VOIT OU NE VOIT PAS : "verra un écran 500", "ne recevra pas son email de rappel", "ne pourra pas cliquer sur Publier", "reste sur la page blanche quelques secondes puis réessaye"
+- Dans le doute, préfère "none"/"silent" et dis-le franchement ("aucun utilisateur affecté directement pour ce run")
+
+## Heuristiques pour URGENCY
+
+- "critical" = perte de données, paiement cassé, auth cassée
+- "high" = fonctionnalité principale cassée pour de vrais utilisateurs
+- "medium" = bug visible mais contournable
+- "low" = cosmétique, edge case rare
+- "noise" = extension navigateur, bot, erreur non-actionnable
+
+## Règle d'or
+
+Si tu hésites à mettre du jargon, demande-toi : est-ce qu'un organisateur non-tech comprendrait ? Si non → reformule. Les seules sections où le jargon est permis sont \`technical\` et le culprit implicite.`;
+}

--- a/src/infrastructure/services/sentry/sentry-issue-analysis-email.tsx
+++ b/src/infrastructure/services/sentry/sentry-issue-analysis-email.tsx
@@ -8,81 +8,65 @@ import {
   infoLabel,
   infoValue,
 } from "../email/templates/components/email-styles";
-import type { UserImpact, UserImpactLevel } from "./analyze-issue";
+import { URGENCY_META, USER_IMPACT_META, type AnalysisResult } from "./analysis-meta";
+import type { IssueInput } from "./analyze-issue";
 
 type Props = {
-  issueShortId: string;
-  issueTitle: string;
-  urgency: string;
-  urgencyLabel: string;
-  trigger: string;
-  functionalConsequence: string;
-  userImpact: UserImpact;
-  technical: string;
+  issue: Pick<IssueInput, "issueShortId" | "issueTitle">;
+  analysis: AnalysisResult;
   sentryUrl: string;
 };
 
-const URGENCY_COLORS: Record<string, string> = {
-  critical: "#dc2626",
-  high: "#ea580c",
-  medium: "#ca8a04",
-  low: "#2563eb",
-  noise: "#71717a",
+type InfoRowProps = {
+  label: string;
+  body: string;
+  accentColor?: string;
+  labelBold?: boolean;
 };
 
-const USER_IMPACT_META: Record<UserImpactLevel, { label: string; color: string }> = {
-  none: { label: "AUCUN IMPACT UTILISATEUR", color: "#16a34a" },
-  silent: { label: "IMPACT SILENCIEUX", color: "#71717a" },
-  degraded: { label: "EXPÉRIENCE DÉGRADÉE", color: "#ea580c" },
-  blocking: { label: "UTILISATEUR BLOQUÉ", color: "#dc2626" },
-};
+function InfoRow({ label, body, accentColor, labelBold }: InfoRowProps) {
+  const sectionStyle = accentColor
+    ? { ...infoCard, borderLeft: `4px solid ${accentColor}` }
+    : infoCard;
+  const finalLabelStyle = accentColor
+    ? { ...infoLabel, color: accentColor, fontWeight: labelBold ? 700 : infoLabel.fontWeight }
+    : infoLabel;
+  return (
+    <Section style={sectionStyle}>
+      <Text style={finalLabelStyle}>{label}</Text>
+      <Text style={bodyText}>{body}</Text>
+    </Section>
+  );
+}
 
-export function SentryIssueAnalysisEmail({
-  issueShortId,
-  issueTitle,
-  urgency,
-  urgencyLabel,
-  trigger,
-  functionalConsequence,
-  userImpact,
-  technical,
-  sentryUrl,
-}: Props) {
-  const color = URGENCY_COLORS[urgency] ?? "#71717a";
-  const impactMeta = USER_IMPACT_META[userImpact.level];
+export function SentryIssueAnalysisEmail({ issue, analysis, sentryUrl }: Props) {
+  const urgencyMeta = URGENCY_META[analysis.urgency];
+  const impactMeta = USER_IMPACT_META[analysis.userImpact.level];
 
   return (
     <EmailLayout
-      preview={`[${urgencyLabel}] ${issueShortId} — ${issueTitle.slice(0, 60)}`}
+      preview={`[${urgencyMeta.label}] ${issue.issueShortId} — ${issue.issueTitle.slice(0, 60)}`}
       footer="Sentry Issue Analysis — The Playground"
     >
-      <Text style={{ ...urgencyBadge, backgroundColor: color }}>
-        {urgencyLabel}
+      <Text style={{ ...urgencyBadge, backgroundColor: urgencyMeta.color }}>
+        {urgencyMeta.label}
       </Text>
 
-      <Text style={heading}>{issueShortId}</Text>
-      <Text style={titleStyle}>{issueTitle}</Text>
+      <Text style={heading}>{issue.issueShortId}</Text>
+      <Text style={titleStyle}>{issue.issueTitle}</Text>
 
-      <Section style={infoCard}>
-        <Text style={infoLabel}>Déclencheur</Text>
-        <Text style={bodyText}>{trigger}</Text>
-      </Section>
-
-      <Section style={infoCard}>
-        <Text style={infoLabel}>Conséquence fonctionnelle</Text>
-        <Text style={bodyText}>{functionalConsequence}</Text>
-      </Section>
-
-      <Section style={{ ...infoCard, borderLeft: `4px solid ${impactMeta.color}` }}>
-        <Text style={{ ...infoLabel, color: impactMeta.color, fontWeight: 700 }}>
-          {impactMeta.label}
-        </Text>
-        <Text style={bodyText}>{userImpact.description}</Text>
-      </Section>
+      <InfoRow label="Déclencheur" body={analysis.trigger} />
+      <InfoRow label="Conséquence fonctionnelle" body={analysis.functionalConsequence} />
+      <InfoRow
+        label={impactMeta.label}
+        body={analysis.userImpact.description}
+        accentColor={impactMeta.color}
+        labelBold
+      />
 
       <Section style={technicalCard}>
         <Text style={technicalLabel}>Détails techniques</Text>
-        <Text style={technicalBody}>{technical}</Text>
+        <Text style={technicalBody}>{analysis.technical}</Text>
       </Section>
 
       <Section style={ctaSection}>

--- a/src/infrastructure/services/sentry/sentry-issue-analysis-email.tsx
+++ b/src/infrastructure/services/sentry/sentry-issue-analysis-email.tsx
@@ -13,12 +13,12 @@ import type { UserImpact, UserImpactLevel } from "./analyze-issue";
 type Props = {
   issueShortId: string;
   issueTitle: string;
-  culprit: string;
   urgency: string;
   urgencyLabel: string;
+  trigger: string;
+  functionalConsequence: string;
   userImpact: UserImpact;
-  diagnosis: string;
-  remediation: string;
+  technical: string;
   sentryUrl: string;
 };
 
@@ -40,12 +40,12 @@ const USER_IMPACT_META: Record<UserImpactLevel, { label: string; color: string }
 export function SentryIssueAnalysisEmail({
   issueShortId,
   issueTitle,
-  culprit,
   urgency,
   urgencyLabel,
+  trigger,
+  functionalConsequence,
   userImpact,
-  diagnosis,
-  remediation,
+  technical,
   sentryUrl,
 }: Props) {
   const color = URGENCY_COLORS[urgency] ?? "#71717a";
@@ -56,13 +56,22 @@ export function SentryIssueAnalysisEmail({
       preview={`[${urgencyLabel}] ${issueShortId} — ${issueTitle.slice(0, 60)}`}
       footer="Sentry Issue Analysis — The Playground"
     >
-      {/* Urgency badge */}
       <Text style={{ ...urgencyBadge, backgroundColor: color }}>
         {urgencyLabel}
       </Text>
 
       <Text style={heading}>{issueShortId}</Text>
       <Text style={titleStyle}>{issueTitle}</Text>
+
+      <Section style={infoCard}>
+        <Text style={infoLabel}>Déclencheur</Text>
+        <Text style={bodyText}>{trigger}</Text>
+      </Section>
+
+      <Section style={infoCard}>
+        <Text style={infoLabel}>Conséquence fonctionnelle</Text>
+        <Text style={bodyText}>{functionalConsequence}</Text>
+      </Section>
 
       <Section style={{ ...infoCard, borderLeft: `4px solid ${impactMeta.color}` }}>
         <Text style={{ ...infoLabel, color: impactMeta.color, fontWeight: 700 }}>
@@ -71,19 +80,9 @@ export function SentryIssueAnalysisEmail({
         <Text style={bodyText}>{userImpact.description}</Text>
       </Section>
 
-      <Section style={infoCard}>
-        <Text style={infoLabel}>Culprit</Text>
-        <Text style={infoValue}>{culprit}</Text>
-      </Section>
-
-      <Section style={infoCard}>
-        <Text style={infoLabel}>Diagnostic</Text>
-        <Text style={bodyText}>{diagnosis}</Text>
-      </Section>
-
-      <Section style={infoCard}>
-        <Text style={infoLabel}>Remédiation</Text>
-        <Text style={bodyText}>{remediation}</Text>
+      <Section style={technicalCard}>
+        <Text style={technicalLabel}>Détails techniques</Text>
+        <Text style={technicalBody}>{technical}</Text>
       </Section>
 
       <Section style={ctaSection}>
@@ -120,6 +119,25 @@ const bodyText: React.CSSProperties = {
   color: "#18181b",
   margin: "0",
   lineHeight: "22px",
+};
+
+const technicalCard: React.CSSProperties = {
+  ...infoCard,
+  backgroundColor: "#fafafa",
+  borderLeft: "3px solid #d4d4d8",
+};
+
+const technicalLabel: React.CSSProperties = {
+  ...infoLabel,
+  color: "#a1a1aa",
+};
+
+const technicalBody: React.CSSProperties = {
+  ...infoValue,
+  fontSize: "13px",
+  color: "#71717a",
+  lineHeight: "20px",
+  fontFamily: "'SF Mono', ui-monospace, Menlo, monospace",
 };
 
 const ctaSection: React.CSSProperties = {

--- a/src/infrastructure/services/slack/slack-notification-service.ts
+++ b/src/infrastructure/services/slack/slack-notification-service.ts
@@ -1,3 +1,5 @@
+import { URGENCY_META, USER_IMPACT_META, type AnalysisResult } from "../sentry/analysis-meta";
+
 const WEBHOOK_URL = process.env.SLACK_ADMIN_WEBHOOK_URL;
 
 export function isAdminEmailEnabled(): boolean {
@@ -130,38 +132,26 @@ export async function notifySlackNewComment(params: {
   });
 }
 
-type UserImpactSlackLevel = "none" | "silent" | "degraded" | "blocking";
-
-const USER_IMPACT_SLACK: Record<UserImpactSlackLevel, { emoji: string; label: string }> = {
-  none: { emoji: "🟢", label: "Aucun impact utilisateur" },
-  silent: { emoji: "⚪", label: "Impact silencieux" },
-  degraded: { emoji: "🟠", label: "Experience degradee" },
-  blocking: { emoji: "🔴", label: "Utilisateur bloque" },
-};
-
 export async function notifySlackSentryIssue(params: {
-  issueShortId: string;
-  issueTitle: string;
-  urgencyLabel: string;
-  trigger: string;
-  functionalConsequence: string;
-  userImpact: { level: UserImpactSlackLevel; description: string };
-  technical: string;
+  issue: { issueShortId: string; issueTitle: string };
+  analysis: AnalysisResult;
   sentryUrl: string;
 }): Promise<void> {
-  const impactMeta = USER_IMPACT_SLACK[params.userImpact.level];
+  const { issue, analysis, sentryUrl } = params;
+  const urgencyLabel = URGENCY_META[analysis.urgency].label;
+  const impactMeta = USER_IMPACT_META[analysis.userImpact.level];
   await sendSlack({
-    text: `🚨 [Sentry ${params.urgencyLabel}] ${params.issueShortId} — ${params.issueTitle}`,
+    text: `🚨 [Sentry ${urgencyLabel}] ${issue.issueShortId} — ${issue.issueTitle}`,
     blocks: [
-      { type: "header", text: { type: "plain_text", text: `🚨 Sentry — Urgence ${params.urgencyLabel}`, emoji: true } },
-      { type: "section", text: { type: "mrkdwn", text: `*${params.issueShortId}*\n${params.issueTitle}` } },
+      { type: "header", text: { type: "plain_text", text: `🚨 Sentry — Urgence ${urgencyLabel}`, emoji: true } },
+      { type: "section", text: { type: "mrkdwn", text: `*${issue.issueShortId}*\n${issue.issueTitle}` } },
       { type: "divider" },
-      { type: "section", text: { type: "mrkdwn", text: `*Déclencheur*\n${params.trigger}` } },
-      { type: "section", text: { type: "mrkdwn", text: `*Conséquence fonctionnelle*\n${params.functionalConsequence}` } },
-      { type: "section", text: { type: "mrkdwn", text: `${impactMeta.emoji} *${impactMeta.label}*\n${params.userImpact.description}` } },
+      { type: "section", text: { type: "mrkdwn", text: `*Déclencheur*\n${analysis.trigger}` } },
+      { type: "section", text: { type: "mrkdwn", text: `*Conséquence fonctionnelle*\n${analysis.functionalConsequence}` } },
+      { type: "section", text: { type: "mrkdwn", text: `${impactMeta.emoji} *${impactMeta.label}*\n${analysis.userImpact.description}` } },
       { type: "divider" },
-      { type: "context", elements: [{ type: "mrkdwn", text: `_Détails techniques_\n\`\`\`${params.technical}\`\`\`` }] },
-      { type: "actions", elements: [{ type: "button", text: { type: "plain_text", text: "Voir dans Sentry" }, url: params.sentryUrl, style: "danger" }] },
+      { type: "context", elements: [{ type: "mrkdwn", text: `_Détails techniques_\n\`\`\`${analysis.technical}\`\`\`` }] },
+      { type: "actions", elements: [{ type: "button", text: { type: "plain_text", text: "Voir dans Sentry" }, url: sentryUrl, style: "danger" }] },
     ],
   });
 }

--- a/src/infrastructure/services/slack/slack-notification-service.ts
+++ b/src/infrastructure/services/slack/slack-notification-service.ts
@@ -142,11 +142,11 @@ const USER_IMPACT_SLACK: Record<UserImpactSlackLevel, { emoji: string; label: st
 export async function notifySlackSentryIssue(params: {
   issueShortId: string;
   issueTitle: string;
-  culprit: string;
   urgencyLabel: string;
+  trigger: string;
+  functionalConsequence: string;
   userImpact: { level: UserImpactSlackLevel; description: string };
-  diagnosis: string;
-  remediation: string;
+  technical: string;
   sentryUrl: string;
 }): Promise<void> {
   const impactMeta = USER_IMPACT_SLACK[params.userImpact.level];
@@ -156,13 +156,11 @@ export async function notifySlackSentryIssue(params: {
       { type: "header", text: { type: "plain_text", text: `🚨 Sentry — Urgence ${params.urgencyLabel}`, emoji: true } },
       { type: "section", text: { type: "mrkdwn", text: `*${params.issueShortId}*\n${params.issueTitle}` } },
       { type: "divider" },
+      { type: "section", text: { type: "mrkdwn", text: `*Déclencheur*\n${params.trigger}` } },
+      { type: "section", text: { type: "mrkdwn", text: `*Conséquence fonctionnelle*\n${params.functionalConsequence}` } },
       { type: "section", text: { type: "mrkdwn", text: `${impactMeta.emoji} *${impactMeta.label}*\n${params.userImpact.description}` } },
       { type: "divider" },
-      { type: "section", fields: [
-        { type: "mrkdwn", text: `*Culprit*\n\`${params.culprit}\`` },
-      ]},
-      { type: "section", text: { type: "mrkdwn", text: `*Diagnostic*\n${params.diagnosis}` } },
-      { type: "section", text: { type: "mrkdwn", text: `*Remediation*\n${params.remediation}` } },
+      { type: "context", elements: [{ type: "mrkdwn", text: `_Détails techniques_\n\`\`\`${params.technical}\`\`\`` }] },
       { type: "actions", elements: [{ type: "button", text: { type: "plain_text", text: "Voir dans Sentry" }, url: params.sentryUrl, style: "danger" }] },
     ],
   });


### PR DESCRIPTION
## Summary

Retravaille l'analyse Sentry envoyée par email + Slack pour qu'elle soit lisible par un non-technicien. L'objectif : répondre à **QUI** a déclenché l'erreur, **QUOI** est cassé côté produit, et **COMMENT** l'utilisateur le ressent, avant toute considération technique.

## Ce qui change

- **Nouveau schéma d'analyse** : `trigger` (déclencheur fonctionnel) + `functionalConsequence` (ce qui est cassé côté produit) + `userImpact` (ce que ressent l'utilisateur) + `technical` (fusion diagnosis + remediation, réservé aux devs).
- **Contexte enrichi transmis à Claude** : tags Sentry (`cron`, `url`, `transaction`, `route`, `server_action`, `runtime`, `release`, `environment`) + request URL/method. Sans ça, impossible de distinguer un cron d'une page `/m/[slug]` ou d'un webhook Stripe.
- **Prompt avec heuristiques explicites** par champ (matrice URL → trigger, traductions technique → métier, checklist d'impact utilisateur, règle d'or « compréhensible par un non-tech »).
- **Email** : nouvel ordre Déclencheur → Conséquence → Impact utilisateur → Détails techniques (bloc gris atténué, monospace, couleur discrète pour rester secondaire).
- **Slack** : même structure, détails techniques placés en `context` avec code block et italique.

## Architecture

- `analysis-meta.ts` : source unique pour `URGENCY_META`, `USER_IMPACT_META`, et les types (`Urgency`, `UserImpactLevel`, `UserImpact`, `AnalysisResult`). Supprime la duplication historique email/Slack.
- `build-prompt.ts` : isole la fonction `buildAnalysisPrompt(issue, context)`.
- `analyze-issue.ts` : orchestration (fetch event Sentry → analyse Claude → email + Slack en parallèle).
- Props regroupées en `{ issue, analysis, sentryUrl }` (plus de 8 props plats).

## Test plan

- [ ] Tester en local avec un payload Sentry webhook factice (voir `/api/sentry/webhook`) qui pointe vers une issue réelle — vérifier le rendu email et Slack.
- [ ] Valider qu'un cron (ex: `send-reminders`) est bien identifié comme déclencheur non-utilisateur.
- [ ] Valider qu'une erreur sur une page `/m/[slug]` est attribuée à « un visiteur/participant ».
- [ ] Vérifier le fallback quand Claude renvoie un JSON invalide.

## Pas dans cette PR

- Factorisation d'un helper partagé `parseClaudeJson<T>` (3e occurrence du pattern avec `radar/route.ts` et `events-radar.ts`) — dette à tracker séparément.

🤖 Generated with [Claude Code](https://claude.com/claude-code)