### PR TITLE
fix(circle-form): empêche le débordement du Select Thématique en mobile

### DIFF
--- a/src/components/circles/circle-form.tsx
+++ b/src/components/circles/circle-form.tsx
@@ -200,7 +200,7 @@ export function CircleForm({ circle, action, stripeConnect }: CircleFormProps) {
                     setLocalError(undefined);
                   }}
                 >
-                  <SelectTrigger className="h-9">
+                  <SelectTrigger className="h-9 w-full">
                     <SelectValue placeholder={t("form.categoryPlaceholder")} />
                   </SelectTrigger>
                   <SelectContent>


### PR DESCRIPTION
## Summary

Le `SelectTrigger` shadcn applique `w-fit` (= `width: fit-content`) par défaut. Sans `w-full`, le trigger se développe à la largeur de son contenu (ex. « Business & Entrepreneuriat ») et déborde du viewport mobile, ignorant le `flex-1 min-w-0` du parent.

C'était une incohérence intra-fichier : le Select Visibilité du même formulaire avait déjà `h-9 w-full`, le Select Thématique l'avait oublié. Bug latent tant que les libellés de catégorie restaient courts (« Sport », « Tech ») — réveillé par « Business & Entrepreneuriat » (23 chars).

## Test plan

- [ ] Page édition Communauté en mobile (≤ 639px), catégorie « Business & Entrepreneuriat » sélectionnée → texte tronqué proprement avec un `…`, pas de débordement viewport
- [ ] Desktop → comportement inchangé
- [ ] Sélectionner une autre catégorie → toujours OK

## Hors scope

`src/components/moments/moment-form-location-row.tsx:190` a aussi `<SelectTrigger className="h-9">` sans `w-full`. Layout différent (block + Label au-dessus), pas de débordement viewport mais trigger plus court qu'attendu. À fixer dans une autre PR si besoin d'uniformiser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)