### PR TITLE
feat(ui): refonte des cards événement et Communauté du dashboard

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -779,7 +779,7 @@
       "moments": "No upcoming Events for this category."
     },
     "circleCard": {
-      "members": "{count} members",
+      "members": "{count, plural, one {# member} other {# members}}",
       "moreMembers": "+{count} more",
       "upcomingMoments": "{count} upcoming Event(s)",
       "noUpcomingMoments": "No upcoming Events",
@@ -1060,7 +1060,7 @@
       "subject": "{playerName} joined {circleName}",
       "heading": "New member",
       "message": "{playerName} joined your community {circleName}.",
-      "memberCountInfo": "{count} member(s)",
+      "memberCountInfo": "{count, plural, one {# member} other {# members}}",
       "manageMembersCta": "View members"
     },
     "hostNotification": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -779,8 +779,8 @@
       "moments": "Aucun événement à venir pour cette thématique."
     },
     "circleCard": {
-      "members": "{count} membres",
-      "moreMembers": "+{count} membres",
+      "members": "{count, plural, one {# membre} other {# membres}}",
+      "moreMembers": "+{count, plural, one {# membre} other {# membres}}",
       "upcomingMoments": "{count} événement(s) à venir",
       "noUpcomingMoments": "Aucun événement à venir",
       "nextMoment": "Prochain événement",
@@ -1060,7 +1060,7 @@
       "subject": "{playerName} a rejoint {circleName}",
       "heading": "Nouveau membre",
       "message": "{playerName} a rejoint votre communauté {circleName}.",
-      "memberCountInfo": "{count} membre(s)",
+      "memberCountInfo": "{count, plural, one {# membre} other {# membres}}",
       "manageMembersCta": "Voir les membres"
     },
     "hostNotification": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -649,8 +649,8 @@
     },
     "registrations": {
       "title": "Participants",
-      "registered": "{count} inscrit(s)",
-      "moreRegistered": "+{count} inscrit(s)",
+      "registered": "{count, plural, one {# inscrit} other {# inscrits}}",
+      "moreRegistered": "+{count, plural, one {# inscrit} other {# inscrits}}",
       "waitlisted": "{count} en liste d'attente",
       "capacity": "{count} places",
       "empty": "Aucune inscription pour le moment.",
@@ -794,8 +794,8 @@
     "momentCard": {
       "free": "Gratuit",
       "spotsRemaining": "{count} places restantes",
-      "registeredCount": "{count} inscrit(s)",
-      "moreRegistered": "+{count} inscrit(s)",
+      "registeredCount": "{count, plural, one {# inscrit} other {# inscrits}}",
+      "moreRegistered": "+{count, plural, one {# inscrit} other {# inscrits}}",
       "online": "En ligne",
       "roleBadge": {
         "host": "Organisateur",

--- a/src/app/[locale]/(routes)/circles/[slug]/page.tsx
+++ b/src/app/[locale]/(routes)/circles/[slug]/page.tsx
@@ -548,7 +548,6 @@ export default async function PublicCirclePage({
                       circleSlug={circle.slug}
                       registrationCount={countByMomentId.get(moment.id) ?? 0}
                       userRegistrationStatus={null}
-                      isOrganizer={false}
                       isLast={i === upcomingMoments.length - 1}
                       variant="public"
                       topAttendees={(topAttendeesByMomentId.get(moment.id) ?? []).map((r) => ({ user: { firstName: r.user.firstName, lastName: r.user.lastName, email: r.user.email, image: r.user.image } }))}
@@ -573,7 +572,6 @@ export default async function PublicCirclePage({
                       circleSlug={circle.slug}
                       registrationCount={countByMomentId.get(moment.id) ?? 0}
                       userRegistrationStatus={null}
-                      isOrganizer={false}
                       isLast={i === pastMoments.length - 1}
                       variant="public"
                       topAttendees={(topAttendeesByMomentId.get(moment.id) ?? []).map((r) => ({ user: { firstName: r.user.firstName, lastName: r.user.lastName, email: r.user.email, image: r.user.image } }))}

--- a/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/page.tsx
+++ b/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/page.tsx
@@ -488,7 +488,6 @@ export default async function CircleDetailPage({
                       circleSlug={circle.slug}
                       registrationCount={countByMomentId.get(moment.id) ?? 0}
                       userRegistrationStatus={userStatusByMomentId.get(moment.id) ?? null}
-                      isOrganizer={isOrganizer}
                       isLast={i === upcomingMoments.length - 1}
                       topAttendees={(topAttendeesByMomentId.get(moment.id) ?? []).map((r) => ({ user: { firstName: r.user.firstName, lastName: r.user.lastName, email: r.user.email, image: r.user.image } }))}
                     />
@@ -512,7 +511,6 @@ export default async function CircleDetailPage({
                       circleSlug={circle.slug}
                       registrationCount={countByMomentId.get(moment.id) ?? 0}
                       userRegistrationStatus={userStatusByMomentId.get(moment.id) ?? null}
-                      isOrganizer={isOrganizer}
                       isLast={i === pastMoments.length - 1}
                       topAttendees={(topAttendeesByMomentId.get(moment.id) ?? []).map((r) => ({ user: { firstName: r.user.firstName, lastName: r.user.lastName, email: r.user.email, image: r.user.image } }))}
                     />

--- a/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/page.tsx
+++ b/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/page.tsx
@@ -115,11 +115,12 @@ export default async function CircleDetailPage({
   const upcomingMoments = allMoments.filter((m) => m.status === "PUBLISHED" || (m.status === "DRAFT" && isOrganizer));
   const pastMoments = allMoments.filter((m) => m.status === "PAST" || m.status === "CANCELLED");
 
-  // Récupère compteurs + inscriptions utilisateur pour TOUS les moments (upcoming + past)
+  // Récupère compteurs + inscriptions utilisateur + top inscrits (avatars) pour TOUS les moments
   const allMomentIds = allMoments.map((m) => m.id);
-  const [countByMomentId, userRegistrationsByMomentId] = await Promise.all([
+  const [countByMomentId, userRegistrationsByMomentId, topAttendeesByMomentId] = await Promise.all([
     prismaRegistrationRepository.findRegisteredCountsByMomentIds(allMomentIds),
     prismaRegistrationRepository.findByMomentIdsAndUser(allMomentIds, session.user.id!),
+    prismaRegistrationRepository.findTopRegistrantsByMomentIds(allMomentIds, 3),
   ]);
   const userStatusByMomentId = new Map(
     [...userRegistrationsByMomentId.entries()].map(([id, reg]) => [id, reg?.status ?? null])
@@ -489,6 +490,7 @@ export default async function CircleDetailPage({
                       userRegistrationStatus={userStatusByMomentId.get(moment.id) ?? null}
                       isOrganizer={isOrganizer}
                       isLast={i === upcomingMoments.length - 1}
+                      topAttendees={(topAttendeesByMomentId.get(moment.id) ?? []).map((r) => ({ user: { firstName: r.user.firstName, lastName: r.user.lastName, email: r.user.email, image: r.user.image } }))}
                     />
                   ))}
                 </PaginatedMomentList>
@@ -512,6 +514,7 @@ export default async function CircleDetailPage({
                       userRegistrationStatus={userStatusByMomentId.get(moment.id) ?? null}
                       isOrganizer={isOrganizer}
                       isLast={i === pastMoments.length - 1}
+                      topAttendees={(topAttendeesByMomentId.get(moment.id) ?? []).map((r) => ({ user: { firstName: r.user.firstName, lastName: r.user.lastName, email: r.user.email, image: r.user.image } }))}
                     />
                   ))}
                 </PaginatedMomentList>

--- a/src/components/badges/draft-badge.tsx
+++ b/src/components/badges/draft-badge.tsx
@@ -6,9 +6,11 @@ type Props = {
   /** "cover" → overlay on image (matches DemoBadge size="lg" + FileEdit icon)
    *  "badge" → inline Badge component for card lists (default) */
   variant?: "cover" | "badge";
+  /** Affiche le label aussi sur mobile (défaut : false → icône seule sur mobile). */
+  showLabelOnMobile?: boolean;
 };
 
-export function DraftBadge({ label, variant = "badge" }: Props) {
+export function DraftBadge({ label, variant = "badge", showLabelOnMobile = false }: Props) {
   if (variant === "cover") {
     return (
       <span className="absolute left-3 top-3 z-10 inline-flex items-center gap-1 rounded-md border border-primary/70 bg-black/80 px-2.5 py-1 text-sm leading-none text-primary">
@@ -21,7 +23,7 @@ export function DraftBadge({ label, variant = "badge" }: Props) {
   return (
     <Badge variant="outline" className="shrink-0 gap-1 border-primary/40 text-xs text-primary">
       <FileEdit className="size-3" />
-      <span className="hidden sm:inline">{label}</span>
+      {showLabelOnMobile ? label : <span className="hidden sm:inline">{label}</span>}
     </Badge>
   );
 }

--- a/src/components/circles/dashboard-circle-card.tsx
+++ b/src/components/circles/dashboard-circle-card.tsx
@@ -64,9 +64,6 @@ export async function DashboardCircleCard({ circle }: Props) {
             <h3 className="truncate text-sm font-semibold leading-snug group-hover:text-primary dark:group-hover:text-[oklch(0.76_0.27_341)] transition-colors">
               {circle.name}
             </h3>
-            <p className="text-muted-foreground line-clamp-1 text-xs">
-              {circle.description}
-            </p>
             {circle.city && (
               <div className="text-muted-foreground flex items-center gap-1 text-xs">
                 <MapPin className="size-3.5 shrink-0" />

--- a/src/components/circles/dashboard-circle-card.tsx
+++ b/src/components/circles/dashboard-circle-card.tsx
@@ -53,7 +53,7 @@ export async function DashboardCircleCard({ circle }: Props) {
           </div>
 
           {/* Body */}
-          <div className="flex min-w-0 flex-1 flex-col gap-[5px] sm:gap-1.5">
+          <div className="flex min-w-0 flex-1 flex-col gap-1.5">
             {/* Badges — catégorie */}
             {categoryLabel && (
               <div className="flex items-center gap-2">

--- a/src/components/circles/dashboard-circle-card.tsx
+++ b/src/components/circles/dashboard-circle-card.tsx
@@ -37,17 +37,17 @@ export async function DashboardCircleCard({ circle }: Props) {
 
           {/* Thumbnail */}
           <div
-            className="size-[100px] sm:size-[120px] shrink-0 overflow-hidden rounded-xl"
+            className="size-[100px] shrink-0 overflow-hidden rounded-xl"
             style={circle.coverImage ? undefined : { background: gradient }}
           >
             {circle.coverImage && (
               <Image
                 src={circle.coverImage}
                 alt={circle.name}
-                width={120}
-                height={120}
+                width={100}
+                height={100}
                 className="size-full object-cover"
-                sizes="120px"
+                sizes="100px"
               />
             )}
           </div>

--- a/src/components/circles/dashboard-circle-card.tsx
+++ b/src/components/circles/dashboard-circle-card.tsx
@@ -53,7 +53,7 @@ export async function DashboardCircleCard({ circle }: Props) {
           </div>
 
           {/* Body */}
-          <div className="min-w-0 flex-1 space-y-1">
+          <div className="min-w-0 flex-1 space-y-[5px] sm:space-y-1.5">
             {/* Badges — catégorie */}
             {categoryLabel && (
               <div className="flex items-center gap-2">

--- a/src/components/circles/dashboard-circle-card.tsx
+++ b/src/components/circles/dashboard-circle-card.tsx
@@ -94,12 +94,12 @@ export async function DashboardCircleCard({ circle }: Props) {
           {/* Colonne droite — desktop uniquement */}
           <div className="hidden sm:flex shrink-0 items-center ml-4">
             {hasNextMoment ? (
-              <div className="flex flex-col gap-1 rounded-xl border border-border bg-muted/50 px-3 py-2 text-xs text-muted-foreground max-w-[200px]">
-                <p className="truncate font-medium text-foreground">{circle.nextMoment!.title}</p>
+              <div className="flex w-[160px] flex-col gap-1 rounded-xl border border-border bg-muted/50 px-3 py-2 text-xs text-muted-foreground">
                 <div className="flex items-center gap-1.5">
                   <CalendarIcon className="size-3 shrink-0 text-foreground" />
                   <span className="whitespace-nowrap">{nextMomentDate} · {nextMomentTime}</span>
                 </div>
+                <p className="line-clamp-2 font-medium leading-snug text-foreground">{circle.nextMoment!.title}</p>
               </div>
             ) : (
               <div className="rounded-xl border border-border bg-muted/50 px-3 py-2 text-xs text-muted-foreground whitespace-nowrap">

--- a/src/components/circles/dashboard-circle-card.tsx
+++ b/src/components/circles/dashboard-circle-card.tsx
@@ -3,12 +3,11 @@ import { Link } from "@/i18n/navigation";
 import { getTranslations, getLocale } from "next-intl/server";
 import { getMomentGradient } from "@/lib/gradient";
 import { formatDayMonth, formatTime } from "@/lib/format-date";
-import { Users, CalendarIcon, MapPin, Crown, Clock } from "lucide-react";
+import { CalendarIcon, MapPin, Clock } from "lucide-react";
 import { AttendeeAvatarStack } from "@/components/moments/attendee-avatar-stack";
 import { Badge } from "@/components/ui/badge";
 import { CategoryBadge } from "@/components/badges/category-badge";
 import type { DashboardCircle } from "@/domain/models/circle";
-import { isOrganizerRole } from "@/domain/models/circle";
 import { resolveCategoryLabel } from "@/lib/circle-category-helpers";
 
 type Props = {
@@ -94,13 +93,12 @@ export async function DashboardCircleCard({ circle }: Props) {
                   }
                 />
               )}
-              <Badge variant="outline" className={`shrink-0 gap-1 text-xs ${circle.membershipStatus === "PENDING" ? "border-amber-500/40 text-amber-500" : "border-primary/40 text-primary"}`}>
-                {circle.membershipStatus === "PENDING"
-                  ? <><Clock className="size-3" /><span className="hidden sm:inline">{t("circleCard.roleBadge.pending")}</span></>
-                  : isOrganizerRole(circle.memberRole)
-                    ? <><Crown className="size-3" /><span className="hidden sm:inline">{t("circleCard.roleBadge.host")}</span></>
-                    : <><Users className="size-3" /><span className="hidden sm:inline">{t("circleCard.roleBadge.member")}</span></>}
-              </Badge>
+              {circle.membershipStatus === "PENDING" && (
+                <Badge variant="outline" className="shrink-0 gap-1 border-amber-500/40 text-xs text-amber-500">
+                  <Clock className="size-3" />
+                  <span className="hidden sm:inline">{t("circleCard.roleBadge.pending")}</span>
+                </Badge>
+              )}
             </div>
           </div>
 

--- a/src/components/circles/dashboard-circle-card.tsx
+++ b/src/components/circles/dashboard-circle-card.tsx
@@ -97,7 +97,7 @@ export async function DashboardCircleCard({ circle }: Props) {
               <div className="flex flex-col gap-1 rounded-xl border border-border bg-muted/50 px-3 py-2 text-xs text-muted-foreground max-w-[200px]">
                 <p className="truncate font-medium text-foreground">{circle.nextMoment!.title}</p>
                 <div className="flex items-center gap-1.5">
-                  <CalendarIcon className="size-3 shrink-0 text-primary" />
+                  <CalendarIcon className="size-3 shrink-0 text-foreground" />
                   <span className="whitespace-nowrap">{nextMomentDate} · {nextMomentTime}</span>
                 </div>
               </div>

--- a/src/components/circles/dashboard-circle-card.tsx
+++ b/src/components/circles/dashboard-circle-card.tsx
@@ -67,20 +67,12 @@ export async function DashboardCircleCard({ circle }: Props) {
             <p className="text-muted-foreground line-clamp-1 text-xs">
               {circle.description}
             </p>
-            <div className="text-muted-foreground flex flex-wrap items-center gap-x-3 gap-y-0.5 text-xs">
-              {circle.city && (
-                <div className="flex items-center gap-1">
-                  <MapPin className="size-3.5 shrink-0" />
-                  <span>{circle.city}</span>
-                </div>
-              )}
-              {circle.upcomingMomentCount > 0 && (
-                <div className="flex items-center gap-1">
-                  <CalendarIcon className="size-3.5 shrink-0" />
-                  <span>{t("circleCard.upcomingMoments", { count: circle.upcomingMomentCount })}</span>
-                </div>
-              )}
-            </div>
+            {circle.city && (
+              <div className="text-muted-foreground flex items-center gap-1 text-xs">
+                <MapPin className="size-3.5 shrink-0" />
+                <span>{circle.city}</span>
+              </div>
+            )}
             <div className="flex items-center gap-2">
               {circle.memberCount > 0 && (
                 <AttendeeAvatarStack

--- a/src/components/circles/dashboard-circle-card.tsx
+++ b/src/components/circles/dashboard-circle-card.tsx
@@ -94,7 +94,7 @@ export async function DashboardCircleCard({ circle }: Props) {
           {/* Colonne droite — desktop uniquement */}
           <div className="hidden sm:flex shrink-0 items-center ml-4">
             {hasNextMoment ? (
-              <div className="flex w-[140px] min-w-0 flex-col gap-1 overflow-hidden rounded-xl border border-border bg-muted/50 px-3 py-2 text-xs text-muted-foreground">
+              <div className="flex w-[160px] min-w-0 flex-col gap-1 overflow-hidden rounded-xl border border-border bg-muted/50 px-3 py-2 text-xs text-muted-foreground">
                 <div className="flex items-center gap-1.5">
                   <CalendarIcon className="size-3 shrink-0 text-foreground" />
                   <span className="whitespace-nowrap">{nextMomentDate} · {nextMomentTime}</span>

--- a/src/components/circles/dashboard-circle-card.tsx
+++ b/src/components/circles/dashboard-circle-card.tsx
@@ -26,7 +26,6 @@ export async function DashboardCircleCard({ circle }: Props) {
   const nextMomentStart = circle.nextMoment?.startsAt ?? null;
   const nextMomentDate = nextMomentStart ? formatDayMonth(nextMomentStart, locale) : null;
   const nextMomentTime = nextMomentStart ? formatTime(nextMomentStart) : null;
-  const hasNextMoment = !!(circle.nextMoment && nextMomentDate);
 
   const categoryLabel = resolveCategoryLabel(circle.category, circle.customCategory, tCategory);
 
@@ -35,7 +34,6 @@ export async function DashboardCircleCard({ circle }: Props) {
       <div className="bg-card overflow-hidden rounded-2xl border p-3 sm:p-4 shadow-lg dark:shadow-none transition-colors hover:border-primary/30">
         <div className="flex items-center gap-4 sm:gap-5">
 
-          {/* Thumbnail */}
           <div
             className="size-[100px] shrink-0 overflow-hidden rounded-xl"
             style={circle.coverImage ? undefined : { background: gradient }}
@@ -52,15 +50,12 @@ export async function DashboardCircleCard({ circle }: Props) {
             )}
           </div>
 
-          {/* Body */}
           <div className="flex min-w-0 flex-1 flex-col gap-1.5">
-            {/* Badges — catégorie */}
             {categoryLabel && (
               <div className="flex items-center gap-2">
                 <CategoryBadge label={categoryLabel} />
               </div>
             )}
-            {/* Titre — pleine largeur */}
             <h3 className="truncate text-sm font-semibold leading-snug group-hover:text-primary dark:group-hover:text-[oklch(0.76_0.27_341)] transition-colors">
               {circle.name}
             </h3>
@@ -91,9 +86,8 @@ export async function DashboardCircleCard({ circle }: Props) {
             </div>
           </div>
 
-          {/* Colonne droite — desktop uniquement */}
           <div className="hidden sm:flex shrink-0 items-center ml-4">
-            {hasNextMoment ? (
+            {circle.nextMoment ? (
               <div className="flex w-[180px] min-w-0 flex-col gap-1 overflow-hidden rounded-xl border border-border bg-muted/50 px-3 py-2 text-xs text-muted-foreground">
                 <p className="text-muted-foreground/70 text-[0.6rem] font-medium uppercase tracking-wider">
                   {t("circleCard.nextMoment")}

--- a/src/components/circles/dashboard-circle-card.tsx
+++ b/src/components/circles/dashboard-circle-card.tsx
@@ -53,7 +53,7 @@ export async function DashboardCircleCard({ circle }: Props) {
           </div>
 
           {/* Body */}
-          <div className="min-w-0 flex-1 space-y-[5px] sm:space-y-1.5">
+          <div className="flex min-w-0 flex-1 flex-col gap-[5px] sm:gap-1.5">
             {/* Badges — catégorie */}
             {categoryLabel && (
               <div className="flex items-center gap-2">

--- a/src/components/circles/dashboard-circle-card.tsx
+++ b/src/components/circles/dashboard-circle-card.tsx
@@ -94,7 +94,7 @@ export async function DashboardCircleCard({ circle }: Props) {
           {/* Colonne droite — desktop uniquement */}
           <div className="hidden sm:flex shrink-0 items-center ml-4">
             {hasNextMoment ? (
-              <div className="flex w-[160px] min-w-0 flex-col gap-1 overflow-hidden rounded-xl border border-border bg-muted/50 px-3 py-2 text-xs text-muted-foreground">
+              <div className="flex w-[180px] min-w-0 flex-col gap-1 overflow-hidden rounded-xl border border-border bg-muted/50 px-3 py-2 text-xs text-muted-foreground">
                 <div className="flex items-center gap-1.5">
                   <CalendarIcon className="size-3 shrink-0 text-foreground" />
                   <span className="whitespace-nowrap">{nextMomentDate} · {nextMomentTime}</span>

--- a/src/components/circles/dashboard-circle-card.tsx
+++ b/src/components/circles/dashboard-circle-card.tsx
@@ -95,6 +95,9 @@ export async function DashboardCircleCard({ circle }: Props) {
           <div className="hidden sm:flex shrink-0 items-center ml-4">
             {hasNextMoment ? (
               <div className="flex w-[180px] min-w-0 flex-col gap-1 overflow-hidden rounded-xl border border-border bg-muted/50 px-3 py-2 text-xs text-muted-foreground">
+                <p className="text-muted-foreground/70 text-[0.6rem] font-medium uppercase tracking-wider">
+                  {t("circleCard.nextMoment")}
+                </p>
                 <div className="flex items-center gap-1.5">
                   <CalendarIcon className="size-3 shrink-0 text-foreground" />
                   <span className="whitespace-nowrap">{nextMomentDate} · {nextMomentTime}</span>

--- a/src/components/circles/dashboard-circle-card.tsx
+++ b/src/components/circles/dashboard-circle-card.tsx
@@ -94,12 +94,12 @@ export async function DashboardCircleCard({ circle }: Props) {
           {/* Colonne droite — desktop uniquement */}
           <div className="hidden sm:flex shrink-0 items-center ml-4">
             {hasNextMoment ? (
-              <div className="flex w-[160px] flex-col gap-1 rounded-xl border border-border bg-muted/50 px-3 py-2 text-xs text-muted-foreground">
+              <div className="flex w-[140px] min-w-0 flex-col gap-1 overflow-hidden rounded-xl border border-border bg-muted/50 px-3 py-2 text-xs text-muted-foreground">
                 <div className="flex items-center gap-1.5">
                   <CalendarIcon className="size-3 shrink-0 text-foreground" />
                   <span className="whitespace-nowrap">{nextMomentDate} · {nextMomentTime}</span>
                 </div>
-                <p className="line-clamp-2 font-medium leading-snug text-foreground">{circle.nextMoment!.title}</p>
+                <p className="line-clamp-2 min-w-0 break-words font-medium leading-snug text-foreground">{circle.nextMoment!.title}</p>
               </div>
             ) : (
               <div className="rounded-xl border border-border bg-muted/50 px-3 py-2 text-xs text-muted-foreground whitespace-nowrap">

--- a/src/components/circles/moment-timeline-item.tsx
+++ b/src/components/circles/moment-timeline-item.tsx
@@ -178,7 +178,7 @@ export async function MomentTimelineItem({
 
                 {/* Title (en variant public, passe en première ligne sur mobile) */}
                 <p
-                  className={`truncate font-semibold leading-snug ${
+                  className={`line-clamp-2 font-semibold leading-snug ${
                     variant === "public" ? "order-first sm:order-none" : ""
                   } ${
                     isCancelled

--- a/src/components/circles/moment-timeline-item.tsx
+++ b/src/components/circles/moment-timeline-item.tsx
@@ -149,9 +149,8 @@ export async function MomentTimelineItem({
             <div className="flex items-center gap-4 p-4">
               {/* Content */}
               <div className="flex min-w-0 flex-1 flex-col gap-2">
-                {/* Heure + lieu (heure toujours masquée mobile ; ligne entière masquée mobile en variant dashboard) */}
                 <div
-                  className={`${variant === "dashboard" ? "hidden sm:flex" : "flex"} items-center gap-3 text-xs ${
+                  className={`flex items-center gap-3 text-xs ${
                     isPast ? "text-muted-foreground/60" : "text-muted-foreground"
                   }`}
                 >
@@ -167,19 +166,7 @@ export async function MomentTimelineItem({
                   )}
                 </div>
 
-                {/* Lieu seul sur sa ligne, mobile only, variant dashboard (la ligne heure+lieu est cachée mobile dashboard) */}
-                {variant === "dashboard" && locationLabel && (
-                  <div
-                    className={`flex items-center gap-1.5 text-xs sm:hidden ${
-                      isPast ? "text-muted-foreground/60" : "text-muted-foreground"
-                    }`}
-                  >
-                    <LocationIcon className="size-3.5 shrink-0" />
-                    <span className="truncate">{locationLabel}</span>
-                  </div>
-                )}
 
-                {/* Title */}
                 <p
                   className={`line-clamp-2 font-semibold leading-snug ${
                     isCancelled
@@ -192,7 +179,6 @@ export async function MomentTimelineItem({
                   {moment.title}
                 </p>
 
-                {/* Inscrits */}
                 {!isCancelled && registrationCount > 0 && (
                   <div className={isPast ? "opacity-60" : ""}>
                     <AttendeeAvatarStack
@@ -207,7 +193,6 @@ export async function MomentTimelineItem({
                   </div>
                 )}
 
-                {/* Badge statut/rôle (desktop only) */}
                 {statusBadge && <div className="hidden sm:block">{statusBadge}</div>}
               </div>
 

--- a/src/components/circles/moment-timeline-item.tsx
+++ b/src/components/circles/moment-timeline-item.tsx
@@ -91,21 +91,21 @@ export async function MomentTimelineItem({
           ? (
               <Badge variant="outline" className="gap-1 border-primary/40 text-xs text-primary">
                 <Crown className="size-3" />
-                <span className="hidden sm:inline">{tDashboard("role.host")}</span>
+                {tDashboard("role.host")}
               </Badge>
             )
           : isRegistered
             ? (
                 <Badge variant="outline" className="gap-1 border-primary/40 text-xs text-primary">
                   <Check className="size-3" />
-                  <span className="hidden sm:inline">{tDashboard("registrationStatus.registered")}</span>
+                  {tDashboard("registrationStatus.registered")}
                 </Badge>
               )
             : isWaitlisted
               ? (
                   <Badge variant="secondary" className="gap-1 text-xs">
                     <Clock className="size-3" />
-                    <span className="hidden sm:inline">{tDashboard("registrationStatus.waitlisted")}</span>
+                    {tDashboard("registrationStatus.waitlisted")}
                   </Badge>
                 )
               : null;

--- a/src/components/circles/moment-timeline-item.tsx
+++ b/src/components/circles/moment-timeline-item.tsx
@@ -179,11 +179,9 @@ export async function MomentTimelineItem({
                   </div>
                 )}
 
-                {/* Title (en variant public, passe en première ligne sur mobile) */}
+                {/* Title */}
                 <p
                   className={`line-clamp-2 font-semibold leading-snug ${
-                    variant === "public" ? "order-first sm:order-none" : ""
-                  } ${
                     isCancelled
                       ? "text-muted-foreground line-through"
                       : isPast

--- a/src/components/circles/moment-timeline-item.tsx
+++ b/src/components/circles/moment-timeline-item.tsx
@@ -3,7 +3,7 @@ import { getTranslations, getLocale } from "next-intl/server";
 import { Link } from "@/i18n/navigation";
 import { getMomentGradient } from "@/lib/gradient";
 import { formatWeekdayAndDate, formatTime, isSameDayInParis } from "@/lib/format-date";
-import { MapPin, Globe, Users, Check, Clock, XCircle, Crown } from "lucide-react";
+import { MapPin, Globe, Check, Clock, XCircle, Crown } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { DraftBadge } from "@/components/badges/draft-badge";
 import { AttendeeAvatarStack } from "@/components/moments/attendee-avatar-stack";
@@ -21,7 +21,7 @@ type Props = {
   /** "dashboard" (défaut) → lien vers le dashboard Host.
    *  "public" → lien vers /m/[slug], sans badges de statut utilisateur. */
   variant?: "dashboard" | "public";
-  /** Premiers inscrits pour l'avatar stack (variant public). */
+  /** Premiers inscrits pour l'avatar stack. */
   topAttendees?: Attendee[];
 };
 
@@ -155,24 +155,20 @@ export async function MomentTimelineItem({
                 </div>
 
                 {/* Title */}
-                {!isCancelled && variant === "dashboard" ? (
-                  <p className={`truncate font-semibold leading-snug ${isPast ? "text-muted-foreground" : "group-hover:text-primary dark:group-hover:text-[oklch(0.76_0.27_341)] transition-colors"}`}>
-                    {moment.title}
-                  </p>
-                ) : (
-                  <p className={`truncate font-semibold leading-snug ${isCancelled ? "text-muted-foreground line-through" : isPast ? "text-muted-foreground" : "group-hover:text-primary dark:group-hover:text-[oklch(0.76_0.27_341)] transition-colors"}`}>
-                    {moment.title}
-                  </p>
-                )}
+                <p
+                  className={`truncate font-semibold leading-snug ${
+                    isCancelled
+                      ? "text-muted-foreground line-through"
+                      : isPast
+                        ? "text-muted-foreground"
+                        : "group-hover:text-primary dark:group-hover:text-[oklch(0.76_0.27_341)] transition-colors"
+                  }`}
+                >
+                  {moment.title}
+                </p>
 
                 {/* Inscrits */}
-                {!isCancelled && registrationCount > 0 && variant === "dashboard" && (
-                  <div className={`flex items-center gap-1 text-xs ${isPast ? "text-muted-foreground/60" : "text-muted-foreground"}`}>
-                    <Users className="size-3 shrink-0" />
-                    <span>{t("registrations.registered", { count: registrationCount })}</span>
-                  </div>
-                )}
-                {!isCancelled && registrationCount > 0 && variant === "public" && (
+                {!isCancelled && registrationCount > 0 && (
                   <div className={isPast ? "opacity-60" : ""}>
                     <AttendeeAvatarStack
                       attendees={topAttendees}

--- a/src/components/circles/moment-timeline-item.tsx
+++ b/src/components/circles/moment-timeline-item.tsx
@@ -124,6 +124,9 @@ export async function MomentTimelineItem({
             <p className="text-sm font-medium leading-snug">{dateStr}</p>
           </>
         )}
+        <p className={`mt-0.5 text-xs sm:hidden ${isPast ? "text-muted-foreground/60" : "text-muted-foreground"}`}>
+          {timeStr}
+        </p>
       </div>
 
       {/* Dot + vertical line */}
@@ -155,9 +158,9 @@ export async function MomentTimelineItem({
             <div className="flex items-center gap-4 p-4">
               {/* Content */}
               <div className="min-w-0 flex-1 space-y-2">
-                {/* Heure + lieu */}
+                {/* Heure + lieu (heure masquée en mobile, déplacée dans la colonne date) */}
                 <div className={`flex items-center gap-3 text-xs ${isPast ? "text-muted-foreground/60" : "text-muted-foreground"}`}>
-                  <span className="flex shrink-0 items-center gap-1.5">
+                  <span className="hidden shrink-0 items-center gap-1.5 sm:flex">
                     <Clock className="size-3.5 shrink-0" />
                     {timeStr}
                   </span>

--- a/src/components/circles/moment-timeline-item.tsx
+++ b/src/components/circles/moment-timeline-item.tsx
@@ -154,7 +154,7 @@ export async function MomentTimelineItem({
             {/* Corps de la carte */}
             <div className="flex items-center gap-4 p-4">
               {/* Content */}
-              <div className="min-w-0 flex-1 space-y-1.5">
+              <div className="min-w-0 flex-1 space-y-2">
                 {/* Heure + lieu */}
                 <div className={`flex items-center gap-3 text-xs ${isPast ? "text-muted-foreground/60" : "text-muted-foreground"}`}>
                   <span className="flex shrink-0 items-center gap-1.5">

--- a/src/components/circles/moment-timeline-item.tsx
+++ b/src/components/circles/moment-timeline-item.tsx
@@ -91,21 +91,21 @@ export async function MomentTimelineItem({
           ? (
               <Badge variant="outline" className="gap-1 border-primary/40 text-xs text-primary">
                 <Crown className="size-3" />
-                {tDashboard("role.host")}
+                <span className="hidden sm:inline">{tDashboard("role.host")}</span>
               </Badge>
             )
           : isRegistered
             ? (
                 <Badge variant="outline" className="gap-1 border-primary/40 text-xs text-primary">
                   <Check className="size-3" />
-                  {tDashboard("registrationStatus.registered")}
+                  <span className="hidden sm:inline">{tDashboard("registrationStatus.registered")}</span>
                 </Badge>
               )
             : isWaitlisted
               ? (
                   <Badge variant="secondary" className="gap-1 text-xs">
                     <Clock className="size-3" />
-                    {tDashboard("registrationStatus.waitlisted")}
+                    <span className="hidden sm:inline">{tDashboard("registrationStatus.waitlisted")}</span>
                   </Badge>
                 )
               : null;

--- a/src/components/circles/moment-timeline-item.tsx
+++ b/src/components/circles/moment-timeline-item.tsx
@@ -167,6 +167,18 @@ export async function MomentTimelineItem({
                   )}
                 </div>
 
+                {/* Lieu seul sur sa ligne, mobile only, variant dashboard (la ligne heure+lieu est cachée mobile dashboard) */}
+                {variant === "dashboard" && locationLabel && (
+                  <div
+                    className={`flex items-center gap-1.5 text-xs sm:hidden ${
+                      isPast ? "text-muted-foreground/60" : "text-muted-foreground"
+                    }`}
+                  >
+                    <LocationIcon className="size-3.5 shrink-0" />
+                    <span className="truncate">{locationLabel}</span>
+                  </div>
+                )}
+
                 {/* Title (en variant public, passe en première ligne sur mobile) */}
                 <p
                   className={`line-clamp-2 font-semibold leading-snug ${

--- a/src/components/circles/moment-timeline-item.tsx
+++ b/src/components/circles/moment-timeline-item.tsx
@@ -215,11 +215,11 @@ export async function MomentTimelineItem({
                   alt={moment.title}
                   width={100}
                   height={100}
-                  className={`size-[100px] shrink-0 rounded-lg object-cover ${isCancelled || isPast ? "grayscale opacity-40" : ""}`}
+                  className={`size-16 shrink-0 rounded-lg object-cover sm:size-[100px] ${isCancelled || isPast ? "grayscale opacity-40" : ""}`}
                 />
               ) : (
                 <div
-                  className={`size-[100px] shrink-0 rounded-lg ${isCancelled || isPast ? "grayscale opacity-40" : ""}`}
+                  className={`size-16 shrink-0 rounded-lg sm:size-[100px] ${isCancelled || isPast ? "grayscale opacity-40" : ""}`}
                   style={{ background: gradient }}
                 />
               )}

--- a/src/components/circles/moment-timeline-item.tsx
+++ b/src/components/circles/moment-timeline-item.tsx
@@ -86,7 +86,7 @@ export async function MomentTimelineItem({
     isCancelled || variant !== "dashboard"
       ? null
       : isDraft
-        ? <DraftBadge label={t("status.draft")} />
+        ? <DraftBadge label={t("status.draft")} showLabelOnMobile />
         : isOrganizer
           ? (
               <Badge variant="outline" className="gap-1 border-primary/40 text-xs text-primary">

--- a/src/components/circles/moment-timeline-item.tsx
+++ b/src/components/circles/moment-timeline-item.tsx
@@ -158,8 +158,12 @@ export async function MomentTimelineItem({
             <div className="flex items-center gap-4 p-4">
               {/* Content */}
               <div className="min-w-0 flex-1 space-y-2">
-                {/* Heure + lieu (heure masquée en mobile, déplacée dans la colonne date) */}
-                <div className={`flex items-center gap-3 text-xs ${isPast ? "text-muted-foreground/60" : "text-muted-foreground"}`}>
+                {/* Heure + lieu (heure toujours masquée mobile ; ligne entière masquée mobile en variant dashboard) */}
+                <div
+                  className={`${variant === "dashboard" ? "hidden sm:flex" : "flex"} items-center gap-3 text-xs ${
+                    isPast ? "text-muted-foreground/60" : "text-muted-foreground"
+                  }`}
+                >
                   <span className="hidden shrink-0 items-center gap-1.5 sm:flex">
                     <Clock className="size-3.5 shrink-0" />
                     {timeStr}

--- a/src/components/circles/moment-timeline-item.tsx
+++ b/src/components/circles/moment-timeline-item.tsx
@@ -217,11 +217,11 @@ export async function MomentTimelineItem({
                   alt={moment.title}
                   width={100}
                   height={100}
-                  className={`size-16 shrink-0 rounded-lg object-cover sm:size-[100px] ${isCancelled || isPast ? "grayscale opacity-40" : ""}`}
+                  className={`size-[100px] shrink-0 rounded-lg object-cover ${isCancelled || isPast ? "grayscale opacity-40" : ""}`}
                 />
               ) : (
                 <div
-                  className={`size-16 shrink-0 rounded-lg sm:size-[100px] ${isCancelled || isPast ? "grayscale opacity-40" : ""}`}
+                  className={`size-[100px] shrink-0 rounded-lg ${isCancelled || isPast ? "grayscale opacity-40" : ""}`}
                   style={{ background: gradient }}
                 />
               )}

--- a/src/components/circles/moment-timeline-item.tsx
+++ b/src/components/circles/moment-timeline-item.tsx
@@ -3,7 +3,7 @@ import { getTranslations, getLocale } from "next-intl/server";
 import { Link } from "@/i18n/navigation";
 import { getMomentGradient } from "@/lib/gradient";
 import { formatWeekdayAndDate, formatTime, isSameDayInParis } from "@/lib/format-date";
-import { MapPin, Globe, Check, Clock, XCircle, Crown } from "lucide-react";
+import { MapPin, Globe, Check, Clock, XCircle } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { DraftBadge } from "@/components/badges/draft-badge";
 import { AttendeeAvatarStack } from "@/components/moments/attendee-avatar-stack";
@@ -16,7 +16,6 @@ type Props = {
   circleSlug: string;
   registrationCount: number;
   userRegistrationStatus: RegistrationStatus | null;
-  isOrganizer: boolean;
   isLast: boolean;
   /** "dashboard" (défaut) → lien vers le dashboard Host.
    *  "public" → lien vers /m/[slug], sans badges de statut utilisateur. */
@@ -30,7 +29,6 @@ export async function MomentTimelineItem({
   circleSlug,
   registrationCount,
   userRegistrationStatus,
-  isOrganizer,
   isLast,
   variant = "dashboard",
   topAttendees = [],
@@ -87,28 +85,21 @@ export async function MomentTimelineItem({
       ? null
       : isDraft
         ? <DraftBadge label={t("status.draft")} showLabelOnMobile />
-        : isOrganizer
+        : isRegistered
           ? (
               <Badge variant="outline" className="gap-1 border-primary/40 text-xs text-primary">
-                <Crown className="size-3" />
-                {tDashboard("role.host")}
+                <Check className="size-3" />
+                {tDashboard("registrationStatus.registered")}
               </Badge>
             )
-          : isRegistered
+          : isWaitlisted
             ? (
-                <Badge variant="outline" className="gap-1 border-primary/40 text-xs text-primary">
-                  <Check className="size-3" />
-                  {tDashboard("registrationStatus.registered")}
+                <Badge variant="secondary" className="gap-1 text-xs">
+                  <Clock className="size-3" />
+                  {tDashboard("registrationStatus.waitlisted")}
                 </Badge>
               )
-            : isWaitlisted
-              ? (
-                  <Badge variant="secondary" className="gap-1 text-xs">
-                    <Clock className="size-3" />
-                    {tDashboard("registrationStatus.waitlisted")}
-                  </Badge>
-                )
-              : null;
+            : null;
 
   return (
     <div className="flex gap-0">
@@ -206,8 +197,8 @@ export async function MomentTimelineItem({
                   </div>
                 )}
 
-                {/* Badge statut/rôle */}
-                {statusBadge && <div>{statusBadge}</div>}
+                {/* Badge statut/rôle (desktop only) */}
+                {statusBadge && <div className="hidden sm:block">{statusBadge}</div>}
               </div>
 
               {/* Thumbnail */}

--- a/src/components/circles/moment-timeline-item.tsx
+++ b/src/components/circles/moment-timeline-item.tsx
@@ -82,6 +82,34 @@ export async function MomentTimelineItem({
 
   const LocationIcon = moment.locationType === "IN_PERSON" ? MapPin : Globe;
 
+  const statusBadge =
+    isCancelled || variant !== "dashboard"
+      ? null
+      : isDraft
+        ? <DraftBadge label={t("status.draft")} />
+        : isOrganizer
+          ? (
+              <Badge variant="outline" className="gap-1 border-primary/40 text-xs text-primary">
+                <Crown className="size-3" />
+                {tDashboard("role.host")}
+              </Badge>
+            )
+          : isRegistered
+            ? (
+                <Badge variant="outline" className="gap-1 border-primary/40 text-xs text-primary">
+                  <Check className="size-3" />
+                  {tDashboard("registrationStatus.registered")}
+                </Badge>
+              )
+            : isWaitlisted
+              ? (
+                  <Badge variant="secondary" className="gap-1 text-xs">
+                    <Clock className="size-3" />
+                    {tDashboard("registrationStatus.waitlisted")}
+                  </Badge>
+                )
+              : null;
+
   return (
     <div className="flex gap-0">
       {/* Date column */}
@@ -127,30 +155,17 @@ export async function MomentTimelineItem({
             <div className="flex items-center gap-4 p-4">
               {/* Content */}
               <div className="min-w-0 flex-1 space-y-1.5">
-                {/* Time + badge rôle — sur la même ligne */}
-                <div className="flex items-center gap-2">
-                  <p className={`text-xs ${isPast ? "text-muted-foreground/60" : "text-muted-foreground"}`}>{timeStr}</p>
-                  {!isCancelled && variant === "dashboard" && (
-                    <>
-                      {isDraft ? (
-                        <DraftBadge label={t("status.draft")} />
-                      ) : isOrganizer ? (
-                        <Badge variant="outline" className="shrink-0 gap-1 border-primary/40 text-xs text-primary">
-                          <Crown className="size-3" />
-                          <span className="hidden sm:inline">{tDashboard("role.host")}</span>
-                        </Badge>
-                      ) : isRegistered ? (
-                        <Badge variant="outline" className="shrink-0 gap-1 border-primary/40 text-xs text-primary">
-                          <Check className="size-3" />
-                          <span className="hidden sm:inline">{tDashboard("registrationStatus.registered")}</span>
-                        </Badge>
-                      ) : isWaitlisted ? (
-                        <Badge variant="secondary" className="shrink-0 gap-1 text-xs">
-                          <Clock className="size-3" />
-                          <span className="hidden sm:inline">{tDashboard("registrationStatus.waitlisted")}</span>
-                        </Badge>
-                      ) : null}
-                    </>
+                {/* Heure + lieu */}
+                <div className={`flex items-center gap-3 text-xs ${isPast ? "text-muted-foreground/60" : "text-muted-foreground"}`}>
+                  <span className="flex shrink-0 items-center gap-1.5">
+                    <Clock className="size-3.5 shrink-0" />
+                    {timeStr}
+                  </span>
+                  {locationLabel && (
+                    <span className="flex min-w-0 items-center gap-1.5">
+                      <LocationIcon className="size-3.5 shrink-0" />
+                      <span className="truncate">{locationLabel}</span>
+                    </span>
                   )}
                 </div>
 
@@ -182,13 +197,8 @@ export async function MomentTimelineItem({
                   </div>
                 )}
 
-                {/* Location */}
-                {locationLabel && (
-                  <div className={`flex items-center gap-1.5 text-xs ${isPast ? "text-muted-foreground/60" : "text-muted-foreground"}`}>
-                    <LocationIcon className="size-3.5 shrink-0" />
-                    <span className="truncate">{locationLabel}</span>
-                  </div>
-                )}
+                {/* Badge statut/rôle */}
+                {statusBadge && <div>{statusBadge}</div>}
               </div>
 
               {/* Thumbnail */}

--- a/src/components/circles/moment-timeline-item.tsx
+++ b/src/components/circles/moment-timeline-item.tsx
@@ -157,7 +157,7 @@ export async function MomentTimelineItem({
             {/* Corps de la carte */}
             <div className="flex items-center gap-4 p-4">
               {/* Content */}
-              <div className="min-w-0 flex-1 space-y-2">
+              <div className="flex min-w-0 flex-1 flex-col gap-2">
                 {/* Heure + lieu (heure toujours masquée mobile ; ligne entière masquée mobile en variant dashboard) */}
                 <div
                   className={`${variant === "dashboard" ? "hidden sm:flex" : "flex"} items-center gap-3 text-xs ${
@@ -176,9 +176,11 @@ export async function MomentTimelineItem({
                   )}
                 </div>
 
-                {/* Title */}
+                {/* Title (en variant public, passe en première ligne sur mobile) */}
                 <p
                   className={`truncate font-semibold leading-snug ${
+                    variant === "public" ? "order-first sm:order-none" : ""
+                  } ${
                     isCancelled
                       ? "text-muted-foreground line-through"
                       : isPast

--- a/src/components/moments/dashboard-moment-card.tsx
+++ b/src/components/moments/dashboard-moment-card.tsx
@@ -249,11 +249,11 @@ export function DashboardMomentCard(props: DashboardMomentCardProps) {
                 alt={momentData.title}
                 width={100}
                 height={100}
-                className={`size-16 shrink-0 rounded-xl object-cover sm:size-[100px] ${isPast ? "opacity-40 grayscale" : ""}`}
+                className={`size-[100px] shrink-0 rounded-xl object-cover ${isPast ? "opacity-40 grayscale" : ""}`}
               />
             ) : (
               <div
-                className={`size-16 shrink-0 rounded-xl sm:size-[100px] ${isPast ? "opacity-40 grayscale" : ""}`}
+                className={`size-[100px] shrink-0 rounded-xl ${isPast ? "opacity-40 grayscale" : ""}`}
                 style={{ background: gradient }}
               />
             )}

--- a/src/components/moments/dashboard-moment-card.tsx
+++ b/src/components/moments/dashboard-moment-card.tsx
@@ -206,7 +206,7 @@ export function DashboardMomentCard(props: DashboardMomentCardProps) {
 
               {/* Title */}
               <p
-                className={`truncate font-semibold leading-snug ${
+                className={`line-clamp-2 font-semibold leading-snug ${
                   isPast ? "text-muted-foreground" : "group-hover:text-primary dark:group-hover:text-[oklch(0.76_0.27_341)] transition-colors"
                 }`}
               >

--- a/src/components/moments/dashboard-moment-card.tsx
+++ b/src/components/moments/dashboard-moment-card.tsx
@@ -6,7 +6,7 @@ import { useTranslations, useLocale } from "next-intl";
 import { Link } from "@/i18n/navigation";
 import { Badge } from "@/components/ui/badge";
 import { DraftBadge } from "@/components/badges/draft-badge";
-import { MapPin, Globe, Clock } from "lucide-react";
+import { MapPin, Globe, Clock, Users } from "lucide-react";
 import { AttendeeAvatarStack } from "@/components/moments/attendee-avatar-stack";
 import { getMomentGradient } from "@/lib/gradient";
 import { formatWeekdayAndDate, formatTime } from "@/lib/format-date";
@@ -219,11 +219,12 @@ export function DashboardMomentCard(props: DashboardMomentCardProps) {
               {/* Communauté + badges (badges desktop only) */}
               <div className="flex items-center gap-2">
                 <span
-                  className={`truncate rounded-full border bg-muted/50 px-3 py-0.5 text-xs ${
+                  className={`flex min-w-0 items-center gap-1.5 rounded-full border bg-muted/50 px-3 py-0.5 text-xs ${
                     isPast ? "border-foreground/10 text-muted-foreground/60" : "border-foreground/20 text-muted-foreground"
                   }`}
                 >
-                  {momentData.circleName}
+                  <Users className="size-3 shrink-0" />
+                  <span className="truncate">{momentData.circleName}</span>
                 </span>
                 <div className="hidden items-center gap-2 sm:flex">
                   {!isPast && isDraft && <DraftBadge label={tMoment("status.draft")} />}

--- a/src/components/moments/dashboard-moment-card.tsx
+++ b/src/components/moments/dashboard-moment-card.tsx
@@ -6,7 +6,7 @@ import { useTranslations, useLocale } from "next-intl";
 import { Link } from "@/i18n/navigation";
 import { Badge } from "@/components/ui/badge";
 import { DraftBadge } from "@/components/badges/draft-badge";
-import { MapPin, Globe, Check, Clock, Crown } from "lucide-react";
+import { MapPin, Globe, Clock } from "lucide-react";
 import { AttendeeAvatarStack } from "@/components/moments/attendee-avatar-stack";
 import { getMomentGradient } from "@/lib/gradient";
 import { formatWeekdayAndDate, formatTime } from "@/lib/format-date";
@@ -114,23 +114,11 @@ export function DashboardMomentCard(props: DashboardMomentCardProps) {
         ? t("hybrid")
         : momentData.locationName;
 
-  const roleBadge = !isPast && !isDraft ? (
-    isOrganizerView || isOrganizer ? (
-      <Badge variant="outline" className="shrink-0 gap-1 border-primary/40 text-xs text-primary">
-        <Crown className="size-3" />
-        <span className="hidden sm:inline">{t("role.host")}</span>
-      </Badge>
-    ) : isRegistered ? (
-      <Badge variant="outline" className="shrink-0 gap-1 border-primary/40 text-xs text-primary">
-        <Check className="size-3" />
-        <span className="hidden sm:inline">{t("registrationStatus.registered")}</span>
-      </Badge>
-    ) : isWaitlisted ? (
-      <Badge variant="secondary" className="shrink-0 gap-1 text-xs">
-        <Clock className="size-3" />
-        <span className="hidden sm:inline">{t("registrationStatus.waitlisted")}</span>
-      </Badge>
-    ) : null
+  const roleBadge = !isPast && !isDraft && isWaitlisted ? (
+    <Badge variant="secondary" className="shrink-0 gap-1 text-xs">
+      <Clock className="size-3" />
+      <span className="hidden sm:inline">{t("registrationStatus.waitlisted")}</span>
+    </Badge>
   ) : null;
 
   const LocationIcon = momentData.locationType === "IN_PERSON" ? MapPin : Globe;

--- a/src/components/moments/dashboard-moment-card.tsx
+++ b/src/components/moments/dashboard-moment-card.tsx
@@ -182,7 +182,7 @@ export function DashboardMomentCard(props: DashboardMomentCardProps) {
           className="group block"
         >
           <div
-            className={`bg-card flex items-start gap-3 rounded-xl border p-3 shadow-lg dark:shadow-none transition-colors sm:items-center ${cardBorderClass}`}
+            className={`bg-card flex items-center gap-3 rounded-xl border p-3 shadow-lg dark:shadow-none transition-colors ${cardBorderClass}`}
           >
             {/* Content — LEFT */}
             <div className="min-w-0 flex-1 space-y-1.5">

--- a/src/components/moments/dashboard-moment-card.tsx
+++ b/src/components/moments/dashboard-moment-card.tsx
@@ -114,7 +114,7 @@ export function DashboardMomentCard(props: DashboardMomentCardProps) {
         ? t("hybrid")
         : momentData.locationName;
 
-  const roleBadge = !isPast && !isDraft && isWaitlisted ? (
+  const waitlistedBadge = !isPast && !isDraft && isWaitlisted ? (
     <Badge variant="secondary" className="shrink-0 gap-1 text-xs">
       <Clock className="size-3" />
       <span className="hidden sm:inline">{t("registrationStatus.waitlisted")}</span>
@@ -172,9 +172,7 @@ export function DashboardMomentCard(props: DashboardMomentCardProps) {
           <div
             className={`bg-card flex items-center gap-3 rounded-xl border p-3 shadow-lg dark:shadow-none transition-colors ${cardBorderClass}`}
           >
-            {/* Content — LEFT */}
             <div className="min-w-0 flex-1 space-y-1.5">
-              {/* Heure + lieu (ligne entière masquée mobile : heure dans la colonne date, lieu non affiché) */}
               <div
                 className={`hidden items-center gap-3 text-xs sm:flex ${
                   isPast ? "text-muted-foreground/60" : "text-muted-foreground"
@@ -192,7 +190,6 @@ export function DashboardMomentCard(props: DashboardMomentCardProps) {
                 )}
               </div>
 
-              {/* Title */}
               <p
                 className={`line-clamp-2 font-semibold leading-snug ${
                   isPast ? "text-muted-foreground" : "group-hover:text-primary dark:group-hover:text-[oklch(0.76_0.27_341)] transition-colors"
@@ -201,7 +198,6 @@ export function DashboardMomentCard(props: DashboardMomentCardProps) {
                 {momentData.title}
               </p>
 
-              {/* Inscrits */}
               {momentData.registrationCount > 0 && (
                 <div className={isPast ? "opacity-60" : ""}>
                   <AttendeeAvatarStack
@@ -216,7 +212,6 @@ export function DashboardMomentCard(props: DashboardMomentCardProps) {
                 </div>
               )}
 
-              {/* Communauté + badges (badges desktop only) */}
               <div className="flex items-center gap-2">
                 <span
                   className={`flex min-w-0 items-center gap-1.5 rounded-full border bg-muted/50 px-3 py-0.5 text-xs ${
@@ -228,12 +223,11 @@ export function DashboardMomentCard(props: DashboardMomentCardProps) {
                 </span>
                 <div className="hidden items-center gap-2 sm:flex">
                   {!isPast && isDraft && <DraftBadge label={tMoment("status.draft")} />}
-                  {roleBadge}
+                  {waitlistedBadge}
                 </div>
               </div>
             </div>
 
-            {/* Cover — RIGHT, alignée avec le titre */}
             {momentData.coverImage ? (
               <Image
                 src={momentData.coverImage}

--- a/src/components/moments/dashboard-moment-card.tsx
+++ b/src/components/moments/dashboard-moment-card.tsx
@@ -222,10 +222,8 @@ export function DashboardMomentCard(props: DashboardMomentCardProps) {
                 </div>
               )}
 
-              {/* Badge + Communauté */}
+              {/* Communauté + badge */}
               <div className="flex items-center gap-2">
-                {!isPast && isDraft && <DraftBadge label={tMoment("status.draft")} />}
-                {roleBadge}
                 <span
                   className={`truncate rounded-full border bg-muted/50 px-3 py-0.5 text-xs ${
                     isPast ? "border-foreground/10 text-muted-foreground/60" : "border-foreground/20 text-muted-foreground"
@@ -233,6 +231,8 @@ export function DashboardMomentCard(props: DashboardMomentCardProps) {
                 >
                   {momentData.circleName}
                 </span>
+                {!isPast && isDraft && <DraftBadge label={tMoment("status.draft")} />}
+                {roleBadge}
               </div>
             </div>
 

--- a/src/components/moments/dashboard-moment-card.tsx
+++ b/src/components/moments/dashboard-moment-card.tsx
@@ -228,7 +228,7 @@ export function DashboardMomentCard(props: DashboardMomentCardProps) {
                 </div>
               )}
 
-              {/* Communauté + badge */}
+              {/* Communauté + badges (badges desktop only) */}
               <div className="flex items-center gap-2">
                 <span
                   className={`truncate rounded-full border bg-muted/50 px-3 py-0.5 text-xs ${
@@ -237,8 +237,10 @@ export function DashboardMomentCard(props: DashboardMomentCardProps) {
                 >
                   {momentData.circleName}
                 </span>
-                {!isPast && isDraft && <DraftBadge label={tMoment("status.draft")} />}
-                {roleBadge}
+                <div className="hidden items-center gap-2 sm:flex">
+                  {!isPast && isDraft && <DraftBadge label={tMoment("status.draft")} />}
+                  {roleBadge}
+                </div>
               </div>
             </div>
 

--- a/src/components/moments/dashboard-moment-card.tsx
+++ b/src/components/moments/dashboard-moment-card.tsx
@@ -186,13 +186,13 @@ export function DashboardMomentCard(props: DashboardMomentCardProps) {
           >
             {/* Content — LEFT */}
             <div className="min-w-0 flex-1 space-y-1.5">
-              {/* Heure + lieu (heure masquée en mobile, déplacée dans la colonne date) */}
+              {/* Heure + lieu (ligne entière masquée mobile : heure dans la colonne date, lieu non affiché) */}
               <div
-                className={`flex items-center gap-3 text-xs ${
+                className={`hidden items-center gap-3 text-xs sm:flex ${
                   isPast ? "text-muted-foreground/60" : "text-muted-foreground"
                 }`}
               >
-                <span className="hidden shrink-0 items-center gap-1.5 sm:flex">
+                <span className="flex shrink-0 items-center gap-1.5">
                   <Clock className="size-3.5 shrink-0" />
                   <span suppressHydrationWarning>{timeStr}</span>
                 </span>

--- a/src/components/moments/dashboard-moment-card.tsx
+++ b/src/components/moments/dashboard-moment-card.tsx
@@ -180,22 +180,22 @@ export function DashboardMomentCard(props: DashboardMomentCardProps) {
           >
             {/* Content — LEFT */}
             <div className="min-w-0 flex-1 space-y-1.5">
-              {/* Time + community pill */}
-              <div className="flex items-center gap-2">
-                <p
-                  className={`shrink-0 text-xs ${isPast ? "text-muted-foreground/60" : "text-muted-foreground"}`}
-                  suppressHydrationWarning
-                >
-                  {timeStr}
-                </p>
-                {!isPast && isDraft && <DraftBadge label={tMoment("status.draft")} />}
-                <span
-                  className={`truncate rounded-full border bg-muted/50 px-3 py-0.5 text-xs ${
-                    isPast ? "border-foreground/10 text-muted-foreground/60" : "border-foreground/20 text-muted-foreground"
-                  }`}
-                >
-                  {momentData.circleName}
+              {/* Heure + lieu */}
+              <div
+                className={`flex items-center gap-3 text-xs ${
+                  isPast ? "text-muted-foreground/60" : "text-muted-foreground"
+                }`}
+              >
+                <span className="flex shrink-0 items-center gap-1.5">
+                  <Clock className="size-3.5 shrink-0" />
+                  <span suppressHydrationWarning>{timeStr}</span>
                 </span>
+                {locationLabel && (
+                  <span className="flex min-w-0 items-center gap-1.5">
+                    <LocationIcon className="size-3.5 shrink-0" />
+                    <span className="truncate">{locationLabel}</span>
+                  </span>
+                )}
               </div>
 
               {/* Title */}
@@ -207,35 +207,33 @@ export function DashboardMomentCard(props: DashboardMomentCardProps) {
                 {momentData.title}
               </p>
 
-              {/* Location */}
-              {locationLabel && (
-                <div
-                  className={`flex items-center gap-1.5 text-xs ${
-                    isPast ? "text-muted-foreground/60" : "text-muted-foreground"
-                  }`}
-                >
-                  <LocationIcon className="size-3 shrink-0" />
-                  <span className="truncate">{locationLabel}</span>
+              {/* Inscrits */}
+              {momentData.registrationCount > 0 && (
+                <div className={isPast ? "opacity-60" : ""}>
+                  <AttendeeAvatarStack
+                    attendees={momentData.topAttendees}
+                    totalCount={momentData.registrationCount}
+                    label={
+                      momentData.topAttendees.length < momentData.registrationCount
+                        ? tMoment("registrations.moreRegistered", { count: momentData.registrationCount - momentData.topAttendees.length })
+                        : tMoment("registrations.registered", { count: momentData.registrationCount })
+                    }
+                  />
                 </div>
               )}
 
-              {/* Inscrits + badge rôle */}
-              {(momentData.registrationCount > 0 || roleBadge) && (
-                <div className={`flex items-center gap-2 ${isPast ? "opacity-60" : ""}`}>
-                  {momentData.registrationCount > 0 && (
-                    <AttendeeAvatarStack
-                      attendees={momentData.topAttendees}
-                      totalCount={momentData.registrationCount}
-                      label={
-                        momentData.topAttendees.length < momentData.registrationCount
-                          ? tMoment("registrations.moreRegistered", { count: momentData.registrationCount - momentData.topAttendees.length })
-                          : tMoment("registrations.registered", { count: momentData.registrationCount })
-                      }
-                    />
-                  )}
-                  {roleBadge}
-                </div>
-              )}
+              {/* Badge + Communauté */}
+              <div className="flex items-center gap-2">
+                {!isPast && isDraft && <DraftBadge label={tMoment("status.draft")} />}
+                {roleBadge}
+                <span
+                  className={`truncate rounded-full border bg-muted/50 px-3 py-0.5 text-xs ${
+                    isPast ? "border-foreground/10 text-muted-foreground/60" : "border-foreground/20 text-muted-foreground"
+                  }`}
+                >
+                  {momentData.circleName}
+                </span>
+              </div>
             </div>
 
             {/* Cover — RIGHT, alignée avec le titre */}

--- a/src/components/moments/dashboard-moment-card.tsx
+++ b/src/components/moments/dashboard-moment-card.tsx
@@ -159,6 +159,12 @@ export function DashboardMomentCard(props: DashboardMomentCardProps) {
             </p>
           </>
         )}
+        <p
+          className={`mt-0.5 text-xs sm:hidden ${isPast ? "text-muted-foreground/60" : "text-muted-foreground"}`}
+          suppressHydrationWarning
+        >
+          {timeStr}
+        </p>
       </div>
 
       {/* Dot + vertical line */}
@@ -180,13 +186,13 @@ export function DashboardMomentCard(props: DashboardMomentCardProps) {
           >
             {/* Content — LEFT */}
             <div className="min-w-0 flex-1 space-y-1.5">
-              {/* Heure + lieu */}
+              {/* Heure + lieu (heure masquée en mobile, déplacée dans la colonne date) */}
               <div
                 className={`flex items-center gap-3 text-xs ${
                   isPast ? "text-muted-foreground/60" : "text-muted-foreground"
                 }`}
               >
-                <span className="flex shrink-0 items-center gap-1.5">
+                <span className="hidden shrink-0 items-center gap-1.5 sm:flex">
                   <Clock className="size-3.5 shrink-0" />
                   <span suppressHydrationWarning>{timeStr}</span>
                 </span>


### PR DESCRIPTION
## Résumé

Refonte UX des cards événement (timeline Communauté + dashboard d'accueil) et de la card Communauté du dashboard. Mobile et desktop traités séparément, avec des décisions distinctes selon le breakpoint.

S'inscrit dans le chantier `spec/refonte-ui-circle-moment.md`.

## Cards événement — nouvelle disposition

### Carte 1 — Timeline Communauté (`MomentTimelineItem`)

| Ligne | Desktop | Mobile |
|---|---|---|
| 1 | `Clock` + heure · `MapPin`/`Globe` + lieu | `MapPin`/`Globe` + lieu (heure cachée) |
| 2 | Titre (line-clamp-2) | Titre (line-clamp-2) |
| 3 | Avatar stack inscrits | Avatar stack inscrits |
| 4 | Badge statut/rôle (DRAFT / Inscrit / En attente) | omis |

Heure mobile déplacée dans la colonne date à gauche.

### Carte 2 — Dashboard d'accueil (`DashboardMomentCard`)

| Ligne | Desktop | Mobile |
|---|---|---|
| 1 | `Clock` + heure · `MapPin`/`Globe` + lieu | omis (heure dans colonne date) |
| 2 | Titre (line-clamp-2) | Titre (line-clamp-2) |
| 3 | Avatar stack inscrits | Avatar stack inscrits |
| 4 | Pill `Users` + Communauté · Badges (DRAFT / En attente) | Pill Communauté seule |

### Carte Communauté (`DashboardCircleCard`)

- Cover unifié à 100×100 sur tous les breakpoints
- Suppression de la description et du compteur d'événements à venir (ligne meta)
- Badge rôle réduit au seul cas PENDING (Crown / Users retirés, redondants avec le filtre dédié)
- Bloc « Prochain événement » refondu : header « PROCHAIN ÉVÉNEMENT » uppercase, date+heure en ligne 1, titre 2 lignes max en ligne 2, largeur fixe 180px

## Ménage transverse

- **Badge Organisateur supprimé** sur la timeline Communauté (variant dashboard) : redondant avec le contexte de page. Prop `isOrganizer` retirée du composant et de ses 2 callers.
- **Avatar stack des inscrits unifié** sur la timeline Communauté : avant en mode texte sur la vue dashboard (oubli de la refonte précédente), maintenant en avatar stack partout.
- **Pluralisation ICU** appliquée sur les compteurs d'inscrits et de membres (FR + EN) → fini les `inscrit(s)` / `member(s)`.

## Changements techniques

- `MomentTimelineItem` : prop `isOrganizer` retirée, doublon ligne lieu mobile/desktop fusionné, badges Inscrit / En attente sur leur propre ligne (desktop), DraftBadge avec nouvelle prop `showLabelOnMobile`
- `DashboardMomentCard` : `roleBadge` renommé `waitlistedBadge` (ne couvre plus que ce cas), badges desktop-only via wrapper unique
- Page `/dashboard/circles/[slug]` : ajout de `findTopRegistrantsByMomentIds` au `Promise.all` SSR
- `messages/{fr,en}.json` : 7 clés pluralisées (4 inscrits + 3 membres)

## Reportés post-merge (refactor structurel)

Identifiés par `/simplify`, méritent une PR refactor dédiée :

- Extraction de `<TimelineDateColumn>`, `<MomentMetaRow>`, `<RegistrationStatusBadge>`, helper `buildAttendeeLabel` (factorisation entre les 3 cards)
- Optimisation N+1 : `findTopRegistrantsByMomentIds` fait `momentIds.length` requêtes parallèles. Remplacer par une window function Postgres (`ROW_NUMBER() PARTITION BY momentId`). À mesurer en prod d'abord, gain réel à confirmer.

## Plan de test

- [ ] Page Communauté publique `/circles/[slug]` desktop : timeline avec heure+lieu ligne 1, titre, inscrits avatar stack, pas de badge
- [ ] Page Communauté publique `/circles/[slug]` mobile : lieu en ligne 1 (titre dessous), inscrits, pas de heure (dans colonne date)
- [ ] Page dashboard Communauté `/dashboard/circles/[slug]` desktop : ligne heure+lieu, titre, inscrits, badge si Brouillon/Inscrit/En attente
- [ ] Page dashboard Communauté `/dashboard/circles/[slug]` mobile : lieu sur ligne dédiée, titre, inscrits, badge omis
- [ ] Dashboard d'accueil `/dashboard` desktop : heure+lieu, titre, inscrits, pill Communauté + badge waitlisted/draft
- [ ] Dashboard d'accueil `/dashboard` mobile : titre, inscrits, pill Communauté seule (badges desktop-only)
- [ ] Carte Communauté du dashboard : icône Users dans la pill, bloc « Prochain événement » 180px desktop avec titre 2 lignes max
- [ ] Compteurs : « 1 inscrit » / « 5 inscrits », « 1 membre » / « 5 membres » (pluralisation ICU)

🤖 Generated with [Claude Code](https://claude.com/claude-code)