### PR TITLE
feat(auth): protéger le magic link du prefetch des scanners email

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -146,9 +146,23 @@
       "title": "Check your email",
       "description": "A sign-in link has been sent to your email address. Click it to sign in."
     },
+    "confirm": {
+      "title": "Confirm your sign-in",
+      "description": "Click the button below to finish signing in to The Playground.",
+      "submit": "Confirm sign-in",
+      "hint": "This step keeps your link safe from anti-phishing scanners that automatically follow email links.",
+      "invalid": {
+        "title": "Invalid link",
+        "description": "This sign-in link is incomplete. Request a new one to continue.",
+        "cta": "Send me a new link"
+      }
+    },
     "error": {
       "title": "Authentication error",
       "backToSignIn": "Back to sign in",
+      "requestNewLink": "Send me a new link",
+      "verificationExplanation": "If you use a corporate inbox (Outlook, Gmail Workspace), your anti-phishing may have visited the link automatically and invalidated it.",
+      "verificationAction": "Request a new link and click it quickly, or sign in with Google/GitHub.",
       "webviewExplanation": "Google and GitHub block sign-in from in-app browsers (LinkedIn, Instagram, Facebook...).",
       "webviewAction": "Use the email sign-in, or open the site in your browser.",
       "openInBrowser": "Open in browser"

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -146,9 +146,23 @@
       "title": "Vérifiez votre email",
       "description": "Un lien de connexion a été envoyé à votre adresse email. Cliquez dessus pour vous connecter."
     },
+    "confirm": {
+      "title": "Confirmer votre connexion",
+      "description": "Cliquez sur le bouton ci-dessous pour finaliser votre connexion à The Playground.",
+      "submit": "Confirmer ma connexion",
+      "hint": "Cette étape protège votre lien des anti-phishing qui parcourent automatiquement les emails.",
+      "invalid": {
+        "title": "Lien invalide",
+        "description": "Ce lien de connexion est incomplet. Demandez-en un nouveau pour continuer.",
+        "cta": "Recevoir un nouveau lien"
+      }
+    },
     "error": {
       "title": "Erreur d'authentification",
       "backToSignIn": "Retour à la connexion",
+      "requestNewLink": "Recevoir un nouveau lien",
+      "verificationExplanation": "Si vous utilisez une boîte mail professionnelle (Outlook, Gmail Workspace), il est possible que votre anti-phishing ait visité le lien automatiquement et l'ait invalidé.",
+      "verificationAction": "Demandez un nouveau lien et cliquez-le rapidement, ou utilisez la connexion Google/GitHub.",
       "webviewExplanation": "Google et GitHub bloquent la connexion depuis les navigateurs intégrés (LinkedIn, Instagram, Facebook...).",
       "webviewAction": "Utilisez la connexion par email, ou ouvrez le site dans votre navigateur.",
       "openInBrowser": "Ouvrir dans le navigateur"

--- a/src/app/[locale]/auth/confirm/page.tsx
+++ b/src/app/[locale]/auth/confirm/page.tsx
@@ -1,0 +1,60 @@
+import { getTranslations } from "next-intl/server";
+import { Button } from "@/components/ui/button";
+import { Link } from "@/i18n/navigation";
+
+type SearchParams = {
+  token?: string;
+  email?: string;
+  callbackUrl?: string;
+};
+
+// Un token consommé ne doit jamais s'afficher depuis un cache CDN.
+export const dynamic = "force-dynamic";
+
+export default async function AuthConfirmPage({
+  searchParams,
+}: {
+  searchParams: Promise<SearchParams>;
+}) {
+  const params = await searchParams;
+  const t = await getTranslations("Auth.confirm");
+
+  if (!params.token || !params.email) {
+    return (
+      <div className="flex min-h-screen items-center justify-center px-4">
+        <div className="w-full max-w-sm space-y-4 text-center">
+          <h1 className="text-2xl font-bold tracking-tight">{t("invalid.title")}</h1>
+          <p className="text-muted-foreground text-sm">{t("invalid.description")}</p>
+          <Button asChild>
+            <Link href="/auth/sign-in">{t("invalid.cta")}</Link>
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  // Auth.js v5 lit token + email depuis l'URL (pas le body) sur le callback
+  // email, même en POST. Les params restent donc en query string.
+  const query = new URLSearchParams({ token: params.token, email: params.email });
+  if (params.callbackUrl) query.set("callbackUrl", params.callbackUrl);
+  const action = `/api/auth/callback/resend?${query.toString()}`;
+
+  return (
+    <div className="flex min-h-screen items-center justify-center px-4">
+      <div className="w-full max-w-sm space-y-6 text-center">
+        <div className="space-y-2">
+          <h1 className="text-2xl font-bold tracking-tight">{t("title")}</h1>
+          <p className="text-muted-foreground text-sm">{t("description")}</p>
+        </div>
+
+        <form action={action} method="POST">
+          <Button type="submit" size="lg" className="w-full">
+            {t("submit")}
+          </Button>
+        </form>
+
+        <p className="text-muted-foreground text-xs">{t("hint")}</p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/[locale]/auth/error/page.tsx
+++ b/src/app/[locale]/auth/error/page.tsx
@@ -8,6 +8,16 @@ import { Button } from "@/components/ui/button";
 import { Link } from "@/i18n/navigation";
 import { ExternalLink } from "lucide-react";
 import { isInAppBrowser } from "@/lib/detect-webview";
+import { classifyAuthError, AUTH_ERROR_VERIFICATION } from "@/lib/auth/error-kinds";
+
+function AuthHint({ explanation, action }: { explanation: string; action: string }) {
+  return (
+    <div className="rounded-lg border border-primary/30 bg-primary/5 px-4 py-3 text-sm text-muted-foreground text-left space-y-2">
+      <p>{explanation}</p>
+      <p className="font-medium text-foreground">{action}</p>
+    </div>
+  );
+}
 
 export default function AuthErrorPage() {
   const searchParams = useSearchParams();
@@ -25,7 +35,11 @@ export default function AuthErrorPage() {
       capturedRef.current = error;
       Sentry.captureMessage(`auth-error-page: ${error}`, {
         level: "warning",
-        tags: { context: "auth", error_code: error },
+        tags: {
+          context: "auth",
+          error_code: error,
+          auth_error_kind: classifyAuthError(error),
+        },
       });
     }
   }, [error]);
@@ -34,22 +48,32 @@ export default function AuthErrorPage() {
     ? t(`errors.${error}`, { defaultValue: t("errors.Default") })
     : t("errors.Default");
 
+  const isVerification = error === AUTH_ERROR_VERIFICATION;
+  const ctaLabel = isVerification ? t("error.requestNewLink") : t("error.backToSignIn");
+
   return (
     <div className="flex min-h-screen items-center justify-center px-4">
       <div className="w-full max-w-sm space-y-4 text-center">
         <h1 className="text-2xl font-bold tracking-tight">{t("error.title")}</h1>
         <p className="text-muted-foreground text-sm">{errorMessage}</p>
 
+        {isVerification && (
+          <AuthHint
+            explanation={t("error.verificationExplanation")}
+            action={t("error.verificationAction")}
+          />
+        )}
+
         {webview && (
-          <div className="rounded-lg border border-primary/30 bg-primary/5 px-4 py-3 text-sm text-muted-foreground text-left space-y-2">
-            <p>{t("error.webviewExplanation")}</p>
-            <p className="font-medium text-foreground">{t("error.webviewAction")}</p>
-          </div>
+          <AuthHint
+            explanation={t("error.webviewExplanation")}
+            action={t("error.webviewAction")}
+          />
         )}
 
         <div className="flex flex-col gap-2">
           <Button asChild>
-            <Link href="/auth/sign-in">{t("error.backToSignIn")}</Link>
+            <Link href="/auth/sign-in">{ctaLabel}</Link>
           </Button>
           {webview && (
             <Button variant="outline" asChild>

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,3 +1,11 @@
 import { handlers } from "@/infrastructure/auth/auth.config";
 
 export const { GET, POST } = handlers;
+
+// Short-circuit HEAD : les scanners de sécurité d'email (Microsoft Defender Safe
+// Links, Mimecast, Proofpoint…) prefetchent les liens en HEAD avant l'utilisateur.
+// Sans cette réponse, Auth.js lève "Only GET and POST requests are supported"
+// et pollue Sentry. On renvoie 200 sans toucher au token.
+export function HEAD() {
+  return new Response(null, { status: 200 });
+}

--- a/src/infrastructure/auth/auth.config.ts
+++ b/src/infrastructure/auth/auth.config.ts
@@ -9,6 +9,8 @@ import { createSafeResend } from "@/lib/email/safe-resend";
 import { MagicLinkEmail } from "@/infrastructure/services/email/templates/magic-link";
 import { isUploadedUrl } from "@/lib/blob";
 import { prismaUserRepository } from "@/infrastructure/repositories/prisma-user-repository";
+import { buildMagicLinkConfirmUrl } from "@/lib/auth/magic-link-url";
+import { classifyAuthError } from "@/lib/auth/error-kinds";
 
 export const { handlers, auth, signIn, signOut } = NextAuth({
   debug: process.env.NODE_ENV !== "production",
@@ -22,16 +24,23 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
     ResendProvider({
       apiKey: process.env.AUTH_RESEND_KEY,
       from: process.env.EMAIL_FROM ?? "onboarding@resend.dev",
-      async sendVerificationRequest({ identifier, url }) {
+      async sendVerificationRequest({ identifier, url, request }) {
         const resend = createSafeResend(process.env.AUTH_RESEND_KEY);
         const from = process.env.EMAIL_FROM ?? "onboarding@resend.dev";
         const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
+
+        // On envoie l'utilisateur sur une page applicative inerte plutôt que
+        // directement sur le callback Auth.js. Les scanners email (Microsoft
+        // Defender Safe Links, Mimecast, Proofpoint…) prefetchent ce lien et
+        // consumeraient le token. La page de confirmation expose un bouton qui
+        // POST sur le callback, déclenchable uniquement par un humain.
+        const confirmUrl = buildMagicLinkConfirmUrl(url, request);
 
         const { error } = await resend.emails.send({
           from,
           to: identifier,
           subject: "Votre lien de connexion — The Playground",
-          react: MagicLinkEmail({ url, baseUrl }),
+          react: MagicLinkEmail({ url: confirmUrl, baseUrl }),
         });
 
         if (error) {
@@ -56,13 +65,29 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
   logger: {
     error(error) {
       console.error("[AUTH ERROR]", error);
-      Sentry.captureException(error, { tags: { context: "auth" } });
+      const code = error?.name ?? "Unknown";
+      const kind = classifyAuthError(code);
+      // Les erreurs "attendues dans le flow utilisateur" (token expiré,
+      // prefetch scanner, refus OAuth) restent capturées mais en niveau
+      // warning pour ne pas spammer les alertes high-priority.
+      Sentry.captureException(error, {
+        level: kind === "expected_user_flow" ? "warning" : "error",
+        tags: {
+          context: "auth",
+          error_code: code,
+          auth_error_kind: kind,
+        },
+      });
     },
     warn(code) {
       console.warn("[AUTH WARN]", code);
       Sentry.captureMessage(`auth:${code}`, {
         level: "warning",
-        tags: { context: "auth" },
+        tags: {
+          context: "auth",
+          error_code: code,
+          auth_error_kind: classifyAuthError(code),
+        },
       });
     },
   },

--- a/src/lib/auth/__tests__/error-kinds.test.ts
+++ b/src/lib/auth/__tests__/error-kinds.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { classifyAuthError } from "@/lib/auth/error-kinds";
+
+describe("classifyAuthError", () => {
+  describe("given a code that occurs in normal user flows", () => {
+    it.each(["Verification", "UnknownAction", "AccessDenied"])(
+      "should classify %s as expected_user_flow",
+      (code) => {
+        expect(classifyAuthError(code)).toBe("expected_user_flow");
+      }
+    );
+  });
+
+  describe("given an unfamiliar or unset code", () => {
+    it.each(["Configuration", "AdapterError", "JWTSessionError", "RandomThing"])(
+      "should classify %s as unexpected",
+      (code) => {
+        expect(classifyAuthError(code)).toBe("unexpected");
+      }
+    );
+
+    it("should classify null as unexpected", () => {
+      expect(classifyAuthError(null)).toBe("unexpected");
+    });
+
+    it("should classify undefined as unexpected", () => {
+      expect(classifyAuthError(undefined)).toBe("unexpected");
+    });
+  });
+
+  describe("given a code prefixed with extra information", () => {
+    it("should normalize before classifying", () => {
+      expect(classifyAuthError("Verification: token expired")).toBe(
+        "expected_user_flow"
+      );
+    });
+  });
+});

--- a/src/lib/auth/__tests__/magic-link-url.test.ts
+++ b/src/lib/auth/__tests__/magic-link-url.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { buildMagicLinkConfirmUrl } from "@/lib/auth/magic-link-url";
+
+const AUTH_URL =
+  "https://app.example.com/api/auth/callback/resend?token=abc&email=user%40example.com&callbackUrl=%2Fdashboard";
+
+function makeRequest(headers: Record<string, string> = {}): Request {
+  return new Request("https://app.example.com/api/auth/signin/resend", {
+    headers,
+  });
+}
+
+describe("buildMagicLinkConfirmUrl", () => {
+  describe("given a default-locale visitor", () => {
+    it("should point to /auth/confirm without locale prefix", () => {
+      const result = buildMagicLinkConfirmUrl(AUTH_URL, makeRequest());
+      const url = new URL(result);
+      expect(url.pathname).toBe("/auth/confirm");
+    });
+
+    it("should preserve token, email and callbackUrl query params", () => {
+      const result = buildMagicLinkConfirmUrl(AUTH_URL, makeRequest());
+      const url = new URL(result);
+      expect(url.searchParams.get("token")).toBe("abc");
+      expect(url.searchParams.get("email")).toBe("user@example.com");
+      expect(url.searchParams.get("callbackUrl")).toBe("/dashboard");
+    });
+
+    it("should keep the original origin", () => {
+      const result = buildMagicLinkConfirmUrl(AUTH_URL, makeRequest());
+      const url = new URL(result);
+      expect(url.origin).toBe("https://app.example.com");
+    });
+  });
+
+  describe("given a visitor with NEXT_LOCALE=en cookie", () => {
+    it("should prefix the path with /en", () => {
+      const request = makeRequest({ cookie: "NEXT_LOCALE=en; foo=bar" });
+      const result = buildMagicLinkConfirmUrl(AUTH_URL, request);
+      const url = new URL(result);
+      expect(url.pathname).toBe("/en/auth/confirm");
+    });
+  });
+
+  describe("given a visitor with Accept-Language en when no cookie", () => {
+    it("should fall back to /en", () => {
+      const request = makeRequest({ "accept-language": "en-US,en;q=0.9" });
+      const result = buildMagicLinkConfirmUrl(AUTH_URL, request);
+      const url = new URL(result);
+      expect(url.pathname).toBe("/en/auth/confirm");
+    });
+  });
+
+  describe("given an unknown locale in the cookie", () => {
+    it("should fall back to default locale", () => {
+      const request = makeRequest({ cookie: "NEXT_LOCALE=xx" });
+      const result = buildMagicLinkConfirmUrl(AUTH_URL, request);
+      const url = new URL(result);
+      expect(url.pathname).toBe("/auth/confirm");
+    });
+  });
+});

--- a/src/lib/auth/error-kinds.ts
+++ b/src/lib/auth/error-kinds.ts
@@ -1,0 +1,21 @@
+export type AuthErrorKind = "expected_user_flow" | "unexpected";
+
+export const AUTH_ERROR_VERIFICATION = "Verification";
+
+const EXPECTED_AUTH_ERROR_CODES = new Set([
+  AUTH_ERROR_VERIFICATION,
+  "UnknownAction",
+  "AccessDenied",
+]);
+
+/**
+ * Range les codes d'erreur Auth.js en deux familles : ceux qu'on attend dans
+ * les flows utilisateurs normaux (token expiré, prefetch scanner, refus OAuth)
+ * et le reste, qui mérite l'attention. Toutes les erreurs sont captées dans
+ * Sentry — la classification sert uniquement à filtrer/grouper sans masquer.
+ */
+export function classifyAuthError(code: string | null | undefined): AuthErrorKind {
+  if (!code) return "unexpected";
+  const normalized = code.split(":")[0]?.trim() ?? "";
+  return EXPECTED_AUTH_ERROR_CODES.has(normalized) ? "expected_user_flow" : "unexpected";
+}

--- a/src/lib/auth/magic-link-url.ts
+++ b/src/lib/auth/magic-link-url.ts
@@ -1,0 +1,35 @@
+import { routing } from "@/i18n/routing";
+
+type Locale = (typeof routing.locales)[number];
+
+const NEXT_LOCALE_COOKIE = /(?:^|;\s*)NEXT_LOCALE=([^;]+)/;
+
+/**
+ * Convertit l'URL de callback générée par Auth.js (Resend provider) en URL
+ * pointant vers la page applicative `/auth/confirm`. Cette indirection évite
+ * que les scanners email (Defender Safe Links, Mimecast…) consument le token
+ * en prefetchant le lien : la page intermédiaire est inerte, seul le bouton
+ * cliqué par l'utilisateur déclenche le POST qui valide le token.
+ */
+export function buildMagicLinkConfirmUrl(authJsUrl: string, request: Request): string {
+  const original = new URL(authJsUrl);
+  const locale = detectLocale(request);
+  const prefix = locale === routing.defaultLocale ? "" : `/${locale}`;
+  const confirm = new URL(`${prefix}/auth/confirm`, original.origin);
+  confirm.search = original.search;
+  return confirm.toString();
+}
+
+function detectLocale(request: Request): Locale {
+  const cookie = request.headers.get("cookie") ?? "";
+  const match = cookie.match(NEXT_LOCALE_COOKIE);
+  if (match && isSupportedLocale(match[1])) return match[1];
+
+  const accept = request.headers.get("accept-language") ?? "";
+  const fromHeader = routing.locales.find((l) => accept.toLowerCase().startsWith(l));
+  return fromHeader ?? routing.defaultLocale;
+}
+
+function isSupportedLocale(value: string): value is Locale {
+  return (routing.locales as readonly string[]).includes(value);
+}

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -59,3 +59,43 @@ test.describe("Authentification — accès non authentifié", () => {
     await expect(page).not.toHaveURL(/\/auth\/sign-in/);
   });
 });
+
+test.describe("Magic link — protection contre les scanners email", () => {
+  test("HEAD on /api/auth/callback/resend should return 200 without consuming the token", async ({
+    request,
+  }) => {
+    // Les scanners email (Defender Safe Links) prefetchent en HEAD. On répond
+    // 200 sans toucher au token plutôt que de laisser Auth.js lever une erreur.
+    const response = await request.head(
+      "/api/auth/callback/resend?token=fake&email=test%40example.com"
+    );
+    expect(response.status()).toBe(200);
+  });
+
+  test("page /auth/confirm should render a POST form when token + email are present", async ({
+    page,
+  }) => {
+    await page.goto(
+      "/fr/auth/confirm?token=fake-token&email=user%40example.com&callbackUrl=%2Fdashboard"
+    );
+    const form = page.locator("form[method='POST'][action*='/api/auth/callback/resend']");
+    await expect(form).toBeVisible();
+    await expect(form).toHaveAttribute("action", /token=fake-token/);
+    await expect(form).toHaveAttribute("action", /email=user%40example.com/);
+    await expect(form.locator("button[type='submit']")).toBeVisible();
+  });
+
+  test("page /auth/confirm should reject a request without token", async ({ page }) => {
+    await page.goto("/fr/auth/confirm");
+    await expect(page.locator("form")).toHaveCount(0);
+    await expect(page.getByRole("link", { name: /nouveau lien/i })).toBeVisible();
+  });
+
+  test("page /auth/error?error=Verification should explain the corporate inbox case", async ({
+    page,
+  }) => {
+    await page.goto("/fr/auth/error?error=Verification");
+    await expect(page.getByText(/anti-phishing/i)).toBeVisible();
+    await expect(page.getByRole("link", { name: /nouveau lien/i })).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Contexte

3 issues Sentry identifiées la semaine dernière (THE-PLAYGROUND-19, 1A, 1B) sur le flow magic link, toutes concentrées sur `/api/auth/callback/resend`. Diagnostic : les scanners email d'entreprise (Microsoft Defender Safe Links, Mimecast, Proofpoint…) prefetchent automatiquement les liens dans les emails, ce qui consomme le token unique avant que l'utilisateur ne clique. Résultat : `Verification` error pour les utilisateurs en environnement Microsoft 365 (typiquement BPCE et toute entreprise sous Defender ATP).

Cas réel investigué : Sophie Lagarde (BPCE) a réussi sa première connexion le 30/04 à 16:12, puis 3 retries dans les 90 secondes suivantes ont tous échoué à cause du scanner. Onboarding jamais complété.

## Changements

### A — Page intermédiaire `/auth/confirm` (fix racine)
Le lien dans l'email pointe désormais sur une page applicative inerte qui présente un bouton « Confirmer ma connexion ». Les scanners GET cette page sans toucher au token ; seul le clic humain déclenche le POST qui valide le token. Auth.js v5 lit `token` + `email` depuis l'URL même en POST, donc on les passe en query string sur l'action du form (body vide, pas de CSRF requis sur les providers email).

- `src/lib/auth/magic-link-url.ts` — helper qui réécrit l'URL Auth.js vers `/auth/confirm` (locale-aware via cookie `NEXT_LOCALE` puis `Accept-Language`)
- `src/app/[locale]/auth/confirm/page.tsx` — page server-component avec form POST
- `src/infrastructure/auth/auth.config.ts` — override de `sendVerificationRequest` qui passe par le helper

### B — Court-circuit HEAD sur `/api/auth/callback/*`
Auth.js renvoie `UnknownAction` sur HEAD, ce qui spamme Sentry. On répond 200 sans toucher au token.

- `src/app/api/auth/[...nextauth]/route.ts` — export `HEAD`

### C — Page d'erreur `/auth/error?error=Verification` explicite
Encart d'explication sur les anti-phishing d'entreprise + CTA « Recevoir un nouveau lien » (au lieu du générique « Retour à la connexion »).

- `src/app/[locale]/auth/error/page.tsx` — composant local `AuthHint` partagé entre `Verification` et `webview`

### D — Tag Sentry `auth_error_kind` pour trier sans masquer
Toutes les erreurs Auth.js restent capturées (zéro filtre). Mais on les classe en `expected_user_flow` (Verification, UnknownAction, AccessDenied) ou `unexpected`, et les codes attendus passent en niveau `warning` au lieu d'`error`. Permet de séparer les alertes high-priority du bruit utilisateur.

- `src/lib/auth/error-kinds.ts` — fonction `classifyAuthError` + constante `AUTH_ERROR_VERIFICATION`
- `auth.config.ts` logger + `auth/error/page.tsx` capture frontend

## Tests

- 16 tests Vitest unitaires sur les helpers (`error-kinds`, `magic-link-url`)
- 4 tests Playwright E2E (HEAD short-circuit, page confirm OK, page confirm sans params, page error explicite)
- Total local : 1030 tests verts, typecheck OK

## Validation manuelle

Mergé en staging et testé end-to-end avec un compte Gmail réel ajouté à `STAGING_EMAIL_ALLOWLIST`. Login magic link → page `/auth/confirm` → clic → connexion OK.

## Hors scope (à suivre)

- Refactor des 4 pages `auth/*` pour partager un `<AuthShell>` (duplication mineure du wrapper flex/min-h-screen).
- Alignement staging ← main une fois cette release stable, pour éviter des conflits sur `safe-resend.test.ts` au prochain merge.

## Refs Sentry

- THE-PLAYGROUND-19 (frontend `auth-error-page: Verification`)
- THE-PLAYGROUND-1A (backend `Verification` sur GET callback)
- THE-PLAYGROUND-1B (backend `UnknownAction` sur HEAD callback)