### PR TITLE
feat(og): agrandit textes et déplace le logo en haut à droite

### DIFF
--- a/src/app/[locale]/(routes)/circles/[slug]/opengraph-image.tsx
+++ b/src/app/[locale]/(routes)/circles/[slug]/opengraph-image.tsx
@@ -181,12 +181,12 @@ export default async function OgImage({
               style={{
                 display: "flex",
                 alignItems: "center",
-                fontSize: "22px",
+                fontSize: "18px",
                 fontWeight: 600,
                 color: "#ec4899",
                 textTransform: "uppercase",
-                letterSpacing: "3px",
-                marginBottom: "20px",
+                letterSpacing: "2.5px",
+                marginBottom: "18px",
               }}
             >
               {locale === "fr" ? "Communauté" : "Community"}
@@ -194,12 +194,12 @@ export default async function OgImage({
 
             <div
               style={{
-                fontSize: "60px",
+                fontSize: "52px",
                 fontWeight: 700,
                 color: "white",
-                lineHeight: 1.1,
-                letterSpacing: "-1.5px",
-                marginBottom: description ? "22px" : "0",
+                lineHeight: 1.12,
+                letterSpacing: "-1.2px",
+                marginBottom: description ? "18px" : "0",
                 display: "flex",
               }}
             >
@@ -211,7 +211,7 @@ export default async function OgImage({
             {description && (
               <div
                 style={{
-                  fontSize: "24px",
+                  fontSize: "22px",
                   color: "rgba(255, 255, 255, 0.65)",
                   lineHeight: 1.4,
                   display: "flex",
@@ -234,14 +234,14 @@ export default async function OgImage({
               style={{
                 display: "flex",
                 alignItems: "center",
-                gap: "14px",
-                fontSize: "32px",
+                gap: "12px",
+                fontSize: "26px",
                 color: "rgba(255, 255, 255, 0.85)",
               }}
             >
               <svg
-                width="32"
-                height="32"
+                width="26"
+                height="26"
                 viewBox="0 0 24 24"
                 fill="none"
                 stroke="rgba(255,255,255,0.6)"
@@ -264,14 +264,14 @@ export default async function OgImage({
                 style={{
                   display: "flex",
                   alignItems: "center",
-                  gap: "14px",
-                  fontSize: "28px",
+                  gap: "12px",
+                  fontSize: "22px",
                   color: "rgba(255, 255, 255, 0.6)",
                 }}
               >
                 <svg
-                  width="28"
-                  height="28"
+                  width="22"
+                  height="22"
                   viewBox="0 0 24 24"
                   fill="none"
                   stroke="rgba(255,255,255,0.5)"

--- a/src/app/[locale]/(routes)/circles/[slug]/opengraph-image.tsx
+++ b/src/app/[locale]/(routes)/circles/[slug]/opengraph-image.tsx
@@ -39,8 +39,8 @@ export default async function OgImage({
   const memberCount = await prismaCircleRepository.countMembers(circle.id);
 
   const description = circle.description
-    ? circle.description.length > 160
-      ? circle.description.slice(0, 157) + "..."
+    ? circle.description.length > 140
+      ? circle.description.slice(0, 137) + "..."
       : circle.description
     : "";
 
@@ -110,139 +110,22 @@ export default async function OgImage({
             height: "100%",
             display: "flex",
             flexDirection: "column",
-            padding: "48px 48px 40px 44px",
+            padding: "40px 48px 44px 48px",
           }}
         >
-          {/* Community label */}
+          {/* Top: branding, aligned to the right */}
           <div
             style={{
               display: "flex",
+              justifyContent: "flex-end",
               alignItems: "center",
-              fontSize: "16px",
-              fontWeight: 600,
-              color: "#ec4899",
-              textTransform: "uppercase",
-              letterSpacing: "2px",
-              marginBottom: "20px",
             }}
           >
-            {locale === "fr" ? "Communauté" : "Community"}
-          </div>
-
-          {/* Circle name */}
-          <div
-            style={{
-              fontSize: "44px",
-              fontWeight: 700,
-              color: "white",
-              lineHeight: 1.15,
-              letterSpacing: "-1px",
-              marginBottom: "18px",
-              display: "flex",
-            }}
-          >
-            {circle.name.length > 60
-              ? circle.name.slice(0, 57) + "..."
-              : circle.name}
-          </div>
-
-          {/* Description */}
-          {description && (
-            <div
-              style={{
-                fontSize: "20px",
-                color: "rgba(255, 255, 255, 0.65)",
-                lineHeight: 1.45,
-                flex: 1,
-                display: "flex",
-              }}
-            >
-              {description}
-            </div>
-          )}
-          {!description && <div style={{ flex: 1 }} />}
-
-          {/* Bottom info */}
-          <div
-            style={{
-              display: "flex",
-              justifyContent: "space-between",
-              alignItems: "flex-end",
-            }}
-          >
-            <div
-              style={{
-                display: "flex",
-                flexDirection: "column",
-                gap: "8px",
-                maxWidth: CONTENT_WIDTH - 180,
-              }}
-            >
-              {/* Members */}
-              <div
-                style={{
-                  display: "flex",
-                  alignItems: "center",
-                  gap: "10px",
-                  fontSize: "20px",
-                  color: "rgba(255, 255, 255, 0.8)",
-                }}
-              >
-                <svg
-                  width="20"
-                  height="20"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="rgba(255,255,255,0.6)"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                >
-                  <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
-                  <circle cx="9" cy="7" r="4" />
-                  <path d="M22 21v-2a4 4 0 0 0-3-3.87" />
-                  <path d="M16 3.13a4 4 0 0 1 0 7.75" />
-                </svg>
-                {locale === "fr"
-                  ? `${memberCount} membre${memberCount !== 1 ? "s" : ""}`
-                  : `${memberCount} member${memberCount !== 1 ? "s" : ""}`}
-              </div>
-
-              {/* City */}
-              {circle.city && (
-                <div
-                  style={{
-                    display: "flex",
-                    alignItems: "center",
-                    gap: "10px",
-                    fontSize: "18px",
-                    color: "rgba(255, 255, 255, 0.6)",
-                  }}
-                >
-                  <svg
-                    width="18"
-                    height="18"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="rgba(255,255,255,0.5)"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  >
-                    <path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0Z" />
-                    <circle cx="12" cy="10" r="3" />
-                  </svg>
-                  {circle.city}
-                </div>
-              )}
-            </div>
-
-            {/* Bottom-right branding */}
             <div
               style={{
                 display: "flex",
                 alignItems: "center",
-                gap: "10px",
+                gap: "12px",
               }}
             >
               <div
@@ -250,39 +133,158 @@ export default async function OgImage({
                   display: "flex",
                   alignItems: "center",
                   justifyContent: "center",
-                  width: "28px",
-                  height: "28px",
-                  borderRadius: "7px",
+                  width: "36px",
+                  height: "36px",
+                  borderRadius: "9px",
                   background: "linear-gradient(135deg, #ec4899, #a855f7)",
                 }}
               >
-                <svg width="11" height="13" viewBox="0 0 13 15" fill="none">
+                <svg width="14" height="16" viewBox="0 0 13 15" fill="none">
                   <polygon points="0,0 0,15 13,7.5" fill="white" />
                 </svg>
               </div>
               <div style={{ display: "flex", alignItems: "baseline" }}>
                 <span
                   style={{
-                    fontSize: "16px",
+                    fontSize: "22px",
                     fontWeight: 700,
                     color: "rgba(255, 255, 255, 0.4)",
-                    letterSpacing: "-0.4px",
+                    letterSpacing: "-0.5px",
                   }}
                 >
-                  {"the\u2009"}
+                  {"the "}
                 </span>
                 <span
                   style={{
-                    fontSize: "16px",
+                    fontSize: "22px",
                     fontWeight: 700,
                     color: "#e8457a",
-                    letterSpacing: "-0.4px",
+                    letterSpacing: "-0.5px",
                   }}
                 >
                   playground
                 </span>
               </div>
             </div>
+          </div>
+
+          {/* Middle: community label + name + description, centered vertically */}
+          <div
+            style={{
+              flex: 1,
+              display: "flex",
+              flexDirection: "column",
+              justifyContent: "center",
+            }}
+          >
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                fontSize: "22px",
+                fontWeight: 600,
+                color: "#ec4899",
+                textTransform: "uppercase",
+                letterSpacing: "3px",
+                marginBottom: "20px",
+              }}
+            >
+              {locale === "fr" ? "Communauté" : "Community"}
+            </div>
+
+            <div
+              style={{
+                fontSize: "60px",
+                fontWeight: 700,
+                color: "white",
+                lineHeight: 1.1,
+                letterSpacing: "-1.5px",
+                marginBottom: description ? "22px" : "0",
+                display: "flex",
+              }}
+            >
+              {circle.name.length > 60
+                ? circle.name.slice(0, 57) + "..."
+                : circle.name}
+            </div>
+
+            {description && (
+              <div
+                style={{
+                  fontSize: "24px",
+                  color: "rgba(255, 255, 255, 0.65)",
+                  lineHeight: 1.4,
+                  display: "flex",
+                }}
+              >
+                {description}
+              </div>
+            )}
+          </div>
+
+          {/* Bottom: members + city */}
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: "12px",
+            }}
+          >
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: "14px",
+                fontSize: "32px",
+                color: "rgba(255, 255, 255, 0.85)",
+              }}
+            >
+              <svg
+                width="32"
+                height="32"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="rgba(255,255,255,0.6)"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
+                <circle cx="9" cy="7" r="4" />
+                <path d="M22 21v-2a4 4 0 0 0-3-3.87" />
+                <path d="M16 3.13a4 4 0 0 1 0 7.75" />
+              </svg>
+              {locale === "fr"
+                ? `${memberCount} membre${memberCount !== 1 ? "s" : ""}`
+                : `${memberCount} member${memberCount !== 1 ? "s" : ""}`}
+            </div>
+
+            {circle.city && (
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "14px",
+                  fontSize: "28px",
+                  color: "rgba(255, 255, 255, 0.6)",
+                }}
+              >
+                <svg
+                  width="28"
+                  height="28"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="rgba(255,255,255,0.5)"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0Z" />
+                  <circle cx="12" cy="10" r="3" />
+                </svg>
+                {circle.city}
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/src/app/[locale]/(routes)/m/[slug]/opengraph-image.tsx
+++ b/src/app/[locale]/(routes)/m/[slug]/opengraph-image.tsx
@@ -199,10 +199,10 @@ export default async function OgImage({
             {circle && (
               <div
                 style={{
-                  fontSize: "32px",
+                  fontSize: "26px",
                   fontWeight: 600,
                   color: "#ec4899",
-                  marginBottom: "24px",
+                  marginBottom: "20px",
                   display: "flex",
                   alignItems: "center",
                 }}
@@ -213,11 +213,11 @@ export default async function OgImage({
 
             <div
               style={{
-                fontSize: "60px",
+                fontSize: "52px",
                 fontWeight: 700,
                 color: "white",
-                lineHeight: 1.1,
-                letterSpacing: "-1.5px",
+                lineHeight: 1.12,
+                letterSpacing: "-1.2px",
                 display: "flex",
               }}
             >
@@ -239,14 +239,14 @@ export default async function OgImage({
               style={{
                 display: "flex",
                 alignItems: "center",
-                gap: "14px",
-                fontSize: "32px",
+                gap: "12px",
+                fontSize: "26px",
                 color: "rgba(255, 255, 255, 0.85)",
               }}
             >
               <svg
-                width="32"
-                height="32"
+                width="26"
+                height="26"
                 viewBox="0 0 24 24"
                 fill="none"
                 stroke="rgba(255,255,255,0.6)"
@@ -267,14 +267,14 @@ export default async function OgImage({
                 style={{
                   display: "flex",
                   alignItems: "center",
-                  gap: "14px",
-                  fontSize: "28px",
+                  gap: "12px",
+                  fontSize: "22px",
                   color: "rgba(255, 255, 255, 0.6)",
                 }}
               >
                 <svg
-                  width="28"
-                  height="28"
+                  width="22"
+                  height="22"
                   viewBox="0 0 24 24"
                   fill="none"
                   stroke="rgba(255,255,255,0.5)"

--- a/src/app/[locale]/(routes)/m/[slug]/opengraph-image.tsx
+++ b/src/app/[locale]/(routes)/m/[slug]/opengraph-image.tsx
@@ -129,124 +129,22 @@ export default async function OgImage({
             height: "100%",
             display: "flex",
             flexDirection: "column",
-            padding: "48px 48px 40px 44px",
+            padding: "40px 48px 44px 48px",
           }}
         >
-          {/* Circle name */}
-          {circle && (
-            <div
-              style={{
-                fontSize: "20px",
-                fontWeight: 600,
-                color: "#ec4899",
-                marginBottom: "18px",
-                display: "flex",
-                alignItems: "center",
-              }}
-            >
-              {circle.name}
-            </div>
-          )}
-
-          {/* Moment title */}
-          <div
-            style={{
-              fontSize: "44px",
-              fontWeight: 700,
-              color: "white",
-              lineHeight: 1.15,
-              letterSpacing: "-1px",
-              flex: 1,
-              display: "flex",
-              alignItems: "flex-start",
-            }}
-          >
-            {moment.title.length > 90
-              ? moment.title.slice(0, 87) + "..."
-              : moment.title}
-          </div>
-
-          {/* Bottom info */}
+          {/* Top: branding, aligned to the right */}
           <div
             style={{
               display: "flex",
-              justifyContent: "space-between",
-              alignItems: "flex-end",
+              justifyContent: "flex-end",
+              alignItems: "center",
             }}
           >
             <div
               style={{
                 display: "flex",
-                flexDirection: "column",
-                gap: "8px",
-                maxWidth: CONTENT_WIDTH - 180,
-              }}
-            >
-              {/* Date + time */}
-              <div
-                style={{
-                  display: "flex",
-                  alignItems: "center",
-                  gap: "10px",
-                  fontSize: "20px",
-                  color: "rgba(255, 255, 255, 0.8)",
-                }}
-              >
-                <svg
-                  width="20"
-                  height="20"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="rgba(255,255,255,0.6)"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                >
-                  <rect width="18" height="18" x="3" y="4" rx="2" ry="2" />
-                  <line x1="16" x2="16" y1="2" y2="6" />
-                  <line x1="8" x2="8" y1="2" y2="6" />
-                  <line x1="3" x2="21" y1="10" y2="10" />
-                </svg>
-                {date} · {time}
-              </div>
-
-              {/* Location */}
-              {location && (
-                <div
-                  style={{
-                    display: "flex",
-                    alignItems: "center",
-                    gap: "10px",
-                    fontSize: "18px",
-                    color: "rgba(255, 255, 255, 0.6)",
-                  }}
-                >
-                  <svg
-                    width="18"
-                    height="18"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="rgba(255,255,255,0.5)"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  >
-                    <path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0Z" />
-                    <circle cx="12" cy="10" r="3" />
-                  </svg>
-                  {location.length > 36
-                    ? location.slice(0, 33) + "..."
-                    : location}
-                </div>
-              )}
-            </div>
-
-            {/* Bottom-right branding */}
-            <div
-              style={{
-                display: "flex",
                 alignItems: "center",
-                gap: "10px",
+                gap: "12px",
               }}
             >
               <div
@@ -254,39 +152,144 @@ export default async function OgImage({
                   display: "flex",
                   alignItems: "center",
                   justifyContent: "center",
-                  width: "28px",
-                  height: "28px",
-                  borderRadius: "7px",
+                  width: "36px",
+                  height: "36px",
+                  borderRadius: "9px",
                   background: "linear-gradient(135deg, #ec4899, #a855f7)",
                 }}
               >
-                <svg width="11" height="13" viewBox="0 0 13 15" fill="none">
+                <svg width="14" height="16" viewBox="0 0 13 15" fill="none">
                   <polygon points="0,0 0,15 13,7.5" fill="white" />
                 </svg>
               </div>
               <div style={{ display: "flex", alignItems: "baseline" }}>
                 <span
                   style={{
-                    fontSize: "16px",
+                    fontSize: "22px",
                     fontWeight: 700,
                     color: "rgba(255, 255, 255, 0.4)",
-                    letterSpacing: "-0.4px",
+                    letterSpacing: "-0.5px",
                   }}
                 >
                   {"the "}
                 </span>
                 <span
                   style={{
-                    fontSize: "16px",
+                    fontSize: "22px",
                     fontWeight: 700,
                     color: "#e8457a",
-                    letterSpacing: "-0.4px",
+                    letterSpacing: "-0.5px",
                   }}
                 >
                   playground
                 </span>
               </div>
             </div>
+          </div>
+
+          {/* Middle: Circle name + title, centered vertically */}
+          <div
+            style={{
+              flex: 1,
+              display: "flex",
+              flexDirection: "column",
+              justifyContent: "center",
+            }}
+          >
+            {circle && (
+              <div
+                style={{
+                  fontSize: "32px",
+                  fontWeight: 600,
+                  color: "#ec4899",
+                  marginBottom: "24px",
+                  display: "flex",
+                  alignItems: "center",
+                }}
+              >
+                {circle.name}
+              </div>
+            )}
+
+            <div
+              style={{
+                fontSize: "60px",
+                fontWeight: 700,
+                color: "white",
+                lineHeight: 1.1,
+                letterSpacing: "-1.5px",
+                display: "flex",
+              }}
+            >
+              {moment.title.length > 90
+                ? moment.title.slice(0, 87) + "..."
+                : moment.title}
+            </div>
+          </div>
+
+          {/* Bottom: date + location */}
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: "12px",
+            }}
+          >
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: "14px",
+                fontSize: "32px",
+                color: "rgba(255, 255, 255, 0.85)",
+              }}
+            >
+              <svg
+                width="32"
+                height="32"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="rgba(255,255,255,0.6)"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <rect width="18" height="18" x="3" y="4" rx="2" ry="2" />
+                <line x1="16" x2="16" y1="2" y2="6" />
+                <line x1="8" x2="8" y1="2" y2="6" />
+                <line x1="3" x2="21" y1="10" y2="10" />
+              </svg>
+              {date} · {time}
+            </div>
+
+            {location && (
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "14px",
+                  fontSize: "28px",
+                  color: "rgba(255, 255, 255, 0.6)",
+                }}
+              >
+                <svg
+                  width="28"
+                  height="28"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="rgba(255,255,255,0.5)"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0Z" />
+                  <circle cx="12" cy="10" r="3" />
+                </svg>
+                {location.length > 36
+                  ? location.slice(0, 33) + "..."
+                  : location}
+              </div>
+            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
Refonte du panneau droit des OG images : le logo passe en haut à droite, le bloc « Communauté + titre » est centré verticalement, la date et le lieu restent en bas. Le risque de chevauchement entre la zone date/lieu et le logo (quand les tailles augmentent) disparaît.

**Nouvelles tailles** :
| Élément | Avant | Après |
|---|---|---|
| Nom Communauté | 20 px | 26 px |
| Titre événement | 44 px | 52 px |
| Date + heure | 20 px | 26 px |
| Lieu | 18 px | 22 px |
| Logo « the playground » | 16 px | 22 px |
| Bloc logo (carré violet) | 28×28 | 36×36 |

Icônes ajustées à la même taille que le texte qu'elles accompagnent.

Même structure appliquée à la page Communauté (label, nom, description, membres, ville).

## Test plan
- [ ] Vérifier sur la preview Vercel que `/m/[slug]/opengraph-image` affiche bien le nouveau layout (logo top-right, bloc centré vertical, date/lieu en bas)
- [ ] Même vérif sur `/circles/[slug]/opengraph-image`
- [ ] Vérifier que le fallback sans cover garde la même lisibilité
- [ ] Partager un lien dans Slack avec `?v=1` pour forcer un re-unfurl et constater le rendu

🤖 Generated with [Claude Code](https://claude.com/claude-code)