### PR TITLE
chore(worktree): symlink .env.local vers le repo principal

### DIFF
--- a/scripts/db-dev-reset.sh
+++ b/scripts/db-dev-reset.sh
@@ -8,13 +8,19 @@
 
 set -euo pipefail
 
+# Source de vérité unique : le .env.local du repo principal. Les worktrees
+# pointent dessus via symlink (cf. scripts/worktree-new.sh), donc un reset
+# depuis n'importe quel worktree met à jour les credentials pour tous.
+MAIN_ROOT="$(git worktree list --porcelain | sed -n 's/^worktree //p' | head -n 1)"
+ENV_FILE="${MAIN_ROOT}/.env.local"
+
 # Load env vars
-if [ -f .env.local ]; then
-  export $(grep -E '^(NEON_API_KEY|NEON_PROJECT_ID|NEON_PROD_BRANCH_ID)=' .env.local | xargs)
+if [ -f "$ENV_FILE" ]; then
+  export $(grep -E '^(NEON_API_KEY|NEON_PROJECT_ID|NEON_PROD_BRANCH_ID)=' "$ENV_FILE" | xargs)
 fi
 
 if [ -z "${NEON_API_KEY:-}" ] || [ -z "${NEON_PROJECT_ID:-}" ] || [ -z "${NEON_PROD_BRANCH_ID:-}" ]; then
-  echo "❌ Missing NEON_API_KEY, NEON_PROJECT_ID, or NEON_PROD_BRANCH_ID in .env.local"
+  echo "❌ Missing NEON_API_KEY, NEON_PROJECT_ID, or NEON_PROD_BRANCH_ID in $ENV_FILE"
   exit 1
 fi
 
@@ -69,18 +75,15 @@ NEW_URL="postgresql://${ROLE}:${PASSWORD}@${POOLER_HOST}/${DB}?sslmode=require"
 echo ""
 echo "✅ Dev branch created: $NEW_BRANCH_ID"
 echo ""
-echo "📋 Update DATABASE_URL in .env.local:"
-echo "   DATABASE_URL=\"${NEW_URL}\""
-echo ""
 
-# Auto-update .env.local
+# Auto-update le .env.local du repo principal (les worktrees pointent dessus via symlink)
 if [[ "$OSTYPE" == "darwin"* ]]; then
-  sed -i '' "s|^DATABASE_URL=.*|DATABASE_URL=\"${NEW_URL}\"|" .env.local
+  sed -i '' "s|^DATABASE_URL=.*|DATABASE_URL=\"${NEW_URL}\"|" "$ENV_FILE"
 else
-  sed -i "s|^DATABASE_URL=.*|DATABASE_URL=\"${NEW_URL}\"|" .env.local
+  sed -i "s|^DATABASE_URL=.*|DATABASE_URL=\"${NEW_URL}\"|" "$ENV_FILE"
 fi
 
-echo "✅ .env.local updated automatically."
+echo "✅ ${ENV_FILE} updated automatically."
 echo ""
 echo "🔄 Regenerating Prisma client..."
 npx prisma generate --no-hints 2>/dev/null

--- a/scripts/worktree-new.sh
+++ b/scripts/worktree-new.sh
@@ -12,7 +12,9 @@
 #   2. Crée un worktree à côté du repo principal, avec une nouvelle branche
 #      partant d'origin/main
 #   3. Installe les dépendances (--prefer-offline, rapide grâce au store pnpm partagé)
-#   4. Copie .env.local depuis le repo principal si présent
+#   4. Crée un symlink .env.local vers le fichier du repo principal
+#      (source unique partagée : un `pnpm db:dev:reset` depuis n'importe
+#      quel worktree met à jour les credentials pour tous les worktrees)
 #   5. Crée un symlink spec/BACKLOG.md vers le fichier du repo principal
 #      (source unique, non trackée, partagée entre tous les worktrees)
 #   6. Affiche un message de fin avec la commande pour lancer le dev server
@@ -57,8 +59,8 @@ cd "$worktree_dir"
 pnpm install --prefer-offline --silent
 
 if [ -f "$main_root/.env.local" ]; then
-  echo "→ Copy .env.local"
-  cp "$main_root/.env.local" .env.local
+  echo "→ Symlink .env.local → repo principal"
+  ln -sf "$main_root/.env.local" .env.local
 fi
 
 if [ -f "$main_root/spec/BACKLOG.md" ]; then


### PR DESCRIPTION
## Summary
Résout un piège silencieux : un `pnpm db:dev:reset` lancé depuis un worktree mettait à jour uniquement ce worktree, laissant le principal et les autres worktrees avec des credentials Neon périmés.

- `worktree-new.sh` : remplace `cp .env.local` par `ln -sf .env.local` (même pattern que pour `spec/BACKLOG.md`).
- `db-dev-reset.sh` : cible désormais explicitement le `.env.local` du repo principal via `git worktree list`, jamais celui du répertoire courant.

Source de vérité unique : le `.env.local` du repo principal. Les worktrees pointent dessus via symlink. Un reset depuis n'importe où propage immédiatement à tout le monde.

## Test plan
- [ ] Sur un nouveau worktree créé via `worktree-new.sh`, vérifier que `.env.local` est bien un symlink (`ls -la`)
- [ ] Depuis ce worktree, modifier une ligne du `.env.local` (via l'éditeur) et vérifier que le changement se reflète dans le principal
- [ ] Lancer `pnpm db:dev:reset` depuis un worktree et vérifier que le `.env.local` du principal est mis à jour
- [ ] Vérifier qu'après le reset, le dev server du principal lit la nouvelle URL

## Note migration
Les worktrees existants gardent leur `.env.local` en fichier régulier jusqu'à migration manuelle :
```bash
MAIN="/chemin/vers/the-playground"
rm .env.local && ln -sf "$MAIN/.env.local" .env.local
```
(Déjà fait sur les worktrees en cours.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)