### PR TITLE
chore(ci): étendre la whitelist docs-only de vercel-ignore.sh

### DIFF
--- a/scripts/vercel-ignore.sh
+++ b/scripts/vercel-ignore.sh
@@ -10,7 +10,8 @@
 #   - Branche `staging` : toujours build
 #   - Branche `main` :
 #       - build si src/content/** a changé (posts blog qui impactent les routes)
-#       - skip si uniquement CHANGELOG.md, spec/**, *.md, .github/** ont changé (docs-only)
+#       - skip si uniquement docs/scripts hors-build ont changé (CHANGELOG.md,
+#         spec/**, memory/**, *.md, .github/**, .gitignore, scripts/**)
 #       - build sinon
 #   - Autres branches : skip (les preview builds sont désactivés sauf staging)
 # ─────────────────────────────────────────────
@@ -29,4 +30,11 @@ if git diff --name-only HEAD~1 -- 'src/content/**' | grep -q .; then
   exit 1
 fi
 
-git diff --quiet HEAD~1 -- ':!CHANGELOG.md' ':!spec/**' ':!*.md' ':!.github/**'
+git diff --quiet HEAD~1 -- \
+  ':!CHANGELOG.md' \
+  ':!spec/**' \
+  ':!memory/**' \
+  ':!*.md' \
+  ':!.github/**' \
+  ':!.gitignore' \
+  ':!scripts/**'


### PR DESCRIPTION
## Contexte

Le commit `09301ad` (migration `spec/BACKLOG.md` → GitHub Issues) a déclenché un build prod **non sollicité** alors qu'il était considéré comme docs-only selon la règle `feedback_no_worktree_for_docs.md`.

Cause : `scripts/vercel-ignore.sh` a une whitelist plus restrictive que la règle. Le commit touchait `.gitignore` et `scripts/worktree-new.sh`, deux fichiers sans impact sur le bundle Next.js mais hors whitelist du script.

## Changements

Étend la whitelist de `scripts/vercel-ignore.sh` avec :

- `memory/**` — mémoire Claude, hors build
- `.gitignore` — métadonnées git, hors build
- `scripts/**` — scripts locaux, hors bundle Next.js

La whitelist devient cohérente avec la règle « no worktree for docs ».

## Test plan

- [x] `bash -n scripts/vercel-ignore.sh` — syntaxe OK
- [ ] Vérifier qu'un futur commit docs-only (modif `memory/`, `.gitignore`, ou `scripts/`) ne déclenche pas de build sur Vercel

> **Note** : ce commit-ci builde une dernière fois car Vercel évalue la règle courante (HEAD~1 → HEAD). À partir du commit suivant qui touche uniquement ces patterns, le build sera skippé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)