### PR TITLE
fix(cover-picker): UX mobile — footer, badge éditabilité et pagination Unsplash adaptée

### DIFF
--- a/spec/mockups/cover-picker-mobile-footer.mockup.html
+++ b/spec/mockups/cover-picker-mobile-footer.mockup.html
@@ -1,0 +1,480 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Cover picker — footer mobile (Options A & B)</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <style>
+    :root {
+      --background: oklch(0.1649 0.0352 281.8285);
+      --card: oklch(0.2542 0.0611 281.1423);
+      --primary: oklch(0.6726 0.2904 341.4084);
+      --primary-foreground: oklch(1 0 0);
+      --foreground: oklch(0.9513 0.0074 260.7315);
+      --muted-foreground: oklch(0.6245 0.05 278.1046);
+      --border: oklch(0.3279 0.0832 280.789);
+      --input: oklch(0.3279 0.0832 280.789);
+      --muted: oklch(0.2123 0.0522 280.9917);
+    }
+    body {
+      font-family: 'Inter', system-ui, sans-serif;
+      background: #0a0a14;
+      color: var(--foreground);
+    }
+    .bg-background { background: var(--background); }
+    .bg-card { background: var(--card); }
+    .bg-primary { background: var(--primary); }
+    .bg-muted { background: var(--muted); }
+    .text-primary-foreground { color: var(--primary-foreground); }
+    .text-foreground { color: var(--foreground); }
+    .text-muted-foreground { color: var(--muted-foreground); }
+    .border-input { border-color: var(--input); }
+    .border-border { border-color: var(--border); }
+    .border-primary { border-color: var(--primary); }
+    .ring-primary { --tw-ring-color: var(--primary); }
+
+    /* iPhone shell */
+    .phone {
+      width: 375px;
+      height: 812px;
+      border-radius: 44px;
+      border: 10px solid #1a1a24;
+      box-shadow: 0 30px 60px rgba(0,0,0,0.6), 0 0 0 2px rgba(255,255,255,0.04);
+      overflow: hidden;
+      position: relative;
+      background: var(--background);
+    }
+    .phone-notch {
+      position: absolute;
+      top: 0;
+      left: 50%;
+      transform: translateX(-50%);
+      width: 130px;
+      height: 28px;
+      background: #1a1a24;
+      border-radius: 0 0 18px 18px;
+      z-index: 30;
+    }
+    .status-bar {
+      height: 44px;
+      padding: 0 24px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      font-size: 15px;
+      font-weight: 600;
+      color: var(--foreground);
+      position: relative;
+      z-index: 5;
+    }
+    .status-icons {
+      display: flex;
+      gap: 6px;
+      align-items: center;
+    }
+    .label {
+      position: absolute;
+      top: -36px;
+      left: 50%;
+      transform: translateX(-50%);
+      font-weight: 700;
+      font-size: 14px;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      color: rgba(255,255,255,0.85);
+      white-space: nowrap;
+    }
+    .label-tag {
+      display: inline-block;
+      margin-left: 10px;
+      padding: 2px 8px;
+      border-radius: 999px;
+      font-size: 10px;
+      letter-spacing: 0.04em;
+      background: var(--primary);
+      color: white;
+      vertical-align: middle;
+    }
+
+    /* Form controls fidèles */
+    .tab {
+      flex: 1;
+      padding: 8px 12px;
+      border-radius: 6px;
+      font-size: 14px;
+      font-weight: 500;
+      text-align: center;
+      transition: all 0.15s;
+    }
+    .tab-active {
+      background: var(--card);
+      border: 2px solid var(--primary);
+      color: var(--foreground);
+    }
+    .tab-inactive {
+      color: var(--muted-foreground);
+    }
+
+    .input-search {
+      width: 100%;
+      padding: 10px 12px 10px 38px;
+      background: transparent;
+      border: 1px solid var(--input);
+      border-radius: 8px;
+      color: var(--foreground);
+      font-size: 14px;
+      outline: none;
+    }
+
+    .btn {
+      padding: 10px 16px;
+      border-radius: 8px;
+      font-size: 14px;
+      font-weight: 500;
+      transition: all 0.15s;
+      cursor: pointer;
+      border: none;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 6px;
+    }
+    .btn-primary {
+      background: var(--primary);
+      color: var(--primary-foreground);
+    }
+    .btn-outline {
+      background: transparent;
+      border: 1px solid var(--input);
+      color: var(--foreground);
+    }
+    .btn-ghost {
+      background: transparent;
+      color: var(--muted-foreground);
+    }
+    .btn-ghost:hover { color: var(--foreground); }
+
+    .modal {
+      position: absolute;
+      inset: 0;
+      background: var(--card);
+      display: flex;
+      flex-direction: column;
+      padding-top: 44px; /* status bar */
+    }
+    .modal-header {
+      position: relative;
+      padding: 16px 16px 12px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .modal-title {
+      font-size: 18px;
+      font-weight: 600;
+      color: var(--foreground);
+    }
+    .modal-close {
+      position: absolute;
+      right: 12px;
+      top: 50%;
+      transform: translateY(-50%);
+      width: 32px;
+      height: 32px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: var(--muted-foreground);
+      cursor: pointer;
+      border-radius: 6px;
+    }
+    .modal-body {
+      flex: 1;
+      padding: 0 16px;
+      overflow-y: auto;
+    }
+    .empty-state {
+      padding: 48px 16px;
+      text-align: center;
+      color: var(--muted-foreground);
+      font-size: 14px;
+    }
+    .modal-footer {
+      padding: 16px;
+      border-top: 1px solid rgba(255,255,255,0.06);
+    }
+
+    /* Layout fix-A : stack vertical mobile */
+    .footer-A {
+      display: flex;
+      flex-direction: column-reverse;
+      gap: 8px;
+    }
+    .footer-A .actions-row {
+      display: flex;
+      gap: 8px;
+    }
+    .footer-A .actions-row > .btn {
+      flex: 1;
+    }
+    .footer-A .remove-btn {
+      align-self: flex-start;
+    }
+
+    /* Layout fix-B : actions en haut, supprimer en bas (lien) */
+    .footer-B {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+    .footer-B .actions-row {
+      display: flex;
+      gap: 8px;
+    }
+    .footer-B .actions-row > .btn {
+      flex: 1;
+    }
+    .footer-B .remove-link {
+      align-self: center;
+      padding-top: 12px;
+      font-size: 13px;
+      color: var(--muted-foreground);
+      text-decoration: underline;
+      text-underline-offset: 3px;
+      cursor: pointer;
+    }
+    .footer-B .remove-link:hover { color: var(--foreground); }
+
+    /* Bug actuel */
+    .footer-bug {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      justify-content: space-between;
+      gap: 8px;
+      width: calc(100% + 80px); /* simule le débordement */
+    }
+    .footer-bug-wrapper {
+      overflow: visible;
+      position: relative;
+    }
+    .overflow-warning {
+      position: absolute;
+      top: -22px;
+      right: 0;
+      font-size: 10px;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      color: #ef4444;
+      font-weight: 700;
+    }
+
+    .stage {
+      display: flex;
+      gap: 80px;
+      flex-wrap: wrap;
+      justify-content: center;
+      padding: 80px 40px 60px;
+      align-items: flex-start;
+    }
+    .stage-row { padding-top: 60px; }
+    .legend {
+      max-width: 760px;
+      margin: 0 auto 24px;
+      padding: 24px;
+      border-radius: 12px;
+      background: rgba(255,255,255,0.03);
+      border: 1px solid rgba(255,255,255,0.06);
+      color: rgba(255,255,255,0.85);
+      font-size: 13px;
+      line-height: 1.6;
+    }
+    .legend h2 {
+      font-weight: 700;
+      font-size: 14px;
+      margin-bottom: 8px;
+      color: white;
+    }
+    .legend strong { color: white; }
+  </style>
+</head>
+<body>
+
+  <div class="legend">
+    <h2>Mockup — fix débordement modale Cover (mobile 375px)</h2>
+    <p>
+      Trois rendus côte à côte : <strong>l'état actuel</strong> (bug : footer en flex-row qui déborde),
+      <strong>Option A</strong> (stack vertical, supprimer en haut), <strong>Option B</strong>
+      (stack vertical, actions en haut, supprimer en lien discret en bas).
+    </p>
+  </div>
+
+  <div class="stage stage-row">
+
+    <!-- ─── ÉTAT ACTUEL — BUG ─── -->
+    <div style="position: relative;">
+      <div class="label">État actuel <span class="label-tag" style="background:#ef4444">BUG</span></div>
+      <div class="phone">
+        <div class="phone-notch"></div>
+        <div class="modal">
+          <div class="status-bar">
+            <span>09:41</span>
+            <div class="status-icons">
+              <svg width="18" height="11" viewBox="0 0 18 11" fill="currentColor"><path d="M1 8h2v2H1zM5 6h2v4H5zM9 4h2v6H9zM13 2h2v8h-2z"/></svg>
+              <svg width="16" height="12" viewBox="0 0 16 12" fill="currentColor"><path d="M8 2C5.5 2 3.2 2.9 1.5 4.5L0 3C2.1 1.1 5 0 8 0s5.9 1.1 8 3l-1.5 1.5C12.8 2.9 10.5 2 8 2zm0 4C6.6 6 5.3 6.5 4.3 7.5L2.8 6c1.4-1.4 3.2-2 5.2-2s3.8.6 5.2 2l-1.5 1.5C10.7 6.5 9.4 6 8 6zm0 4l3-3c-.8-.8-1.9-1-3-1s-2.2.2-3 1l3 3z"/></svg>
+              <svg width="26" height="12" viewBox="0 0 26 12" fill="currentColor"><rect x="1" y="1" width="22" height="10" rx="2.5" stroke="currentColor" fill="none" stroke-width="1"/><rect x="3" y="3" width="18" height="6" rx="1" fill="currentColor"/><rect x="24" y="4" width="2" height="4" rx="1" fill="currentColor"/></svg>
+            </div>
+          </div>
+
+          <div class="modal-header">
+            <div class="modal-title">Image de couverture</div>
+            <div class="modal-close">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18M6 6l12 12"/></svg>
+            </div>
+          </div>
+
+          <div class="modal-body">
+            <div style="display: flex; gap: 4px; padding: 4px; background: var(--muted); border-radius: 8px; margin-bottom: 16px;">
+              <div class="tab tab-active">Photos</div>
+              <div class="tab tab-inactive">Importer</div>
+            </div>
+            <div style="position: relative;">
+              <svg style="position: absolute; left: 12px; top: 50%; transform: translateY(-50%); color: var(--muted-foreground);" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/></svg>
+              <input class="input-search" value="Communauté WOLD" />
+            </div>
+            <div class="empty-state">Aucun résultat pour « Communauté WOLD »</div>
+          </div>
+
+          <div class="modal-footer footer-bug-wrapper">
+            <div class="overflow-warning">déborde →</div>
+            <div class="footer-bug">
+              <button class="btn btn-ghost" style="font-size:13px; flex-shrink:0;">Supprimer la couverture</button>
+              <button class="btn btn-outline" style="flex-shrink:0;">Annuler</button>
+              <button class="btn btn-primary" style="flex-shrink:0;">Appliquer</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ─── OPTION A ─── -->
+    <div style="position: relative;">
+      <div class="label">Option A <span class="label-tag">recommandée</span></div>
+      <div class="phone">
+        <div class="phone-notch"></div>
+        <div class="modal">
+          <div class="status-bar">
+            <span>09:41</span>
+            <div class="status-icons">
+              <svg width="18" height="11" viewBox="0 0 18 11" fill="currentColor"><path d="M1 8h2v2H1zM5 6h2v4H5zM9 4h2v6H9zM13 2h2v8h-2z"/></svg>
+              <svg width="16" height="12" viewBox="0 0 16 12" fill="currentColor"><path d="M8 2C5.5 2 3.2 2.9 1.5 4.5L0 3C2.1 1.1 5 0 8 0s5.9 1.1 8 3l-1.5 1.5C12.8 2.9 10.5 2 8 2zm0 4C6.6 6 5.3 6.5 4.3 7.5L2.8 6c1.4-1.4 3.2-2 5.2-2s3.8.6 5.2 2l-1.5 1.5C10.7 6.5 9.4 6 8 6zm0 4l3-3c-.8-.8-1.9-1-3-1s-2.2.2-3 1l3 3z"/></svg>
+              <svg width="26" height="12" viewBox="0 0 26 12" fill="currentColor"><rect x="1" y="1" width="22" height="10" rx="2.5" stroke="currentColor" fill="none" stroke-width="1"/><rect x="3" y="3" width="18" height="6" rx="1" fill="currentColor"/><rect x="24" y="4" width="2" height="4" rx="1" fill="currentColor"/></svg>
+            </div>
+          </div>
+
+          <div class="modal-header">
+            <div class="modal-title">Image de couverture</div>
+            <div class="modal-close">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18M6 6l12 12"/></svg>
+            </div>
+          </div>
+
+          <div class="modal-body">
+            <div style="display: flex; gap: 4px; padding: 4px; background: var(--muted); border-radius: 8px; margin-bottom: 16px;">
+              <div class="tab tab-active">Photos</div>
+              <div class="tab tab-inactive">Importer</div>
+            </div>
+            <div style="position: relative;">
+              <svg style="position: absolute; left: 12px; top: 50%; transform: translateY(-50%); color: var(--muted-foreground);" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/></svg>
+              <input class="input-search" value="Communauté WOLD" />
+            </div>
+            <div class="empty-state">Aucun résultat pour « Communauté WOLD »</div>
+          </div>
+
+          <div class="modal-footer">
+            <div class="footer-A">
+              <div class="actions-row">
+                <button class="btn btn-outline">Annuler</button>
+                <button class="btn btn-primary">Appliquer</button>
+              </div>
+              <button class="btn btn-ghost remove-btn" style="font-size:13px; padding-left:0;">Supprimer la couverture</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ─── OPTION B ─── -->
+    <div style="position: relative;">
+      <div class="label">Option B</div>
+      <div class="phone">
+        <div class="phone-notch"></div>
+        <div class="modal">
+          <div class="status-bar">
+            <span>09:41</span>
+            <div class="status-icons">
+              <svg width="18" height="11" viewBox="0 0 18 11" fill="currentColor"><path d="M1 8h2v2H1zM5 6h2v4H5zM9 4h2v6H9zM13 2h2v8h-2z"/></svg>
+              <svg width="16" height="12" viewBox="0 0 16 12" fill="currentColor"><path d="M8 2C5.5 2 3.2 2.9 1.5 4.5L0 3C2.1 1.1 5 0 8 0s5.9 1.1 8 3l-1.5 1.5C12.8 2.9 10.5 2 8 2zm0 4C6.6 6 5.3 6.5 4.3 7.5L2.8 6c1.4-1.4 3.2-2 5.2-2s3.8.6 5.2 2l-1.5 1.5C10.7 6.5 9.4 6 8 6zm0 4l3-3c-.8-.8-1.9-1-3-1s-2.2.2-3 1l3 3z"/></svg>
+              <svg width="26" height="12" viewBox="0 0 26 12" fill="currentColor"><rect x="1" y="1" width="22" height="10" rx="2.5" stroke="currentColor" fill="none" stroke-width="1"/><rect x="3" y="3" width="18" height="6" rx="1" fill="currentColor"/><rect x="24" y="4" width="2" height="4" rx="1" fill="currentColor"/></svg>
+            </div>
+          </div>
+
+          <div class="modal-header">
+            <div class="modal-title">Image de couverture</div>
+            <div class="modal-close">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18M6 6l12 12"/></svg>
+            </div>
+          </div>
+
+          <div class="modal-body">
+            <div style="display: flex; gap: 4px; padding: 4px; background: var(--muted); border-radius: 8px; margin-bottom: 16px;">
+              <div class="tab tab-active">Photos</div>
+              <div class="tab tab-inactive">Importer</div>
+            </div>
+            <div style="position: relative;">
+              <svg style="position: absolute; left: 12px; top: 50%; transform: translateY(-50%); color: var(--muted-foreground);" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/></svg>
+              <input class="input-search" value="Communauté WOLD" />
+            </div>
+            <div class="empty-state">Aucun résultat pour « Communauté WOLD »</div>
+          </div>
+
+          <div class="modal-footer">
+            <div class="footer-B">
+              <div class="actions-row">
+                <button class="btn btn-outline">Annuler</button>
+                <button class="btn btn-primary">Appliquer</button>
+              </div>
+              <a class="remove-link">Supprimer la couverture</a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+  <div class="legend" style="margin-top: 40px;">
+    <h2>Notes</h2>
+    <p>
+      <strong>Option A</strong> — Layout shadcn par défaut (`flex-col-reverse gap-2 sm:flex-row`).
+      Boutons d'action fullwidth (flex-1) en bas, "Supprimer la couverture" en bouton ghost discret au-dessus.
+      Diff minimal, pattern aligné avec le reste du projet.
+    </p>
+    <p style="margin-top: 8px;">
+      <strong>Option B</strong> — Actions principales en haut (zone du pouce), action destructive
+      transformée en lien underline en bas, plus discrète. Hiérarchie visuelle plus marquée mais
+      pattern lien-au-lieu-de-bouton inhabituel dans le projet.
+    </p>
+    <p style="margin-top: 8px;">
+      Dans les deux cas, le footer est aligné sur le pattern shadcn `flex-col-reverse … sm:flex-row`,
+      donc en desktop (≥640px) on retrouve la disposition horizontale d'origine — le fix est
+      strictement mobile.
+    </p>
+  </div>
+
+</body>
+</html>

--- a/src/app/api/unsplash/_lib/parse-per-page.ts
+++ b/src/app/api/unsplash/_lib/parse-per-page.ts
@@ -1,0 +1,9 @@
+// Unsplash limite `per_page` (search) et `count` (random) à 30 — clamp commun
+// pour éviter les 422 Unprocessable Entity en cas de paramètre client invalide.
+const UNSPLASH_MAX_PER_PAGE = 30;
+
+export function parsePerPage(raw: string | null, fallback: number): number {
+  const parsed = parseInt(raw ?? String(fallback), 10);
+  const value = Number.isFinite(parsed) ? parsed : fallback;
+  return Math.min(UNSPLASH_MAX_PER_PAGE, Math.max(1, value));
+}

--- a/src/app/api/unsplash/random/route.ts
+++ b/src/app/api/unsplash/random/route.ts
@@ -1,8 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import type { UnsplashPhoto } from "@/app/api/unsplash/search/route";
+import { parsePerPage } from "../_lib/parse-per-page";
 
-// Nombre de photos aléatoires par défaut (desktop) — borne 1-30 imposée par l'API
-// Unsplash /photos/random qui retourne un array quand `count` est fourni.
 const DEFAULT_RANDOM_COUNT = 8;
 
 type UnsplashRandomPhoto = {
@@ -17,13 +16,9 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: "Unsplash not configured" }, { status: 503 });
   }
 
-  const perPageParam = parseInt(
-    request.nextUrl.searchParams.get("perPage") ?? String(DEFAULT_RANDOM_COUNT),
-    10
-  );
-  const count = Math.min(
-    30,
-    Math.max(1, Number.isFinite(perPageParam) ? perPageParam : DEFAULT_RANDOM_COUNT)
+  const count = parsePerPage(
+    request.nextUrl.searchParams.get("perPage"),
+    DEFAULT_RANDOM_COUNT
   );
 
   const url = new URL("https://api.unsplash.com/photos/random");

--- a/src/app/api/unsplash/random/route.ts
+++ b/src/app/api/unsplash/random/route.ts
@@ -1,9 +1,9 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import type { UnsplashPhoto } from "@/app/api/unsplash/search/route";
 
-// Nombre de photos aléatoires à récupérer en une seule requête.
-// Unsplash /photos/random retourne un array quand `count` est fourni (max 30).
-const RANDOM_COUNT = 8;
+// Nombre de photos aléatoires par défaut (desktop) — borne 1-30 imposée par l'API
+// Unsplash /photos/random qui retourne un array quand `count` est fourni.
+const DEFAULT_RANDOM_COUNT = 8;
 
 type UnsplashRandomPhoto = {
   id: string;
@@ -11,14 +11,23 @@ type UnsplashRandomPhoto = {
   user: { name: string; links: { html: string } };
 };
 
-export async function GET() {
+export async function GET(request: NextRequest) {
   const accessKey = process.env.UNSPLASH_ACCESS_KEY;
   if (!accessKey) {
     return NextResponse.json({ error: "Unsplash not configured" }, { status: 503 });
   }
 
+  const perPageParam = parseInt(
+    request.nextUrl.searchParams.get("perPage") ?? String(DEFAULT_RANDOM_COUNT),
+    10
+  );
+  const count = Math.min(
+    30,
+    Math.max(1, Number.isFinite(perPageParam) ? perPageParam : DEFAULT_RANDOM_COUNT)
+  );
+
   const url = new URL("https://api.unsplash.com/photos/random");
-  url.searchParams.set("count", String(RANDOM_COUNT));
+  url.searchParams.set("count", String(count));
   url.searchParams.set("orientation", "squarish");
 
   const response = await fetch(url.toString(), {

--- a/src/app/api/unsplash/search/route.ts
+++ b/src/app/api/unsplash/search/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { parsePerPage } from "../_lib/parse-per-page";
 
 export type UnsplashPhoto = {
   id: string;
@@ -36,8 +37,7 @@ export async function GET(request: NextRequest) {
   }
 
   const page = Math.max(1, parseInt(searchParams.get("page") ?? "1", 10));
-  const perPageParam = parseInt(searchParams.get("perPage") ?? "12", 10);
-  const perPage = Math.min(30, Math.max(1, Number.isFinite(perPageParam) ? perPageParam : 12));
+  const perPage = parsePerPage(searchParams.get("perPage"), 12);
 
   const url = new URL("https://api.unsplash.com/search/photos");
   url.searchParams.set("query", q.trim());

--- a/src/app/api/unsplash/search/route.ts
+++ b/src/app/api/unsplash/search/route.ts
@@ -36,11 +36,13 @@ export async function GET(request: NextRequest) {
   }
 
   const page = Math.max(1, parseInt(searchParams.get("page") ?? "1", 10));
+  const perPageParam = parseInt(searchParams.get("perPage") ?? "12", 10);
+  const perPage = Math.min(30, Math.max(1, Number.isFinite(perPageParam) ? perPageParam : 12));
 
   const url = new URL("https://api.unsplash.com/search/photos");
   url.searchParams.set("query", q.trim());
   url.searchParams.set("orientation", "squarish");
-  url.searchParams.set("per_page", "12");
+  url.searchParams.set("per_page", String(perPage));
   url.searchParams.set("page", String(page));
 
   const response = await fetch(url.toString(), {

--- a/src/components/circles/cover-image-picker.tsx
+++ b/src/components/circles/cover-image-picker.tsx
@@ -42,6 +42,14 @@ type Props = {
 const CONTEXT_QUERY_MAX_LENGTH = 80;
 const MIN_QUERY_LENGTH = 2;
 
+// Mobile (< sm:) reçoit moins de photos pour rester confortable au scroll : 6 (3 lignes
+// de 2) en recherche, 6 en fallback random. Desktop garde 12 / 8 — valeurs d'origine.
+const SEARCH_PER_PAGE_MOBILE = 6;
+const SEARCH_PER_PAGE_DESKTOP = 12;
+const RANDOM_PER_PAGE_MOBILE = 6;
+const RANDOM_PER_PAGE_DESKTOP = 8;
+const MOBILE_BREAKPOINT_QUERY = "(max-width: 639px)";
+
 
 // ── Photo Grid ─────────────────────────────────────────────────
 
@@ -124,6 +132,21 @@ export function CoverImagePicker({
   const [uploadFile, setUploadFile] = useState<File | null>(null);
   const [uploadError, setUploadError] = useState<string | null>(null);
 
+  // Viewport — pilote la pagination Unsplash (moins de photos sur mobile pour
+  // limiter le scroll et la consommation data). Pas de refetch sur resize :
+  // la valeur courante est figée pour le batch déjà chargé, le prochain fetch
+  // (pagination ou nouvelle recherche) prendra la valeur mise à jour.
+  const [isMobile, setIsMobile] = useState(false);
+  useEffect(() => {
+    const mql = window.matchMedia(MOBILE_BREAKPOINT_QUERY);
+    const update = () => setIsMobile(mql.matches);
+    update();
+    mql.addEventListener("change", update);
+    return () => mql.removeEventListener("change", update);
+  }, []);
+  const searchPerPage = isMobile ? SEARCH_PER_PAGE_MOBILE : SEARCH_PER_PAGE_DESKTOP;
+  const randomPerPage = isMobile ? RANDOM_PER_PAGE_MOBILE : RANDOM_PER_PAGE_DESKTOP;
+
   const gradient = getMomentGradient(circleName ?? "");
 
   const displayedPhotos = searchResults ?? defaultPhotos ?? [];
@@ -137,7 +160,7 @@ export function CoverImagePicker({
       setSearchPage(page);
       try {
         const res = await fetch(
-          `/api/unsplash/search?q=${encodeURIComponent(value.trim())}&page=${page}`
+          `/api/unsplash/search?q=${encodeURIComponent(value.trim())}&page=${page}&perPage=${searchPerPage}`
         );
         if (res.ok) {
           const data = await res.json();
@@ -159,7 +182,7 @@ export function CoverImagePicker({
         setIsSearching(false);
       }
     },
-    [t]
+    [t, searchPerPage]
   );
 
   // Debounced Unsplash search — utilisé quand l'utilisateur tape dans l'input
@@ -192,7 +215,7 @@ export function CoverImagePicker({
     if (!query || isLoadingMore) return;
     setIsLoadingMore(true);
     try {
-      const res = await fetch(`/api/unsplash/search?q=${encodeURIComponent(query.trim())}&page=${page}`);
+      const res = await fetch(`/api/unsplash/search?q=${encodeURIComponent(query.trim())}&page=${page}&perPage=${searchPerPage}`);
       if (res.ok) {
         const data = await res.json();
         setSearchResults(data.results);
@@ -271,7 +294,7 @@ export function CoverImagePicker({
       } else if (defaultPhotos === null && !isLoadingDefaults) {
         // Fallback : photos random (première ouverture uniquement)
         setIsLoadingDefaults(true);
-        fetch("/api/unsplash/random")
+        fetch(`/api/unsplash/random?perPage=${randomPerPage}`)
           .then((res) => (res.ok ? res.json() : null))
           .then((data) => {
             if (data?.results) setDefaultPhotos(data.results as UnsplashPhoto[]);
@@ -509,23 +532,24 @@ export function CoverImagePicker({
             </TabsContent>
           </Tabs>
 
-          <DialogFooter className="flex flex-row items-center justify-between">
+          <DialogFooter className="sm:items-center">
             {currentImage && (
               <Button
                 type="button"
                 variant="ghost"
                 size="sm"
                 onClick={handleRemove}
-                className="text-muted-foreground"
+                className="text-muted-foreground self-center underline underline-offset-4 sm:mr-auto sm:self-auto sm:no-underline"
               >
                 {t("removeCover")}
               </Button>
             )}
-            <div className="flex gap-2 ml-auto">
+            <div className="flex w-full gap-2 sm:w-auto">
               <Button
                 type="button"
                 variant="outline"
                 onClick={() => handleOpenChange(false)}
+                className="flex-1 sm:flex-none"
               >
                 {t("cancel")}
               </Button>
@@ -533,6 +557,7 @@ export function CoverImagePicker({
                 type="button"
                 onClick={handleApply}
                 disabled={!pending}
+                className="flex-1 sm:flex-none"
               >
                 {t("apply")}
               </Button>

--- a/src/components/circles/cover-image-picker.tsx
+++ b/src/components/circles/cover-image-picker.tsx
@@ -351,12 +351,21 @@ export function CoverImagePicker({
           <div className="size-full" style={{ background: gradient }} />
         )}
 
-        {/* Overlay au survol */}
+        {/* Overlay au survol (desktop) */}
         <div className="absolute inset-0 flex items-center justify-center bg-black/0 transition-colors group-hover:bg-black/40">
           <div className="flex translate-y-1 items-center gap-2 rounded-full bg-white/90 px-3 py-1.5 text-sm font-medium text-black opacity-0 shadow transition-all group-hover:translate-y-0 group-hover:opacity-100">
             <Camera className="size-4" />
             {t("modifyButton")}
           </div>
+        </div>
+
+        {/* Badge permanent (mobile) — sur mobile, pas de hover, donc on signale
+            l'éditabilité avec une icône caméra discrète en bas à droite. */}
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute bottom-3 right-3 flex size-9 items-center justify-center rounded-full bg-black/60 shadow backdrop-blur-sm sm:hidden"
+        >
+          <Camera className="size-[18px] text-white" />
         </div>
       </button>
 

--- a/src/components/circles/cover-image-picker.tsx
+++ b/src/components/circles/cover-image-picker.tsx
@@ -42,12 +42,11 @@ type Props = {
 const CONTEXT_QUERY_MAX_LENGTH = 80;
 const MIN_QUERY_LENGTH = 2;
 
-// Mobile (< sm:) reçoit moins de photos pour rester confortable au scroll : 6 (3 lignes
-// de 2) en recherche, 6 en fallback random. Desktop garde 12 / 8 — valeurs d'origine.
 const SEARCH_PER_PAGE_MOBILE = 6;
 const SEARCH_PER_PAGE_DESKTOP = 12;
 const RANDOM_PER_PAGE_MOBILE = 6;
 const RANDOM_PER_PAGE_DESKTOP = 8;
+// Tailwind v4 sm: = 40rem, on cible le viewport en-dessous.
 const MOBILE_BREAKPOINT_QUERY = "(max-width: 639px)";
 
 
@@ -132,10 +131,9 @@ export function CoverImagePicker({
   const [uploadFile, setUploadFile] = useState<File | null>(null);
   const [uploadError, setUploadError] = useState<string | null>(null);
 
-  // Viewport — pilote la pagination Unsplash (moins de photos sur mobile pour
-  // limiter le scroll et la consommation data). Pas de refetch sur resize :
-  // la valeur courante est figée pour le batch déjà chargé, le prochain fetch
-  // (pagination ou nouvelle recherche) prendra la valeur mise à jour.
+  // Pas de refetch sur resize : la valeur courante est figée pour le batch déjà
+  // chargé, le prochain fetch (pagination ou nouvelle recherche) prendra la
+  // valeur mise à jour.
   const [isMobile, setIsMobile] = useState(false);
   useEffect(() => {
     const mql = window.matchMedia(MOBILE_BREAKPOINT_QUERY);
@@ -159,9 +157,12 @@ export function CoverImagePicker({
       setSearchError(null);
       setSearchPage(page);
       try {
-        const res = await fetch(
-          `/api/unsplash/search?q=${encodeURIComponent(value.trim())}&page=${page}&perPage=${searchPerPage}`
-        );
+        const params = new URLSearchParams({
+          q: value.trim(),
+          page: String(page),
+          perPage: String(searchPerPage),
+        });
+        const res = await fetch(`/api/unsplash/search?${params}`);
         if (res.ok) {
           const data = await res.json();
           setSearchResults(data.results);
@@ -215,7 +216,12 @@ export function CoverImagePicker({
     if (!query || isLoadingMore) return;
     setIsLoadingMore(true);
     try {
-      const res = await fetch(`/api/unsplash/search?q=${encodeURIComponent(query.trim())}&page=${page}&perPage=${searchPerPage}`);
+      const params = new URLSearchParams({
+        q: query.trim(),
+        page: String(page),
+        perPage: String(searchPerPage),
+      });
+      const res = await fetch(`/api/unsplash/search?${params}`);
       if (res.ok) {
         const data = await res.json();
         setSearchResults(data.results);
@@ -294,7 +300,7 @@ export function CoverImagePicker({
       } else if (defaultPhotos === null && !isLoadingDefaults) {
         // Fallback : photos random (première ouverture uniquement)
         setIsLoadingDefaults(true);
-        fetch(`/api/unsplash/random?perPage=${randomPerPage}`)
+        fetch(`/api/unsplash/random?${new URLSearchParams({ perPage: String(randomPerPage) })}`)
           .then((res) => (res.ok ? res.json() : null))
           .then((data) => {
             if (data?.results) setDefaultPhotos(data.results as UnsplashPhoto[]);
@@ -351,7 +357,6 @@ export function CoverImagePicker({
           <div className="size-full" style={{ background: gradient }} />
         )}
 
-        {/* Overlay au survol (desktop) */}
         <div className="absolute inset-0 flex items-center justify-center bg-black/0 transition-colors group-hover:bg-black/40">
           <div className="flex translate-y-1 items-center gap-2 rounded-full bg-white/90 px-3 py-1.5 text-sm font-medium text-black opacity-0 shadow transition-all group-hover:translate-y-0 group-hover:opacity-100">
             <Camera className="size-4" />


### PR DESCRIPTION
## Summary

Trois ajustements UX du cover-picker en mobile, plus un refactoring.

- **Footer en stack vertical sur mobile (option B)** : `[Annuler][Appliquer]` fullwidth en haut, "Supprimer la couverture" en lien underline subtil en bas. Layout horizontal d'origine conservé en desktop. Corrige le débordement de la modale en plein écran sur iPhone.
- **Badge caméra permanent sur mobile** : sur device tactile sans hover, on signale l'éditabilité avec un badge rond semi-opaque en bas à droite de la cover. Desktop strictement inchangé (overlay + pill au survol).
- **Pagination Unsplash adaptée au viewport** : 6 photos sur mobile (3 lignes de 2) au lieu de 12, pour limiter scroll et data. Desktop garde 12 (search) / 8 (random). Détection via `matchMedia("(max-width: 639px)")`, pas de refetch sur resize.
- **Refactoring** : helper partagé `parsePerPage` (clamp 1-30) extrait dans `src/app/api/unsplash/_lib/`, querystring côté client converti en `URLSearchParams` pour rester cohérent avec le reste du projet.

Mockup retenu : `spec/mockups/cover-picker-mobile-footer.mockup.html`.

## Test plan

- [ ] Mobile (≤ 639px) — page Communauté/événement en édition
  - [ ] Footer modale Cover : actions fullwidth en haut, "Supprimer la couverture" en lien underline en bas
  - [ ] Recherche : 6 photos par page (3 lignes de 2)
  - [ ] Sans recherche (random) : 6 photos
  - [ ] Badge caméra visible en bas à droite de la cover, semi-opaque
- [ ] Desktop (≥ 640px)
  - [ ] Footer modale : layout horizontal inchangé ("Supprimer" gauche, [Annuler][Appliquer] droite)
  - [ ] Recherche : 12 photos par page
  - [ ] Random : 8 photos
  - [ ] Aucun badge mobile visible, hover overlay + pill "Modifier" comme avant
- [ ] Désactiver la cover existante puis la rouvrir → "Supprimer la couverture" n'apparaît que si `currentImage` est défini

🤖 Generated with [Claude Code](https://claude.com/claude-code)