### PR TITLE
chore(pre-release): màj page Aide + stats À propos

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1725,6 +1725,7 @@
       "members": {
         "title": "Manage community members",
         "intro": "From your community page, you can see the full member list with their emails. Each name is clickable and links to the member's public profile. You can remove a member via the <strong>⋮</strong> menu next to their name.",
+        "exportNote": "You can export the full member list as a CSV file via the «Export» button in the members modal. Useful for importing into an external tool or sending a bulk email.",
         "outro": "Members automatically join your community when they register for one of your events."
       },
       "coHosts": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1725,6 +1725,7 @@
       "members": {
         "title": "Gérer les membres de votre communauté",
         "intro": "Depuis la page de votre communauté, vous voyez la liste complète des membres avec leurs emails. Chaque nom est cliquable et pointe vers le profil public du membre. Vous pouvez retirer un membre via le menu <strong>⋮</strong> à côté de son nom.",
+        "exportNote": "Vous pouvez exporter la liste complète des membres en CSV depuis le bouton «Exporter» dans la modale membres. Pratique pour importer dans un outil externe ou faire un envoi d'email.",
         "outro": "Les membres rejoignent automatiquement votre communauté lorsqu'ils s'inscrivent à l'un de vos événements."
       },
       "coHosts": {

--- a/src/app/[locale]/(routes)/(static)/about/page.tsx
+++ b/src/app/[locale]/(routes)/(static)/about/page.tsx
@@ -375,10 +375,10 @@ export default async function AboutPage() {
         </h2>
         <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
           {[
-            { value: "1 800+", label: isFr ? "commits" : "commits" },
-            { value: "380+", label: isFr ? "pull requests" : "pull requests" },
-            { value: "75", label: isFr ? "cas d'usage" : "use cases" },
-            { value: "960+", label: isFr ? "tests" : "tests" },
+            { value: "1 900+", label: isFr ? "commits" : "commits" },
+            { value: "390+", label: isFr ? "pull requests" : "pull requests" },
+            { value: "80", label: isFr ? "cas d'usage" : "use cases" },
+            { value: "1 010+", label: isFr ? "tests" : "tests" },
           ].map(({ value, label }) => (
             <div key={label} className="text-center">
               <p className="text-2xl font-extrabold tracking-tight bg-gradient-to-r from-pink-500 to-violet-500 bg-clip-text text-transparent">

--- a/src/app/[locale]/(routes)/(static)/help/page.tsx
+++ b/src/app/[locale]/(routes)/(static)/help/page.tsx
@@ -573,6 +573,9 @@ export default async function HelpPage() {
                 {t.rich("organizer.members.intro", rich)}
               </p>
               <p className="text-sm leading-relaxed text-muted-foreground">
+                {t("organizer.members.exportNote")}
+              </p>
+              <p className="text-sm leading-relaxed text-muted-foreground">
                 {t("organizer.members.outro")}
               </p>
             </div>


### PR DESCRIPTION
## Summary

Pré-release 2.11.0 :

### Page Aide
- Ajout du paragraphe sur l'**export CSV des membres** (`Help.organizer.members.exportNote` FR + EN, affichage dans `help/page.tsx`). Feature mergée depuis la 2.10.0 mais non documentée jusqu'ici.

### Page À propos — section "En chiffres"
Actualisation des 4 chiffres :

| Stat | Avant | Après | Réel |
|---|---|---|---|
| Commits | 1 800+ | **1 900+** | 1934 |
| Pull requests | 380+ | **390+** | 395 |
| Cas d'usage | 75 | **80** | 80 |
| Tests | 960+ | **1 010+** | 1014 |

## Test plan

- [ ] Vérifier sur la preview Vercel : page `/about` affiche les nouveaux chiffres
- [ ] Vérifier sur la preview Vercel : page `/help` affiche le nouveau paragraphe export CSV

🤖 Generated with [Claude Code](https://claude.com/claude-code)