### PR TITLE
feat(admin): ajouter "Voir dans PostHog" et regrouper les actions debug

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -866,7 +866,8 @@
       "actions": {
         "copyId": "Copy ID",
         "idCopied": "Copied",
-        "viewInSentry": "View in Sentry"
+        "viewInSentry": "View in Sentry",
+        "viewInPostHog": "View in PostHog"
       }
     },
     "circleDetail": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -866,7 +866,8 @@
       "actions": {
         "copyId": "Copier l'ID",
         "idCopied": "Copié",
-        "viewInSentry": "Voir dans Sentry"
+        "viewInSentry": "Voir dans Sentry",
+        "viewInPostHog": "Voir dans PostHog"
       }
     },
     "circleDetail": {

--- a/src/app/[locale]/(routes)/admin/users/[id]/page.tsx
+++ b/src/app/[locale]/(routes)/admin/users/[id]/page.tsx
@@ -9,6 +9,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { CopyButton } from "@/components/ui/copy-button";
 import { formatLongDate } from "@/lib/format-date";
 import { buildSentryIssuesSearchUrl } from "@/lib/sentry-url";
+import { buildPostHogPersonUrl } from "@/lib/posthog-url";
 import { AdminUserDeleteButton } from "./delete-button";
 
 type Props = {
@@ -33,24 +34,7 @@ export default async function AdminUserDetailPage({ params }: Props) {
           <p className="text-sm text-muted-foreground">{t("userDetail.title")}</p>
           <h1 className="text-2xl font-bold">{displayName}</h1>
         </div>
-        <div className="flex items-center gap-2">
-          <CopyButton
-            value={user.id}
-            label={t("userDetail.actions.copyId")}
-            copiedLabel={t("userDetail.actions.idCopied")}
-          />
-          <Button variant="ghost" size="sm" asChild>
-            <a
-              href={buildSentryIssuesSearchUrl(`user.email:${user.email}`)}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <ExternalLink className="size-4" />
-              {t("userDetail.actions.viewInSentry")}
-            </a>
-          </Button>
-          <AdminUserDeleteButton userId={user.id} />
-        </div>
+        <AdminUserDeleteButton userId={user.id} />
       </div>
 
       <div className="grid gap-4 sm:grid-cols-2">
@@ -137,6 +121,33 @@ export default async function AdminUserDetailPage({ params }: Props) {
             label={t("userDetail.auth.welcomeEmail")}
             value={formatDateOrNever(user.auth.welcomeEmailSentAt, locale, t("userDetail.auth.never"))}
           />
+          <div className="flex flex-wrap items-center gap-2 pt-3 border-t">
+            <CopyButton
+              value={user.id}
+              label={t("userDetail.actions.copyId")}
+              copiedLabel={t("userDetail.actions.idCopied")}
+            />
+            <Button variant="ghost" size="sm" asChild>
+              <a
+                href={buildSentryIssuesSearchUrl(`user.email:${user.email}`)}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <ExternalLink className="size-4" />
+                {t("userDetail.actions.viewInSentry")}
+              </a>
+            </Button>
+            <Button variant="ghost" size="sm" asChild>
+              <a
+                href={buildPostHogPersonUrl(user.id)}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <ExternalLink className="size-4" />
+                {t("userDetail.actions.viewInPostHog")}
+              </a>
+            </Button>
+          </div>
         </CardContent>
       </Card>
 

--- a/src/lib/posthog-url.ts
+++ b/src/lib/posthog-url.ts
@@ -1,0 +1,7 @@
+// Project ID PostHog déjà utilisé dans les cron jobs reporting (eu.posthog.com).
+const POSTHOG_PROJECT_ID = "134622";
+const POSTHOG_HOST = "https://eu.posthog.com";
+
+export function buildPostHogPersonUrl(distinctId: string): string {
+  return `${POSTHOG_HOST}/project/${POSTHOG_PROJECT_ID}/person/${encodeURIComponent(distinctId)}`;
+}


### PR DESCRIPTION
## Contexte

Suite à la PR #421 qui a introduit la card « Authentification » sur `/admin/users/[id]`, ajout du bouton manquant « Voir dans PostHog » qui était dans la proposition initiale mais avait été coupé en route.

## Changements

- **Nouveau bouton** « Voir dans PostHog » qui ouvre la page Person de l'utilisateur sur eu.posthog.com (`distinct_id = User.id`, cohérent avec `posthog-identify.tsx`).
- **Regroupement des actions de debug dans la card Authentification** (footer), séparées par un `border-t`. Le header conserve uniquement le bouton de suppression (action destructive, nature différente).
- **Helper `buildPostHogPersonUrl`** extrait dans `src/lib/posthog-url.ts`, cohérent avec `sentry-url.ts`.

## Tests

- ✅ `pnpm typecheck`
- Pas de modif domain/usecase, donc pas de test unit ajouté.

## Pas de changement schema