### PR TITLE
feat(og): intégrer la cover dans les OG images événement et Communauté

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "remark-parse": "^11.0.0",
     "remark-rehype": "^11.1.2",
     "resend": "^6.9.2",
+    "sharp": "0.34.5",
     "sonner": "^2.0.7",
     "stripe": "^20.4.1",
     "tailwind-merge": "^3.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,6 +122,9 @@ importers:
       resend:
         specifier: ^6.9.2
         version: 6.9.2(@react-email/render@2.0.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+      sharp:
+        specifier: 0.34.5
+        version: 0.34.5
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -7556,8 +7559,7 @@ snapshots:
     dependencies:
       hono: 4.12.3
 
-  '@img/colour@1.0.0':
-    optional: true
+  '@img/colour@1.0.0': {}
 
   '@img/sharp-darwin-arm64@0.34.5':
     optionalDependencies:
@@ -12586,8 +12588,7 @@ snapshots:
 
   semver@7.6.3: {}
 
-  semver@7.7.4:
-    optional: true
+  semver@7.7.4: {}
 
   send@1.2.1:
     dependencies:
@@ -12716,7 +12717,6 @@ snapshots:
       '@img/sharp-win32-arm64': 0.34.5
       '@img/sharp-win32-ia32': 0.34.5
       '@img/sharp-win32-x64': 0.34.5
-    optional: true
 
   shebang-command@2.0.0:
     dependencies:

--- a/src/app/[locale]/(routes)/circles/[slug]/opengraph-image.tsx
+++ b/src/app/[locale]/(routes)/circles/[slug]/opengraph-image.tsx
@@ -2,11 +2,16 @@ import { ImageResponse } from "next/og";
 import { prismaCircleRepository } from "@/infrastructure/repositories";
 import { getCircleBySlug } from "@/domain/usecases/get-circle";
 import { CircleNotFoundError } from "@/domain/errors";
+import { getMomentGradient } from "@/lib/gradient";
+import { loadOgCoverAsDataUrl } from "@/lib/og-image-loader";
 
 export const runtime = "nodejs";
 export const alt = "Community — The Playground";
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
+
+const COVER_SIZE = 630;
+const CONTENT_WIDTH = size.width - COVER_SIZE;
 
 export default async function OgImage({
   params,
@@ -34,10 +39,15 @@ export default async function OgImage({
   const memberCount = await prismaCircleRepository.countMembers(circle.id);
 
   const description = circle.description
-    ? circle.description.length > 120
-      ? circle.description.slice(0, 117) + "..."
+    ? circle.description.length > 160
+      ? circle.description.slice(0, 157) + "..."
       : circle.description
     : "";
+
+  const gradient = getMomentGradient(circle.id);
+  const coverDataUrl = circle.coverImage
+    ? await loadOgCoverAsDataUrl(circle.coverImage)
+    : null;
 
   return new ImageResponse(
     (
@@ -46,13 +56,12 @@ export default async function OgImage({
           width: "100%",
           height: "100%",
           display: "flex",
-          flexDirection: "column",
+          flexDirection: "row",
           background: "linear-gradient(180deg, #0c0a14 0%, #1a1028 100%)",
-          padding: "48px 56px",
           position: "relative",
         }}
       >
-        {/* Top gradient bar */}
+        {/* Top gradient bar, full width */}
         <div
           style={{
             position: "absolute",
@@ -64,138 +73,119 @@ export default async function OgImage({
           }}
         />
 
-        {/* Icon + Circle label */}
+        {/* Left: square cover (or gradient fallback) */}
         <div
           style={{
+            width: COVER_SIZE,
+            height: COVER_SIZE,
             display: "flex",
-            alignItems: "center",
-            gap: "16px",
-            marginBottom: "24px",
+            flexShrink: 0,
+            position: "relative",
           }}
         >
+          {coverDataUrl ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={coverDataUrl}
+              alt=""
+              width={COVER_SIZE}
+              height={COVER_SIZE}
+              style={{ width: COVER_SIZE, height: COVER_SIZE, objectFit: "cover" }}
+            />
+          ) : (
+            <div
+              style={{
+                width: COVER_SIZE,
+                height: COVER_SIZE,
+                background: gradient,
+              }}
+            />
+          )}
+        </div>
+
+        {/* Right: content */}
+        <div
+          style={{
+            width: CONTENT_WIDTH,
+            height: "100%",
+            display: "flex",
+            flexDirection: "column",
+            padding: "48px 48px 40px 44px",
+          }}
+        >
+          {/* Community label */}
           <div
             style={{
               display: "flex",
               alignItems: "center",
-              justifyContent: "center",
-              width: "56px",
-              height: "56px",
-              borderRadius: "16px",
-              background: "linear-gradient(135deg, #ec4899, #a855f7)",
-            }}
-          >
-            <svg
-              width="28"
-              height="28"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="white"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
-              <circle cx="9" cy="7" r="4" />
-              <path d="M22 21v-2a4 4 0 0 0-3-3.87" />
-              <path d="M16 3.13a4 4 0 0 1 0 7.75" />
-            </svg>
-          </div>
-          <span
-            style={{
-              fontSize: "18px",
+              fontSize: "16px",
               fontWeight: 600,
               color: "#ec4899",
               textTransform: "uppercase",
               letterSpacing: "2px",
+              marginBottom: "20px",
             }}
           >
             {locale === "fr" ? "Communauté" : "Community"}
-          </span>
-        </div>
+          </div>
 
-        {/* Circle name */}
-        <div
-          style={{
-            fontSize: "52px",
-            fontWeight: 700,
-            color: "white",
-            lineHeight: 1.15,
-            letterSpacing: "-1px",
-            marginBottom: "20px",
-            maxWidth: "900px",
-          }}
-        >
-          {circle.name.length > 60
-            ? circle.name.slice(0, 57) + "..."
-            : circle.name}
-        </div>
-
-        {/* Description */}
-        {description && (
+          {/* Circle name */}
           <div
             style={{
-              fontSize: "22px",
-              color: "rgba(255, 255, 255, 0.6)",
-              lineHeight: 1.5,
-              flex: 1,
-              maxWidth: "800px",
+              fontSize: "44px",
+              fontWeight: 700,
+              color: "white",
+              lineHeight: 1.15,
+              letterSpacing: "-1px",
+              marginBottom: "18px",
+              display: "flex",
             }}
           >
-            {description}
+            {circle.name.length > 60
+              ? circle.name.slice(0, 57) + "..."
+              : circle.name}
           </div>
-        )}
 
-        {/* Bottom info */}
-        <div
-          style={{
-            display: "flex",
-            justifyContent: "space-between",
-            alignItems: "flex-end",
-          }}
-        >
-          {/* Stats */}
+          {/* Description */}
+          {description && (
+            <div
+              style={{
+                fontSize: "20px",
+                color: "rgba(255, 255, 255, 0.65)",
+                lineHeight: 1.45,
+                flex: 1,
+                display: "flex",
+              }}
+            >
+              {description}
+            </div>
+          )}
+          {!description && <div style={{ flex: 1 }} />}
+
+          {/* Bottom info */}
           <div
             style={{
               display: "flex",
-              gap: "32px",
+              justifyContent: "space-between",
+              alignItems: "flex-end",
             }}
           >
             <div
               style={{
                 display: "flex",
-                alignItems: "center",
+                flexDirection: "column",
                 gap: "8px",
-                fontSize: "20px",
-                color: "rgba(255, 255, 255, 0.7)",
+                maxWidth: CONTENT_WIDTH - 180,
               }}
             >
-              <svg
-                width="20"
-                height="20"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="rgba(255,255,255,0.5)"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              >
-                <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
-                <circle cx="9" cy="7" r="4" />
-                <path d="M22 21v-2a4 4 0 0 0-3-3.87" />
-                <path d="M16 3.13a4 4 0 0 1 0 7.75" />
-              </svg>
-              {locale === "fr"
-                ? `${memberCount} membre${memberCount !== 1 ? "s" : ""}`
-                : `${memberCount} member${memberCount !== 1 ? "s" : ""}`}
-            </div>
-            {circle.city && (
+              {/* Members */}
               <div
                 style={{
                   display: "flex",
                   alignItems: "center",
-                  gap: "8px",
+                  gap: "10px",
                   fontSize: "20px",
-                  color: "rgba(255, 255, 255, 0.7)",
+                  color: "rgba(255, 255, 255, 0.8)",
                 }}
               >
                 <svg
@@ -203,63 +193,95 @@ export default async function OgImage({
                   height="20"
                   viewBox="0 0 24 24"
                   fill="none"
-                  stroke="rgba(255,255,255,0.5)"
+                  stroke="rgba(255,255,255,0.6)"
                   strokeWidth="2"
                   strokeLinecap="round"
                   strokeLinejoin="round"
                 >
-                  <path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0Z" />
-                  <circle cx="12" cy="10" r="3" />
+                  <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
+                  <circle cx="9" cy="7" r="4" />
+                  <path d="M22 21v-2a4 4 0 0 0-3-3.87" />
+                  <path d="M16 3.13a4 4 0 0 1 0 7.75" />
                 </svg>
-                {circle.city}
+                {locale === "fr"
+                  ? `${memberCount} membre${memberCount !== 1 ? "s" : ""}`
+                  : `${memberCount} member${memberCount !== 1 ? "s" : ""}`}
               </div>
-            )}
-          </div>
 
-          {/* Branding */}
-          <div
-            style={{
-              display: "flex",
-              alignItems: "center",
-              gap: "10px",
-            }}
-          >
+              {/* City */}
+              {circle.city && (
+                <div
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: "10px",
+                    fontSize: "18px",
+                    color: "rgba(255, 255, 255, 0.6)",
+                  }}
+                >
+                  <svg
+                    width="18"
+                    height="18"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="rgba(255,255,255,0.5)"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0Z" />
+                    <circle cx="12" cy="10" r="3" />
+                  </svg>
+                  {circle.city}
+                </div>
+              )}
+            </div>
+
+            {/* Bottom-right branding */}
             <div
               style={{
                 display: "flex",
                 alignItems: "center",
-                justifyContent: "center",
-                width: "28px",
-                height: "28px",
-                borderRadius: "7px",
-                background: "linear-gradient(135deg, #ec4899, #a855f7)",
+                gap: "10px",
               }}
             >
-              <svg width="11" height="13" viewBox="0 0 13 15" fill="none">
-                <polygon points="0,0 0,15 13,7.5" fill="white" />
-              </svg>
-            </div>
-            <div style={{ display: "flex", alignItems: "baseline" }}>
-              <span
+              <div
                 style={{
-                  fontSize: "16px",
-                  fontWeight: 700,
-                  color: "rgba(255, 255, 255, 0.4)",
-                  letterSpacing: "-0.4px",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  width: "28px",
+                  height: "28px",
+                  borderRadius: "7px",
+                  background: "linear-gradient(135deg, #ec4899, #a855f7)",
                 }}
               >
-                {"the\u2009"}
-              </span>
-              <span
-                style={{
-                  fontSize: "16px",
-                  fontWeight: 700,
-                  color: "#e8457a",
-                  letterSpacing: "-0.4px",
-                }}
-              >
-                playground
-              </span>
+                <svg width="11" height="13" viewBox="0 0 13 15" fill="none">
+                  <polygon points="0,0 0,15 13,7.5" fill="white" />
+                </svg>
+              </div>
+              <div style={{ display: "flex", alignItems: "baseline" }}>
+                <span
+                  style={{
+                    fontSize: "16px",
+                    fontWeight: 700,
+                    color: "rgba(255, 255, 255, 0.4)",
+                    letterSpacing: "-0.4px",
+                  }}
+                >
+                  {"the\u2009"}
+                </span>
+                <span
+                  style={{
+                    fontSize: "16px",
+                    fontWeight: 700,
+                    color: "#e8457a",
+                    letterSpacing: "-0.4px",
+                  }}
+                >
+                  playground
+                </span>
+              </div>
             </div>
           </div>
         </div>

--- a/src/app/[locale]/(routes)/m/[slug]/opengraph-image.tsx
+++ b/src/app/[locale]/(routes)/m/[slug]/opengraph-image.tsx
@@ -6,11 +6,16 @@ import {
 import { getMomentBySlug } from "@/domain/usecases/get-moment";
 import { MomentNotFoundError } from "@/domain/errors";
 import { isValidSlug } from "@/lib/slug";
+import { getMomentGradient } from "@/lib/gradient";
+import { loadOgCoverAsDataUrl } from "@/lib/og-image-loader";
 
 export const runtime = "nodejs";
 export const alt = "Event — The Playground";
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
+
+const COVER_SIZE = 630;
+const CONTENT_WIDTH = size.width - COVER_SIZE;
 
 export default async function OgImage({
   params,
@@ -58,6 +63,11 @@ export default async function OgImage({
         ? hybridLabel
         : moment.locationName ?? moment.locationAddress ?? "";
 
+  const gradient = getMomentGradient(moment.id);
+  const coverDataUrl = moment.coverImage
+    ? await loadOgCoverAsDataUrl(moment.coverImage)
+    : null;
+
   return new ImageResponse(
     (
       <div
@@ -65,13 +75,12 @@ export default async function OgImage({
           width: "100%",
           height: "100%",
           display: "flex",
-          flexDirection: "column",
+          flexDirection: "row",
           background: "linear-gradient(180deg, #0c0a14 0%, #1a1028 100%)",
-          padding: "48px 56px",
           position: "relative",
         }}
       >
-        {/* Top gradient bar */}
+        {/* Top gradient bar, full width */}
         <div
           style={{
             position: "absolute",
@@ -83,93 +92,104 @@ export default async function OgImage({
           }}
         />
 
-        {/* Circle name */}
-        {circle && (
-          <div
-            style={{
-              fontSize: "20px",
-              fontWeight: 600,
-              color: "#ec4899",
-              marginBottom: "16px",
-              display: "flex",
-              alignItems: "center",
-            }}
-          >
-            {circle.name}
-          </div>
-        )}
-
-        {/* Moment title */}
+        {/* Left: square cover (or gradient fallback) */}
         <div
           style={{
-            fontSize: "52px",
-            fontWeight: 700,
-            color: "white",
-            lineHeight: 1.15,
-            letterSpacing: "-1px",
-            flex: 1,
+            width: COVER_SIZE,
+            height: COVER_SIZE,
             display: "flex",
-            alignItems: "flex-start",
-            maxWidth: "900px",
+            flexShrink: 0,
+            position: "relative",
           }}
         >
-          {moment.title.length > 80
-            ? moment.title.slice(0, 77) + "..."
-            : moment.title}
+          {coverDataUrl ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={coverDataUrl}
+              alt=""
+              width={COVER_SIZE}
+              height={COVER_SIZE}
+              style={{ width: COVER_SIZE, height: COVER_SIZE, objectFit: "cover" }}
+            />
+          ) : (
+            <div
+              style={{
+                width: COVER_SIZE,
+                height: COVER_SIZE,
+                background: gradient,
+              }}
+            />
+          )}
         </div>
 
-        {/* Bottom info */}
+        {/* Right: content */}
         <div
           style={{
+            width: CONTENT_WIDTH,
+            height: "100%",
             display: "flex",
-            justifyContent: "space-between",
-            alignItems: "flex-end",
+            flexDirection: "column",
+            padding: "48px 48px 40px 44px",
           }}
         >
+          {/* Circle name */}
+          {circle && (
+            <div
+              style={{
+                fontSize: "20px",
+                fontWeight: 600,
+                color: "#ec4899",
+                marginBottom: "18px",
+                display: "flex",
+                alignItems: "center",
+              }}
+            >
+              {circle.name}
+            </div>
+          )}
+
+          {/* Moment title */}
+          <div
+            style={{
+              fontSize: "44px",
+              fontWeight: 700,
+              color: "white",
+              lineHeight: 1.15,
+              letterSpacing: "-1px",
+              flex: 1,
+              display: "flex",
+              alignItems: "flex-start",
+            }}
+          >
+            {moment.title.length > 90
+              ? moment.title.slice(0, 87) + "..."
+              : moment.title}
+          </div>
+
+          {/* Bottom info */}
           <div
             style={{
               display: "flex",
-              flexDirection: "column",
-              gap: "8px",
+              justifyContent: "space-between",
+              alignItems: "flex-end",
             }}
           >
-            {/* Date + time */}
             <div
               style={{
                 display: "flex",
-                alignItems: "center",
-                gap: "10px",
-                fontSize: "22px",
-                color: "rgba(255, 255, 255, 0.8)",
+                flexDirection: "column",
+                gap: "8px",
+                maxWidth: CONTENT_WIDTH - 180,
               }}
             >
-              <svg
-                width="22"
-                height="22"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="rgba(255,255,255,0.6)"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              >
-                <rect width="18" height="18" x="3" y="4" rx="2" ry="2" />
-                <line x1="16" x2="16" y1="2" y2="6" />
-                <line x1="8" x2="8" y1="2" y2="6" />
-                <line x1="3" x2="21" y1="10" y2="10" />
-              </svg>
-              {date} · {time}
-            </div>
-
-            {/* Location */}
-            {location && (
+              {/* Date + time */}
               <div
                 style={{
                   display: "flex",
                   alignItems: "center",
                   gap: "10px",
                   fontSize: "20px",
-                  color: "rgba(255, 255, 255, 0.6)",
+                  color: "rgba(255, 255, 255, 0.8)",
                 }}
               >
                 <svg
@@ -177,65 +197,95 @@ export default async function OgImage({
                   height="20"
                   viewBox="0 0 24 24"
                   fill="none"
-                  stroke="rgba(255,255,255,0.5)"
+                  stroke="rgba(255,255,255,0.6)"
                   strokeWidth="2"
                   strokeLinecap="round"
                   strokeLinejoin="round"
                 >
-                  <path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0Z" />
-                  <circle cx="12" cy="10" r="3" />
+                  <rect width="18" height="18" x="3" y="4" rx="2" ry="2" />
+                  <line x1="16" x2="16" y1="2" y2="6" />
+                  <line x1="8" x2="8" y1="2" y2="6" />
+                  <line x1="3" x2="21" y1="10" y2="10" />
                 </svg>
-                {location.length > 60
-                  ? location.slice(0, 57) + "..."
-                  : location}
+                {date} · {time}
               </div>
-            )}
-          </div>
 
-          {/* Bottom-right branding */}
-          <div
-            style={{
-              display: "flex",
-              alignItems: "center",
-              gap: "10px",
-            }}
-          >
+              {/* Location */}
+              {location && (
+                <div
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: "10px",
+                    fontSize: "18px",
+                    color: "rgba(255, 255, 255, 0.6)",
+                  }}
+                >
+                  <svg
+                    width="18"
+                    height="18"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="rgba(255,255,255,0.5)"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0Z" />
+                    <circle cx="12" cy="10" r="3" />
+                  </svg>
+                  {location.length > 36
+                    ? location.slice(0, 33) + "..."
+                    : location}
+                </div>
+              )}
+            </div>
+
+            {/* Bottom-right branding */}
             <div
               style={{
                 display: "flex",
                 alignItems: "center",
-                justifyContent: "center",
-                width: "28px",
-                height: "28px",
-                borderRadius: "7px",
-                background: "linear-gradient(135deg, #ec4899, #a855f7)",
+                gap: "10px",
               }}
             >
-              <svg width="11" height="13" viewBox="0 0 13 15" fill="none">
-                <polygon points="0,0 0,15 13,7.5" fill="white" />
-              </svg>
-            </div>
-            <div style={{ display: "flex", alignItems: "baseline" }}>
-              <span
+              <div
                 style={{
-                  fontSize: "16px",
-                  fontWeight: 700,
-                  color: "rgba(255, 255, 255, 0.4)",
-                  letterSpacing: "-0.4px",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  width: "28px",
+                  height: "28px",
+                  borderRadius: "7px",
+                  background: "linear-gradient(135deg, #ec4899, #a855f7)",
                 }}
               >
-                {"the\u2009"}
-              </span>
-              <span
-                style={{
-                  fontSize: "16px",
-                  fontWeight: 700,
-                  color: "#e8457a",
-                  letterSpacing: "-0.4px",
-                }}
-              >
-                playground
-              </span>
+                <svg width="11" height="13" viewBox="0 0 13 15" fill="none">
+                  <polygon points="0,0 0,15 13,7.5" fill="white" />
+                </svg>
+              </div>
+              <div style={{ display: "flex", alignItems: "baseline" }}>
+                <span
+                  style={{
+                    fontSize: "16px",
+                    fontWeight: 700,
+                    color: "rgba(255, 255, 255, 0.4)",
+                    letterSpacing: "-0.4px",
+                  }}
+                >
+                  {"the "}
+                </span>
+                <span
+                  style={{
+                    fontSize: "16px",
+                    fontWeight: 700,
+                    color: "#e8457a",
+                    letterSpacing: "-0.4px",
+                  }}
+                >
+                  playground
+                </span>
+              </div>
             </div>
           </div>
         </div>

--- a/src/lib/og-image-loader.ts
+++ b/src/lib/og-image-loader.ts
@@ -1,0 +1,34 @@
+import sharp from "sharp";
+
+/**
+ * Satori (le moteur derrière `next/og`) ne sait pas décoder le WebP.
+ * Comme nos covers sont uploadées en WebP, on doit les re-encoder en PNG
+ * avant de les passer au composant JSX de l'OG image. On renvoie une data URL
+ * inlinable, et null en cas d'échec (le caller retombe alors sur un fallback).
+ */
+export async function loadOgCoverAsDataUrl(
+  url: string
+): Promise<string | null> {
+  try {
+    const response = await fetch(url, {
+      cache: "force-cache",
+      signal: AbortSignal.timeout(4000),
+    });
+    if (!response.ok) return null;
+
+    const contentType = response.headers.get("content-type") ?? "";
+    const buffer = Buffer.from(await response.arrayBuffer());
+
+    const needsConversion = contentType.includes("webp");
+    const output = needsConversion
+      ? await sharp(buffer).png().toBuffer()
+      : buffer;
+    const mime = needsConversion
+      ? "image/png"
+      : contentType.split(";")[0] || "image/png";
+
+    return `data:${mime};base64,${output.toString("base64")}`;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- Refonte des routes `opengraph-image.tsx` (Moment + Communauté) : **cover carrée 630×630 à gauche**, contenu (titre, date/lieu, branding) à droite. Fallback gradient coloré si pas de cover.
- Ajout du helper `loadOgCoverAsDataUrl` : Satori (moteur derrière `next/og`) ne décode pas le WebP, et toutes nos covers sont uploadées en WebP → fetch + conversion PNG via `sharp` + data URL.
- Dépendance directe `sharp@0.34.5` (déjà installée transitivement via Next).

Ref backlog `#004`.

## Test plan
- [ ] Vérifier sur la preview Vercel que `/m/[slug]/opengraph-image` d'un événement avec cover renvoie une image 1200×630 avec la cover à gauche
- [ ] Vérifier que `/circles/[slug]/opengraph-image` d'une Communauté avec cover fait pareil
- [ ] Vérifier le fallback sur un événement/Communauté sans cover → gradient coloré
- [ ] Partager le lien dans Slack et constater que la preview affiche bien la nouvelle image

🤖 Generated with [Claude Code](https://claude.com/claude-code)