### PR TITLE
fix(cover-picker): fallback gradient si la preview ne se charge pas

### DIFF
--- a/src/components/circles/cover-image-picker.tsx
+++ b/src/components/circles/cover-image-picker.tsx
@@ -108,6 +108,9 @@ export function CoverImagePicker({
   const t = useTranslations("Circle.coverPicker");
   const [open, setOpen] = useState(false);
   const [pending, setPending] = useState<CoverSelection | null>(null);
+  // Si l'URL stockée pointe vers un blob supprimé (404), on retombe sur le
+  // gradient placeholder au lieu d'afficher une icône d'image cassée.
+  const [previewLoadError, setPreviewLoadError] = useState(false);
 
   // Default random photos (fetched once on first open, cached)
   const [defaultPhotos, setDefaultPhotos] = useState<UnsplashPhoto[] | null>(null);
@@ -336,6 +339,13 @@ export function CoverImagePicker({
           ? null
           : currentImage;
 
+  // Reset le flag d'erreur quand la source de la preview change
+  useEffect(() => {
+    setPreviewLoadError(false);
+  }, [previewImage]);
+
+  const showPreviewImage = previewImage && !previewLoadError;
+
   return (
     <>
       {/* Zone de couverture cliquable */}
@@ -346,12 +356,13 @@ export function CoverImagePicker({
         style={{ aspectRatio: "1 / 1" }}
         aria-label={t("ariaModify")}
       >
-        {previewImage ? (
+        {showPreviewImage ? (
           // eslint-disable-next-line @next/next/no-img-element
           <img
             src={previewImage}
             alt="Image de couverture"
             className="size-full object-cover"
+            onError={() => setPreviewLoadError(true)}
           />
         ) : (
           <div className="size-full" style={{ background: gradient }} />


### PR DESCRIPTION
## Summary

Bug observé en prod sur la Communauté "Test en prod" : le formulaire d'édition affichait une icône d'image cassée à la place de la cover, alors que la page Communauté hors édition montrait toujours l'image.

**Cause** : la cover en DB référençait un blob Vercel `*.public.blob.vercel-storage.com/covers/...webp` retournant 404. La page Communauté hors édition s'affiche quand même grâce au cache CDN de `next/image` (qui sert la version optimisée même quand la source est morte). Le formulaire d'édition utilise `<img>` natif → URL directe → 404 visible.

**Fix défensif** : flag `previewLoadError` activé via `onError` sur le `<img>` du picker, fallback sur le gradient placeholder. Le flag est réinitialisé quand la source de la preview change.

## Hors scope (à investiguer séparément)

La cause racine du blob disparu n'est pas adressée ici. Probable race condition ou ordre fragile dans `src/app/actions/circle.ts:216-222` (delete du blob après update DB) — à investiguer.

## Test plan

- [ ] CI verte
- [ ] Vérifier sur la preview Vercel : éditer une Communauté avec une cover OK → image affichée normalement
- [ ] Si possible : tester avec une cover ayant un blob 404 → gradient affiché au lieu d'image cassée

🤖 Generated with [Claude Code](https://claude.com/claude-code)