### PR TITLE
feat(admin): enrichir la page utilisateur avec les infos d'auth

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -849,7 +849,25 @@
       "circles": "Communities",
       "noCircles": "No communities.",
       "moments": "Events",
-      "noMoments": "No Events."
+      "noMoments": "No Events.",
+      "auth": {
+        "title": "Authentication",
+        "providers": "Connected providers",
+        "magicLinkOnly": "Magic link only",
+        "emailVerified": "Email verified",
+        "activeSessions": "Active sessions",
+        "sessionsExpiring": "{count, plural, =1 {1 session, expires {date}} other {# sessions, latest expires {date}}}",
+        "pendingMagicLinks": "Pending magic links",
+        "tokensExpiring": "{count, plural, =1 {1 token, expires {date}} other {# tokens, latest expires {date}}}",
+        "welcomeEmail": "Welcome email",
+        "never": "Never",
+        "none": "None"
+      },
+      "actions": {
+        "copyId": "Copy ID",
+        "idCopied": "Copied",
+        "viewInSentry": "View in Sentry"
+      }
     },
     "circleDetail": {
       "title": "Community detail",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -849,7 +849,25 @@
       "circles": "Communautés",
       "noCircles": "Aucune communauté.",
       "moments": "Événements",
-      "noMoments": "Aucun événement."
+      "noMoments": "Aucun événement.",
+      "auth": {
+        "title": "Authentification",
+        "providers": "Providers connectés",
+        "magicLinkOnly": "Magic link uniquement",
+        "emailVerified": "Email vérifié",
+        "activeSessions": "Sessions actives",
+        "sessionsExpiring": "{count, plural, =1 {1 session, expire le {date}} other {# sessions, plus tardive expire le {date}}}",
+        "pendingMagicLinks": "Magic links en attente",
+        "tokensExpiring": "{count, plural, =1 {1 token, expire le {date}} other {# tokens, plus tardif expire le {date}}}",
+        "welcomeEmail": "Email de bienvenue",
+        "never": "Jamais",
+        "none": "Aucun"
+      },
+      "actions": {
+        "copyId": "Copier l'ID",
+        "idCopied": "Copié",
+        "viewInSentry": "Voir dans Sentry"
+      }
     },
     "circleDetail": {
       "title": "Détail communauté",

--- a/src/app/[locale]/(routes)/admin/users/[id]/page.tsx
+++ b/src/app/[locale]/(routes)/admin/users/[id]/page.tsx
@@ -1,9 +1,14 @@
 import { notFound } from "next/navigation";
-import { getTranslations } from "next-intl/server";
+import { getLocale, getTranslations } from "next-intl/server";
 import Link from "next/link";
+import { ExternalLink } from "lucide-react";
 import { prismaAdminRepository } from "@/infrastructure/repositories";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { CopyButton } from "@/components/ui/copy-button";
+import { formatLongDate } from "@/lib/format-date";
+import { buildSentryIssuesSearchUrl } from "@/lib/sentry-url";
 import { AdminUserDeleteButton } from "./delete-button";
 
 type Props = {
@@ -14,6 +19,7 @@ export default async function AdminUserDetailPage({ params }: Props) {
   const { id } = await params;
   const t = await getTranslations("Admin");
   const tRole = await getTranslations("Dashboard.role");
+  const locale = await getLocale();
   const user = await prismaAdminRepository.findUserById(id);
 
   if (!user) notFound();
@@ -22,12 +28,29 @@ export default async function AdminUserDetailPage({ params }: Props) {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
+      <div className="flex items-start justify-between gap-4 flex-wrap">
         <div>
           <p className="text-sm text-muted-foreground">{t("userDetail.title")}</p>
           <h1 className="text-2xl font-bold">{displayName}</h1>
         </div>
-        <AdminUserDeleteButton userId={user.id} />
+        <div className="flex items-center gap-2">
+          <CopyButton
+            value={user.id}
+            label={t("userDetail.actions.copyId")}
+            copiedLabel={t("userDetail.actions.idCopied")}
+          />
+          <Button variant="ghost" size="sm" asChild>
+            <a
+              href={buildSentryIssuesSearchUrl(`user.email:${user.email}`)}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <ExternalLink className="size-4" />
+              {t("userDetail.actions.viewInSentry")}
+            </a>
+          </Button>
+          <AdminUserDeleteButton userId={user.id} />
+        </div>
       </div>
 
       <div className="grid gap-4 sm:grid-cols-2">
@@ -63,7 +86,60 @@ export default async function AdminUserDetailPage({ params }: Props) {
         </Card>
       </div>
 
-      {/* Circles list */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">{t("userDetail.auth.title")}</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3 p-5 pt-0">
+          <Row
+            label={t("userDetail.auth.providers")}
+            value={
+              user.auth.providers.length === 0 ? (
+                <Badge variant="outline">{t("userDetail.auth.magicLinkOnly")}</Badge>
+              ) : (
+                <div className="flex flex-wrap gap-1 justify-end">
+                  {user.auth.providers.map((p) => (
+                    <Badge key={p} variant="secondary" className="capitalize">
+                      {p}
+                    </Badge>
+                  ))}
+                </div>
+              )
+            }
+          />
+          <Row
+            label={t("userDetail.auth.emailVerified")}
+            value={formatDateOrNever(user.auth.emailVerified, locale, t("userDetail.auth.never"))}
+          />
+          <Row
+            label={t("userDetail.auth.activeSessions")}
+            value={
+              user.auth.activeSessionsCount === 0 || !user.auth.latestSessionExpires
+                ? t("userDetail.auth.never")
+                : t("userDetail.auth.sessionsExpiring", {
+                    count: user.auth.activeSessionsCount,
+                    date: formatLongDate(user.auth.latestSessionExpires, locale),
+                  })
+            }
+          />
+          <Row
+            label={t("userDetail.auth.pendingMagicLinks")}
+            value={
+              user.auth.pendingMagicLinksCount === 0 || !user.auth.latestPendingMagicLinkExpires
+                ? t("userDetail.auth.none")
+                : t("userDetail.auth.tokensExpiring", {
+                    count: user.auth.pendingMagicLinksCount,
+                    date: formatLongDate(user.auth.latestPendingMagicLinkExpires, locale),
+                  })
+            }
+          />
+          <Row
+            label={t("userDetail.auth.welcomeEmail")}
+            value={formatDateOrNever(user.auth.welcomeEmailSentAt, locale, t("userDetail.auth.never"))}
+          />
+        </CardContent>
+      </Card>
+
       <Card>
         <CardHeader>
           <CardTitle className="text-base">{t("userDetail.circles")}</CardTitle>
@@ -91,7 +167,6 @@ export default async function AdminUserDetailPage({ params }: Props) {
         </CardContent>
       </Card>
 
-      {/* Moments list */}
       <Card>
         <CardHeader>
           <CardTitle className="text-base">{t("userDetail.moments")}</CardTitle>
@@ -127,6 +202,10 @@ export default async function AdminUserDetailPage({ params }: Props) {
   );
 }
 
+function formatDateOrNever(date: Date | null, locale: string, neverLabel: string): string {
+  return date ? formatLongDate(date, locale) : neverLabel;
+}
+
 function statusVariant(status: string): "default" | "secondary" | "outline" | "destructive" {
   switch (status) {
     case "PUBLISHED": return "default";
@@ -139,9 +218,9 @@ function statusVariant(status: string): "default" | "secondary" | "outline" | "d
 
 function Row({ label, value }: { label: string; value: React.ReactNode }) {
   return (
-    <div className="flex items-center justify-between text-sm">
-      <span className="text-muted-foreground">{label}</span>
-      <span className="font-medium">{value}</span>
+    <div className="flex items-center justify-between text-sm gap-4">
+      <span className="text-muted-foreground shrink-0">{label}</span>
+      <span className="font-medium text-right">{value}</span>
     </div>
   );
 }

--- a/src/components/ui/copy-button.tsx
+++ b/src/components/ui/copy-button.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useState } from "react";
+import { Check, Copy } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+type Variant = "default" | "outline" | "ghost" | "secondary";
+type Size = "default" | "sm" | "lg" | "icon";
+
+type Props = {
+  value: string;
+  label: string;
+  copiedLabel: string;
+  variant?: Variant;
+  size?: Size;
+};
+
+export function CopyButton({ value, label, copiedLabel, variant = "ghost", size = "sm" }: Props) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // navigator.clipboard indisponible (HTTP, anciens navigateurs) — silencieux
+    }
+  };
+
+  return (
+    <Button
+      type="button"
+      variant={variant}
+      size={size}
+      aria-label={copied ? copiedLabel : label}
+      onClick={handleCopy}
+    >
+      {copied ? <Check className="size-4" /> : <Copy className="size-4" />}
+      {copied ? copiedLabel : label}
+    </Button>
+  );
+}

--- a/src/domain/ports/repositories/admin-repository.ts
+++ b/src/domain/ports/repositories/admin-repository.ts
@@ -50,6 +50,7 @@ export type AdminUserDetail = AdminUserRow & {
   image: string | null;
   onboardingCompleted: boolean;
   registrationCount: number;
+  auth: AdminUserAuthInfo;
   circles: Array<{
     id: string;
     name: string;
@@ -64,6 +65,23 @@ export type AdminUserDetail = AdminUserRow & {
     status: string;
     circleName: string;
   }>;
+};
+
+export type AdminUserAuthInfo = {
+  /** Providers OAuth liés. Vide = magic link uniquement. */
+  providers: string[];
+  /** Date de vérification de l'email (premier login magic link réussi ou OAuth). */
+  emailVerified: Date | null;
+  /** Nombre de sessions actives (Auth.js). */
+  activeSessionsCount: number;
+  /** Date d'expiration de la session la plus récente (≈ dernière login + 30j). */
+  latestSessionExpires: Date | null;
+  /** Nombre de magic links non consommés en attente. */
+  pendingMagicLinksCount: number;
+  /** Date d'expiration du magic link en attente le plus récent. */
+  latestPendingMagicLinkExpires: Date | null;
+  /** Date d'envoi de l'email de bienvenue. */
+  welcomeEmailSentAt: Date | null;
 };
 
 // ─────────────────────────────────────────────

--- a/src/domain/usecases/__tests__/admin/mock-admin-repository.ts
+++ b/src/domain/usecases/__tests__/admin/mock-admin-repository.ts
@@ -113,6 +113,15 @@ export function makeAdminUserDetail(
     image: null,
     onboardingCompleted: true,
     registrationCount: 10,
+    auth: {
+      providers: [],
+      emailVerified: new Date("2026-01-01"),
+      activeSessionsCount: 1,
+      latestSessionExpires: new Date("2099-12-31"),
+      pendingMagicLinksCount: 0,
+      latestPendingMagicLinkExpires: null,
+      welcomeEmailSentAt: new Date("2026-01-01"),
+    },
     circles: [
       { id: "circle-1", name: "Tech Paris", slug: "tech-paris", role: "HOST" },
     ],

--- a/src/infrastructure/repositories/prisma-admin-repository.ts
+++ b/src/infrastructure/repositories/prisma-admin-repository.ts
@@ -442,10 +442,18 @@ export const prismaAdminRepository: AdminRepository = {
   },
 
   async findUserById(id: string): Promise<AdminUserDetail | null> {
+    const now = new Date();
     const record = await prisma.user.findUnique({
       where: { id },
       include: {
         _count: { select: { memberships: true, registrations: true } },
+        accounts: { select: { provider: true } },
+        sessions: {
+          where: { expires: { gt: now } },
+          select: { expires: true },
+          orderBy: { expires: "desc" },
+          take: 1,
+        },
         memberships: {
           include: { circle: { select: { id: true, name: true, slug: true } } },
         },
@@ -460,6 +468,17 @@ export const prismaAdminRepository: AdminRepository = {
       },
     });
     if (!record) return null;
+
+    const [activeSessionsCount, pendingMagicLinksCount, latestPendingToken] = await Promise.all([
+      prisma.session.count({ where: { userId: id, expires: { gt: now } } }),
+      prisma.verificationToken.count({ where: { identifier: record.email, expires: { gt: now } } }),
+      prisma.verificationToken.findFirst({
+        where: { identifier: record.email, expires: { gt: now } },
+        select: { expires: true },
+        orderBy: { expires: "desc" },
+      }),
+    ]);
+
     return {
       id: record.id,
       email: record.email,
@@ -473,6 +492,15 @@ export const prismaAdminRepository: AdminRepository = {
       momentCount: record._count.registrations,
       registrationCount: record._count.registrations,
       createdAt: record.createdAt,
+      auth: {
+        providers: record.accounts.map((a) => a.provider),
+        emailVerified: record.emailVerified,
+        activeSessionsCount,
+        latestSessionExpires: record.sessions[0]?.expires ?? null,
+        pendingMagicLinksCount,
+        latestPendingMagicLinkExpires: latestPendingToken?.expires ?? null,
+        welcomeEmailSentAt: record.welcomeEmailSentAt,
+      },
       circles: record.memberships.map((m) => ({
         id: m.circle.id,
         name: m.circle.name,

--- a/src/infrastructure/services/sentry/analyze-issue.ts
+++ b/src/infrastructure/services/sentry/analyze-issue.ts
@@ -5,6 +5,7 @@ import { notifySlackSentryIssue, isAdminEmailEnabled } from "@/infrastructure/se
 import { SentryIssueAnalysisEmail } from "./sentry-issue-analysis-email";
 import { URGENCY_META, type AnalysisResult, type UserImpact, type UserImpactLevel } from "./analysis-meta";
 import { buildAnalysisPrompt } from "./build-prompt";
+import { buildSentryIssueUrl } from "@/lib/sentry-url";
 
 export type { UserImpact, UserImpactLevel } from "./analysis-meta";
 
@@ -207,15 +208,13 @@ export async function analyzeSentryIssue(issue: IssueInput): Promise<void> {
   const token = process.env.SENTRY_AUTH_TOKEN;
   if (!token) return;
 
-  const sentryOrg = process.env.SENTRY_ORG ?? "the-playground-id";
-
   const event = await fetchLatestEvent(issue.issueId, token);
   const context: EventContext = event
     ? extractEventContext(event)
     : { stacktrace: "", tags: {} };
 
   const analysis = await analyzeWithClaude(issue, context);
-  const sentryUrl = `https://${sentryOrg}.sentry.io/issues/${issue.issueId}/`;
+  const sentryUrl = buildSentryIssueUrl(issue.issueId);
 
   await Promise.all([
     isAdminEmailEnabled() ? sendAnalysisEmail(issue, analysis, sentryUrl) : Promise.resolve(),

--- a/src/lib/sentry-url.ts
+++ b/src/lib/sentry-url.ts
@@ -1,0 +1,13 @@
+const DEFAULT_SENTRY_ORG = "the-playground-id";
+
+function getSentryOrg(): string {
+  return process.env.SENTRY_ORG ?? DEFAULT_SENTRY_ORG;
+}
+
+export function buildSentryIssueUrl(issueId: string): string {
+  return `https://${getSentryOrg()}.sentry.io/issues/${issueId}/`;
+}
+
+export function buildSentryIssuesSearchUrl(query: string): string {
+  return `https://${getSentryOrg()}.sentry.io/issues/?query=${encodeURIComponent(query)}`;
+}


### PR DESCRIPTION
## Contexte

Suite aux incidents magic link de la semaine dernière (PR #419), la page admin `/admin/users/[id]` ne montrait pas les informations nécessaires au debug d'un compte cassé. Pour Sophie Lagarde par exemple, il a fallu écrire un script ad-hoc pour vérifier `accounts`, `sessions`, `verificationToken`, `welcomeEmailSentAt`. Cette PR rend ces infos directement visibles dans la console admin.

## Changements

### Carte « Authentification »
Nouvelle card sur la page admin user, entre les cards d'identité et les listes de Communautés/Événements :
- **Providers connectés** — badges des providers OAuth liés, ou « Magic link uniquement » si aucun
- **Email vérifié** — date du premier login réussi (Auth.js `emailVerified`)
- **Sessions actives** — count + date d'expiration la plus tardive
- **Magic links en attente** — count + date d'expiration la plus tardive (tokens non consommés)
- **Email de bienvenue** — date d'envoi ou « Jamais »

### Actions admin (header)
- **Copier l'ID** — pour cross-ref Sentry/PostHog/Stripe
- **Voir dans Sentry** — issues filtrées sur `user.email:<email>` ouvertes dans un nouvel onglet

### Refactor utilitaires (extraits du `/simplify`)
- `src/lib/sentry-url.ts` — helpers `buildSentryIssueUrl(issueId)` et `buildSentryIssuesSearchUrl(query)`. Évite la duplication du fallback `SENTRY_ORG ?? "the-playground-id"` qui existait déjà dans `analyze-issue.ts`. Ce dernier utilise désormais le helper.
- `src/components/ui/copy-button.tsx` — composant générique réutilisable (value, label, copiedLabel, variant, size). Remplace un `copy-id-button.tsx` ad-hoc qui dupliquait le pattern de `CopyLinkButton`.

### Domain & infra
- `AdminUserDetail` étendu avec une sous-structure `auth: AdminUserAuthInfo` (7 champs).
- `findUserById` étendu : `accounts` + `sessions` (filtrées DB sur `expires > now`, take 1) + 3 queries parallèles (`Promise.all`) pour `session.count`, `verificationToken.count`, `verificationToken.findFirst`.

## Tests

- ✅ `pnpm typecheck`
- ✅ `pnpm test:unit` — 1030 tests verts (mock factory `makeAdminUserDetail` mise à jour avec `auth`)

Pas de test E2E ajouté : le projet n'a pas de pattern E2E admin (setup auth admin lourd) et la logique nouvelle est déjà couverte par les usecase tests via le mock.

## Pas de changement schema

`git diff main...HEAD -- prisma/schema.prisma` est vide. Pas de `db:push:prod` à faire.