### PR TITLE
fix(email): résoudre la locale par destinataire + i18n magic link

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1151,6 +1151,16 @@
       "notRefunded": "No refund issued (non-refundable event).",
       "manageCta": "Manage registrations"
     },
+    "magicLink": {
+      "subject": "Your sign-in link — The Playground",
+      "preview": "Your sign-in link to The Playground",
+      "heading": "Your sign-in link",
+      "bodyText": "Click the button below to sign in. This link is valid for 15 minutes and can only be used once.",
+      "ctaLabel": "Sign in →",
+      "expiryText": "Expires in 15 minutes · Single use",
+      "securityText": "Didn't request this link? Your account is still secure, just ignore this email.",
+      "footer": "The Playground · If you didn't request this link, you can safely ignore it."
+    },
     "common": {
       "dateLabel": "Date",
       "locationLabel": "Location",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1151,6 +1151,16 @@
       "notRefunded": "Aucun remboursement effectué (événement non remboursable).",
       "manageCta": "Gérer les inscriptions"
     },
+    "magicLink": {
+      "subject": "Votre lien de connexion — The Playground",
+      "preview": "Votre lien de connexion à The Playground",
+      "heading": "Votre lien de connexion",
+      "bodyText": "Cliquez sur le bouton ci-dessous pour vous connecter. Ce lien est valable 15 minutes et ne peut être utilisé qu'une seule fois.",
+      "ctaLabel": "Se connecter →",
+      "expiryText": "Expire dans 15 minutes · Usage unique",
+      "securityText": "Vous n'avez pas demandé ce lien ? Votre compte reste sécurisé, ignorez simplement cet email.",
+      "footer": "The Playground · Si vous n'avez pas demandé ce lien, ignorez cet email en toute sécurité."
+    },
     "common": {
       "dateLabel": "Date",
       "locationLabel": "Lieu",

--- a/src/app/[locale]/(routes)/lab/emails/page.tsx
+++ b/src/app/[locale]/(routes)/lab/emails/page.tsx
@@ -363,6 +363,18 @@ async function buildTemplates(): Promise<{ id: string; label: string; html: stri
       element: MagicLinkEmail({
         url: `${BASE_URL}/auth/verify?token=abc123`,
         baseUrl: BASE_URL,
+        strings: {
+          preview: "Votre lien de connexion à The Playground",
+          heading: "Votre lien de connexion",
+          bodyText:
+            "Cliquez sur le bouton ci-dessous pour vous connecter. Ce lien est valable 15 minutes et ne peut être utilisé qu'une seule fois.",
+          ctaLabel: "Se connecter →",
+          expiryText: "Expire dans 15 minutes · Usage unique",
+          securityText:
+            "Vous n'avez pas demandé ce lien ? Votre compte reste sécurisé, ignorez simplement cet email.",
+          footer:
+            "The Playground · Si vous n'avez pas demandé ce lien, ignorez cet email en toute sécurité.",
+        },
       }),
     },
     {

--- a/src/app/actions/broadcast-moment.ts
+++ b/src/app/actions/broadcast-moment.ts
@@ -4,7 +4,7 @@ import * as Sentry from "@sentry/nextjs";
 import { formatInTimeZone } from "date-fns-tz";
 import { fr } from "date-fns/locale/fr";
 import { enUS } from "date-fns/locale/en-US";
-import { getLocale, getTranslations } from "next-intl/server";
+import { getTranslations } from "next-intl/server";
 
 const PLATFORM_TIMEZONE = "Europe/Paris";
 import { revalidatePath } from "next/cache";
@@ -18,6 +18,7 @@ import { createResendEmailService } from "@/infrastructure/services";
 import type { ActionResult } from "./types";
 import { isAdminInHostMode } from "@/lib/admin-host-mode";
 import { isActiveOrganizer } from "@/domain/models/circle";
+import { DEFAULT_RECIPIENT_LOCALE } from "@/lib/email/email-locale";
 
 const emailService = createResendEmailService();
 
@@ -92,9 +93,10 @@ export async function broadcastMomentAction(
   const allUserIds = members.map((r) => r.userId);
   const prefsMap = await prismaUserRepository.findNotificationPreferencesByIds(allUserIds);
 
-  // Résoudre la locale dans le contexte de la request
-  const locale = await getLocale();
-  const t = await getTranslations("Email.broadcastMoment");
+  // Tous les destinataires (membres du Circle) sont des "tiers" vis-à-vis du
+  // déclencheur Host → broadcast formaté dans la locale par défaut FR.
+  const locale = DEFAULT_RECIPIENT_LOCALE;
+  const t = await getTranslations({ locale, namespace: "Email.broadcastMoment" });
 
   const momentDate = formatMomentDate(moment.startsAt, locale);
   const momentDateMonth = formatMomentDateMonth(moment.startsAt, locale);

--- a/src/app/actions/circle.ts
+++ b/src/app/actions/circle.ts
@@ -2,7 +2,7 @@
 
 import { after } from "next/server";
 import * as Sentry from "@sentry/nextjs";
-import { getLocale, getTranslations } from "next-intl/server";
+import { getTranslations } from "next-intl/server";
 import { auth } from "@/infrastructure/auth/auth.config";
 import { prismaCircleRepository } from "@/infrastructure/repositories";
 import { prisma } from "@/infrastructure/db/prisma";
@@ -44,6 +44,11 @@ import { isAdminUser, resolveCircleRepository } from "@/lib/admin-host-mode";
 import { getDisplayName } from "@/lib/display-name";
 import { isValidUrl } from "@/lib/url";
 import { invalidateDashboardCache } from "@/lib/dashboard-cache";
+import {
+  buildEmailLocaleResolver,
+  DEFAULT_RECIPIENT_LOCALE,
+  type EmailLocaleResolver,
+} from "@/lib/email/email-locale";
 
 export async function createCircleAction(
   formData: FormData
@@ -261,8 +266,8 @@ export async function joinCircleDirectlyAction(
     );
 
     if (!alreadyMember) {
-      const t = await getTranslations("Email");
-      notifyHostCircleJoin(circleId, userId, pendingApproval, t).catch((err) => {
+      const resolver = await buildEmailLocaleResolver(userId);
+      notifyHostCircleJoin(circleId, userId, pendingApproval, resolver).catch((err) => {
         console.error("[joinCircleDirectlyAction] Erreur notification host :", err);
         Sentry.captureException(err);
       });
@@ -314,7 +319,8 @@ export async function removeCircleMemberAction(
       }
     );
 
-    const t = await getTranslations("Email");
+    // Déclencheur = Host, destinataire = membre retiré → membre ≠ déclencheur → FR par défaut
+    const resolver = await buildEmailLocaleResolver(hostUserId);
     after(async () => {
       try {
         const [targetUser, circle] = await Promise.all([
@@ -324,6 +330,7 @@ export async function removeCircleMemberAction(
         if (!targetUser || !circle) return;
 
         const memberName = getDisplayName(targetUser.firstName, targetUser.lastName, targetUser.email);
+        const t = await resolver.translationsFor(targetUserId);
         const footer = t("common.footer");
 
         await emailService.sendMemberRemovedFromCircle({
@@ -383,7 +390,12 @@ export async function inviteToCircleByEmailAction(
     const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? "";
     const circleUrl = `${baseUrl}/circles/${circle.slug}`;
     const inviterName = session.user.name ?? session.user.email ?? "";
-    const t = await getTranslations("Email.circleInvitation");
+    // Invités = adresses email seules → impossible de les rattacher à un userId.
+    // Tous traités comme "tiers" → locale par défaut FR.
+    const t = await getTranslations({
+      locale: DEFAULT_RECIPIENT_LOCALE,
+      namespace: "Email.circleInvitation",
+    });
 
     after(async () => {
       try {
@@ -430,7 +442,8 @@ export async function approveCircleMembershipAction(
       { circleRepository: prismaCircleRepository }
     );
 
-    const t = await getTranslations("Email");
+    // Déclencheur = Host, destinataire = membre approuvé → ≠ déclencheur → FR par défaut
+    const resolver = await buildEmailLocaleResolver(hostUserId);
     after(async () => {
       try {
         const [circle, user] = await Promise.all([
@@ -439,6 +452,7 @@ export async function approveCircleMembershipAction(
         ]);
         if (!circle || !user) return;
         const playerName = getDisplayName(user.firstName, user.lastName, user.email);
+        const t = await resolver.translationsFor(memberUserId);
         await emailService.sendApprovalNotification({
           to: user.email,
           recipientName: playerName,
@@ -478,7 +492,8 @@ export async function rejectCircleMembershipAction(
       { circleRepository: prismaCircleRepository }
     );
 
-    const t = await getTranslations("Email");
+    // Déclencheur = Host, destinataire = membre rejeté → ≠ déclencheur → FR par défaut
+    const resolver = await buildEmailLocaleResolver(hostUserId);
     after(async () => {
       try {
         const [circle, user] = await Promise.all([
@@ -487,6 +502,7 @@ export async function rejectCircleMembershipAction(
         ]);
         if (!circle || !user) return;
         const playerName = getDisplayName(user.firstName, user.lastName, user.email);
+        const t = await resolver.translationsFor(memberUserId);
         await emailService.sendApprovalNotification({
           to: user.email,
           recipientName: playerName,
@@ -515,7 +531,7 @@ async function notifyHostCircleJoin(
   circleId: string,
   userId: string,
   pendingApproval: boolean,
-  t: Awaited<ReturnType<typeof getTranslations<"Email">>>,
+  resolver: EmailLocaleResolver,
   circleSlug?: string,
   circleName?: string,
 ): Promise<void> {
@@ -540,6 +556,7 @@ async function notifyHostCircleJoin(
       hosts.map(async (host) => {
         const prefs = prefsMap.get(host.userId);
         if (!prefs?.notifyNewRegistration) return;
+        const t = await resolver.translationsFor(host.userId);
         const hostName =
           [host.user.firstName, host.user.lastName].filter(Boolean).join(" ") || host.user.email;
         return emailService.sendApprovalNotification({
@@ -559,6 +576,8 @@ async function notifyHostCircleJoin(
     );
   } else {
     // Membre accepté directement → notification classique
+    // Les Hosts ne sont pas le déclencheur ici → tous reçoivent en locale par défaut.
+    const t = await resolver.defaultTranslations();
     await notifyHostNewCircleMember(
       circleId,
       circle.slug,
@@ -589,7 +608,10 @@ export async function promoteToCoHostAction(
   const hostUserId = session.user.id;
 
   return toActionResult(async () => {
-    const t = await getTranslations("Email.coHostPromoted");
+    // Déclencheur = Host, destinataire = co-host promu → ≠ déclencheur → FR par défaut
+    const resolver = await buildEmailLocaleResolver(hostUserId);
+    const targetLocale = resolver.resolveFor(targetUserId);
+    const t = await getTranslations({ locale: targetLocale, namespace: "Email.coHostPromoted" });
     await promoteToCoHost(
       { circleId, hostUserId, targetUserId },
       {
@@ -633,7 +655,10 @@ export async function demoteFromCoHostAction(
   const hostUserId = session.user.id;
 
   return toActionResult(async () => {
-    const t = await getTranslations("Email.coHostDemoted");
+    // Déclencheur = Host, destinataire = co-host dégradé → ≠ déclencheur → FR par défaut
+    const resolver = await buildEmailLocaleResolver(hostUserId);
+    const targetLocale = resolver.resolveFor(targetUserId);
+    const t = await getTranslations({ locale: targetLocale, namespace: "Email.coHostDemoted" });
     await demoteFromCoHost(
       { circleId, hostUserId, targetUserId },
       {

--- a/src/app/actions/circle.ts
+++ b/src/app/actions/circle.ts
@@ -319,7 +319,6 @@ export async function removeCircleMemberAction(
       }
     );
 
-    // Déclencheur = Host, destinataire = membre retiré → membre ≠ déclencheur → FR par défaut
     const resolver = await buildEmailLocaleResolver(hostUserId);
     after(async () => {
       try {
@@ -442,7 +441,6 @@ export async function approveCircleMembershipAction(
       { circleRepository: prismaCircleRepository }
     );
 
-    // Déclencheur = Host, destinataire = membre approuvé → ≠ déclencheur → FR par défaut
     const resolver = await buildEmailLocaleResolver(hostUserId);
     after(async () => {
       try {
@@ -492,7 +490,6 @@ export async function rejectCircleMembershipAction(
       { circleRepository: prismaCircleRepository }
     );
 
-    // Déclencheur = Host, destinataire = membre rejeté → ≠ déclencheur → FR par défaut
     const resolver = await buildEmailLocaleResolver(hostUserId);
     after(async () => {
       try {
@@ -532,13 +529,9 @@ async function notifyHostCircleJoin(
   userId: string,
   pendingApproval: boolean,
   resolver: EmailLocaleResolver,
-  circleSlug?: string,
-  circleName?: string,
 ): Promise<void> {
   const [circle, user] = await Promise.all([
-    circleSlug && circleName
-      ? Promise.resolve({ id: circleId, slug: circleSlug, name: circleName })
-      : prismaCircleRepository.findById(circleId),
+    prismaCircleRepository.findById(circleId),
     prismaUserRepository.findById(userId),
   ]);
   if (!circle || !user) return;
@@ -608,10 +601,8 @@ export async function promoteToCoHostAction(
   const hostUserId = session.user.id;
 
   return toActionResult(async () => {
-    // Déclencheur = Host, destinataire = co-host promu → ≠ déclencheur → FR par défaut
     const resolver = await buildEmailLocaleResolver(hostUserId);
-    const targetLocale = resolver.resolveFor(targetUserId);
-    const t = await getTranslations({ locale: targetLocale, namespace: "Email.coHostPromoted" });
+    const t = await resolver.translationsFor(targetUserId);
     await promoteToCoHost(
       { circleId, hostUserId, targetUserId },
       {
@@ -620,19 +611,19 @@ export async function promoteToCoHostAction(
         emailService,
         emailStrings: {
           promotedBy: async ({ inviterName, circleName }) => ({
-            subject: t("subject", { circleName }),
-            heading: t("heading", { circleName }),
-            intro: t("intro", { inviterName }),
-            rightsTitle: t("rightsTitle"),
-            rightCreateEvents: t("rightCreateEvents"),
-            rightManageRegistrations: t("rightManageRegistrations"),
-            rightUpdateCircle: t("rightUpdateCircle"),
-            rightBroadcast: t("rightBroadcast"),
-            rightReceiveNotifications: t("rightReceiveNotifications"),
-            limitsNote: t("limitsNote"),
-            ctaLabel: t("ctaLabel"),
-            footer: t("footer"),
-            leaveLink: t("leaveLink"),
+            subject: t("coHostPromoted.subject", { circleName }),
+            heading: t("coHostPromoted.heading", { circleName }),
+            intro: t("coHostPromoted.intro", { inviterName }),
+            rightsTitle: t("coHostPromoted.rightsTitle"),
+            rightCreateEvents: t("coHostPromoted.rightCreateEvents"),
+            rightManageRegistrations: t("coHostPromoted.rightManageRegistrations"),
+            rightUpdateCircle: t("coHostPromoted.rightUpdateCircle"),
+            rightBroadcast: t("coHostPromoted.rightBroadcast"),
+            rightReceiveNotifications: t("coHostPromoted.rightReceiveNotifications"),
+            limitsNote: t("coHostPromoted.limitsNote"),
+            ctaLabel: t("coHostPromoted.ctaLabel"),
+            footer: t("coHostPromoted.footer"),
+            leaveLink: t("coHostPromoted.leaveLink"),
           }),
         },
       }
@@ -655,10 +646,8 @@ export async function demoteFromCoHostAction(
   const hostUserId = session.user.id;
 
   return toActionResult(async () => {
-    // Déclencheur = Host, destinataire = co-host dégradé → ≠ déclencheur → FR par défaut
     const resolver = await buildEmailLocaleResolver(hostUserId);
-    const targetLocale = resolver.resolveFor(targetUserId);
-    const t = await getTranslations({ locale: targetLocale, namespace: "Email.coHostDemoted" });
+    const t = await resolver.translationsFor(targetUserId);
     await demoteFromCoHost(
       { circleId, hostUserId, targetUserId },
       {
@@ -667,14 +656,14 @@ export async function demoteFromCoHostAction(
         emailService,
         emailStrings: {
           demoted: async ({ circleName }) => ({
-            subject: t("subject", { circleName }),
-            heading: t("heading", { circleName }),
-            intro: t("intro", { circleName }),
-            newRoleLabel: t("newRoleLabel"),
-            registrationsNote: t("registrationsNote"),
-            ctaLabel: t("ctaLabel"),
-            footer: t("footer"),
-            preferencesLink: t("preferencesLink"),
+            subject: t("coHostDemoted.subject", { circleName }),
+            heading: t("coHostDemoted.heading", { circleName }),
+            intro: t("coHostDemoted.intro", { circleName }),
+            newRoleLabel: t("coHostDemoted.newRoleLabel"),
+            registrationsNote: t("coHostDemoted.registrationsNote"),
+            ctaLabel: t("coHostDemoted.ctaLabel"),
+            footer: t("coHostDemoted.footer"),
+            preferencesLink: t("coHostDemoted.preferencesLink"),
           }),
         },
       }

--- a/src/app/actions/comment.ts
+++ b/src/app/actions/comment.ts
@@ -1,7 +1,6 @@
 "use server";
 
 import * as Sentry from "@sentry/nextjs";
-import { getLocale, getTranslations } from "next-intl/server";
 import { fileTypeFromBuffer } from "file-type";
 import { auth } from "@/infrastructure/auth/auth.config";
 import {
@@ -25,6 +24,10 @@ import {
 import type { Comment } from "@/domain/models/comment";
 import type { ActionResult } from "./types";
 import { toActionResult } from "./helpers/to-action-result";
+import {
+  buildEmailLocaleResolver,
+  type EmailLocaleResolver,
+} from "@/lib/email/email-locale";
 
 const emailService = createResendEmailService();
 
@@ -123,10 +126,9 @@ export async function addCommentAction(
     );
 
     // Resolve i18n in the request context (before fire-and-forget)
-    const locale = await getLocale();
-    const t = await getTranslations("Email");
+    const resolver = await buildEmailLocaleResolver(userId);
 
-    sendCommentNotifications(momentId, userId, content, t, locale).catch(
+    sendCommentNotifications(momentId, userId, content, resolver).catch(
       (err) => {
         console.error(err);
         Sentry.captureException(err);
@@ -162,14 +164,11 @@ export async function deleteCommentAction(
 
 // --- Fire-and-forget email helpers ---
 
-type TranslationFunction = Awaited<ReturnType<typeof getTranslations<"Email">>>;
-
 async function sendCommentNotifications(
   momentId: string,
   commenterId: string,
   content: string,
-  t: TranslationFunction,
-  _locale: string
+  resolver: EmailLocaleResolver
 ): Promise<void> {
   const [commenter, moment] = await Promise.all([
     prismaUserRepository.findById(commenterId),
@@ -226,25 +225,12 @@ async function sendCommentNotifications(
   const prefsMap =
     await prismaUserRepository.findNotificationPreferencesByIds(recipientIds);
 
-  const emailStrings = {
-    subject: t("commentNotification.subject", {
-      playerName,
-      momentTitle: moment.title,
-    }),
-    heading: t("commentNotification.heading"),
-    message: t("commentNotification.message", {
-      playerName,
-      momentTitle: moment.title,
-    }),
-    commentPreviewLabel: t("commentNotification.commentPreviewLabel"),
-    viewCommentCta: t("commentNotification.viewCommentCta"),
-    footer: t("common.footer"),
-  };
-
   await Promise.all(
     [...recipientMap.values()].map(async (recipient) => {
       const prefs = prefsMap.get(recipient.userId);
       if (!prefs?.notifyNewComment) return;
+
+      const t = await resolver.translationsFor(recipient.userId);
 
       return emailService.sendNewComment({
         to: recipient.email,
@@ -253,7 +239,20 @@ async function sendCommentNotifications(
         momentTitle: moment.title,
         momentSlug: moment.slug,
         commentPreview,
-        strings: emailStrings,
+        strings: {
+          subject: t("commentNotification.subject", {
+            playerName,
+            momentTitle: moment.title,
+          }),
+          heading: t("commentNotification.heading"),
+          message: t("commentNotification.message", {
+            playerName,
+            momentTitle: moment.title,
+          }),
+          commentPreviewLabel: t("commentNotification.commentPreviewLabel"),
+          viewCommentCta: t("commentNotification.viewCommentCta"),
+          footer: t("common.footer"),
+        },
       });
     })
   );

--- a/src/app/actions/moment.ts
+++ b/src/app/actions/moment.ts
@@ -6,7 +6,6 @@ import { fr } from "date-fns/locale/fr";
 import { enUS } from "date-fns/locale/en-US";
 
 const PLATFORM_TIMEZONE = "Europe/Paris";
-import { getLocale, getTranslations } from "next-intl/server";
 import { auth } from "@/infrastructure/auth/auth.config";
 import {
   prismaCircleRepository,
@@ -39,6 +38,10 @@ import { notifyNewMoment } from "./notify-new-moment";
 import { notifyAdminEntityCreated } from "./notify-admin-entity-created";
 import { isAdminUser, resolveCircleRepository } from "@/lib/admin-host-mode";
 import { getDisplayName } from "@/lib/display-name";
+import {
+  buildEmailLocaleResolver,
+  type EmailLocaleResolver,
+} from "@/lib/email/email-locale";
 
 const emailService = createResendEmailService();
 const paymentService = createStripePaymentService();
@@ -175,7 +178,8 @@ export async function createMomentAction(
         { momentRepository: prismaMomentRepository, circleRepository: circleRepo }
       );
 
-      sendMomentPublishedNotifications(publishResult.moment, userId);
+      const resolver = await buildEmailLocaleResolver(userId);
+      sendMomentPublishedNotifications(publishResult.moment, userId, resolver);
 
       revalidatePath(`/dashboard/circles/${publishResult.moment.circleId}`);
       revalidatePath(`/m/${publishResult.moment.slug}`);
@@ -301,14 +305,12 @@ export async function updateMomentAction(
         (locationAddress !== null && locationAddress !== existingMoment.locationAddress);
 
       if ((dateChanged || locationChanged) && !isAdminUser(session)) {
-        const locale = await getLocale();
-        const t = await getTranslations("Email");
+        const resolver = await buildEmailLocaleResolver(userId);
         sendMomentUpdateEmails(
           result.moment,
           Boolean(dateChanged),
           Boolean(locationChanged),
-          t,
-          locale
+          resolver
         ).catch((err) => Sentry.captureException(err));
       }
     }
@@ -327,7 +329,8 @@ export async function updateMomentAction(
           { momentRepository: prismaMomentRepository, circleRepository: circleRepo }
         );
 
-        sendMomentPublishedNotifications(publishResult.moment, userId);
+        const resolver = await buildEmailLocaleResolver(userId);
+        sendMomentPublishedNotifications(publishResult.moment, userId, resolver);
 
         revalidatePath(`/dashboard/circles/${publishResult.moment.circleId}`);
         revalidatePath(`/m/${publishResult.moment.slug}`);
@@ -348,14 +351,11 @@ export async function updateMomentAction(
   });
 }
 
-type TranslationFunction = Awaited<ReturnType<typeof getTranslations<"Email">>>;
-
 async function sendMomentUpdateEmails(
   moment: Moment,
   dateChanged: boolean,
   locationChanged: boolean,
-  t: TranslationFunction,
-  locale: string
+  resolver: EmailLocaleResolver
 ): Promise<void> {
   const [circle, registrations, hosts] = await Promise.all([
     prismaCircleRepository.findById(moment.circleId),
@@ -370,6 +370,10 @@ async function sendMomentUpdateEmails(
   const { participants: participantRecipients, hosts: hostRecipients } =
     partitionMomentUpdateRecipients(confirmed, hosts);
 
+  // Tous les destinataires d'un batch update sont des "tiers" (≠ déclencheur Host)
+  // → locale par défaut FR pour rester cohérent et formaté en français.
+  const t = await resolver.defaultTranslations();
+  const locale = resolver.defaultLocale;
   const dateFnsLocale = getDateFnsLocale(locale);
   const momentDate = formatInTimeZone(moment.startsAt, PLATFORM_TIMEZONE, "EEEE d MMMM yyyy, HH:mm", {
     locale: dateFnsLocale,
@@ -489,7 +493,8 @@ export async function deleteMomentAction(
       : false;
     const shouldNotify = momentToDelete && registrationsToNotify.length > 0 && (!isAdminUser(session) || isOrganizerOfEvent);
     if (shouldNotify) {
-      sendMomentCancelledEmails(momentToDelete, registrationsToNotify).catch(
+      const resolver = await buildEmailLocaleResolver(userId);
+      sendMomentCancelledEmails(momentToDelete, registrationsToNotify, resolver).catch(
         (err) => Sentry.captureException(err)
       );
     }
@@ -505,13 +510,15 @@ export async function deleteMomentAction(
 
 async function sendMomentCancelledEmails(
   moment: Moment,
-  registrations: RegistrationWithUser[]
+  registrations: RegistrationWithUser[],
+  resolver: EmailLocaleResolver
 ): Promise<void> {
   const circle = await prismaCircleRepository.findById(moment.circleId);
   if (!circle) return;
 
-  const locale = await getLocale();
-  const t = await getTranslations({ locale, namespace: "Email" });
+  // Tous les destinataires sont des participants ≠ déclencheur Host → FR par défaut.
+  const t = await resolver.defaultTranslations();
+  const locale = resolver.defaultLocale;
   const dateFnsLocale = getDateFnsLocale(locale);
 
   const momentDate = formatInTimeZone(moment.startsAt, PLATFORM_TIMEZONE, "EEEE d MMMM yyyy, HH:mm", { locale: dateFnsLocale });
@@ -573,7 +580,8 @@ export async function publishMomentAction(
       { momentRepository: prismaMomentRepository, circleRepository: circleRepo }
     );
 
-    sendMomentPublishedNotifications(result.moment, userId);
+    const resolver = await buildEmailLocaleResolver(userId);
+    sendMomentPublishedNotifications(result.moment, userId, resolver);
 
     revalidatePath(`/dashboard/circles/${result.moment.circleId}`);
     revalidatePath(`/m/${result.moment.slug}`);
@@ -594,7 +602,11 @@ export async function publishMomentAction(
  * and `createMomentAction` with `intent=publish` (create + publish in one
  * operation).
  */
-function sendMomentPublishedNotifications(moment: Moment, userId: string): void {
+function sendMomentPublishedNotifications(
+  moment: Moment,
+  userId: string,
+  resolver: EmailLocaleResolver,
+): void {
   prismaCircleRepository
     .findById(moment.circleId)
     .then(async (circle) => {
@@ -605,12 +617,12 @@ function sendMomentPublishedNotifications(moment: Moment, userId: string): void 
         Sentry.captureException(err);
       });
 
-      const [host, locale] = await Promise.all([
-        prismaUserRepository.findById(userId),
-        getLocale(),
-      ]);
+      const host = await prismaUserRepository.findById(userId);
       if (!host?.email) return;
 
+      // Le Host est le déclencheur : il garde la locale de la requête.
+      const t = await resolver.translationsFor(userId);
+      const locale = resolver.resolveFor(userId);
       const dateFnsLocale = getDateFnsLocale(locale);
       const momentDate = formatInTimeZone(moment.startsAt, PLATFORM_TIMEZONE, "EEEE d MMMM yyyy, HH:mm", { locale: dateFnsLocale });
       const momentDateMonth = formatInTimeZone(moment.startsAt, PLATFORM_TIMEZONE, "MMM", { locale: dateFnsLocale }).toUpperCase();
@@ -639,7 +651,6 @@ function sendMomentPublishedNotifications(moment: Moment, userId: string): void 
         attendeeEmail: host.email,
       });
 
-      const t = await getTranslations({ locale, namespace: "Email" });
       await emailService.sendHostMomentCreated({
         to: host.email,
         hostName,

--- a/src/app/actions/moment.ts
+++ b/src/app/actions/moment.ts
@@ -1,11 +1,6 @@
 "use server";
 
 import * as Sentry from "@sentry/nextjs";
-import { formatInTimeZone } from "date-fns-tz";
-import { fr } from "date-fns/locale/fr";
-import { enUS } from "date-fns/locale/en-US";
-
-const PLATFORM_TIMEZONE = "Europe/Paris";
 import { auth } from "@/infrastructure/auth/auth.config";
 import {
   prismaCircleRepository,
@@ -40,31 +35,13 @@ import { isAdminUser, resolveCircleRepository } from "@/lib/admin-host-mode";
 import { getDisplayName } from "@/lib/display-name";
 import {
   buildEmailLocaleResolver,
+  DEFAULT_RECIPIENT_LOCALE,
   type EmailLocaleResolver,
 } from "@/lib/email/email-locale";
+import { buildMomentEmailContext } from "@/lib/email/format-moment-email";
 
 const emailService = createResendEmailService();
 const paymentService = createStripePaymentService();
-
-function getDateFnsLocale(locale: string) {
-  return locale === "fr" ? fr : enUS;
-}
-
-function formatLocationText(
-  locationType: string,
-  locationName: string | null,
-  locationAddress: string | null,
-  videoLink: string | null,
-  locale: string
-): string {
-  if (locationType === "ONLINE") {
-    return videoLink ?? (locale === "fr" ? "En ligne" : "Online");
-  }
-  return (
-    [locationName, locationAddress].filter(Boolean).join(", ") ||
-    (locale === "fr" ? "À définir" : "TBD")
-  );
-}
 
 export async function createMomentAction(
   circleId: string,
@@ -373,22 +350,7 @@ async function sendMomentUpdateEmails(
   // Tous les destinataires d'un batch update sont des "tiers" (≠ déclencheur Host)
   // → locale par défaut FR pour rester cohérent et formaté en français.
   const t = await resolver.defaultTranslations();
-  const locale = resolver.defaultLocale;
-  const dateFnsLocale = getDateFnsLocale(locale);
-  const momentDate = formatInTimeZone(moment.startsAt, PLATFORM_TIMEZONE, "EEEE d MMMM yyyy, HH:mm", {
-    locale: dateFnsLocale,
-  });
-  const momentDateMonth = formatInTimeZone(moment.startsAt, PLATFORM_TIMEZONE, "MMM", {
-    locale: dateFnsLocale,
-  });
-  const momentDateDay = formatInTimeZone(moment.startsAt, PLATFORM_TIMEZONE, "d");
-  const locationText = formatLocationText(
-    moment.locationType,
-    moment.locationName,
-    moment.locationAddress,
-    moment.videoLink,
-    locale
-  );
+  const ctx = buildMomentEmailContext(moment, DEFAULT_RECIPIENT_LOCALE);
 
   const baseUrl = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
   const icsContent = generateIcs({
@@ -397,7 +359,7 @@ async function sendMomentUpdateEmails(
     description: moment.description,
     startsAt: moment.startsAt,
     endsAt: moment.endsAt,
-    location: locationText,
+    location: ctx.locationText,
     videoLink: moment.videoLink,
     url: `${baseUrl}/m/${moment.slug}`,
     organizerName: circle.name,
@@ -417,10 +379,10 @@ async function sendMomentUpdateEmails(
   const commonFields = {
     momentTitle: moment.title,
     momentSlug: moment.slug,
-    momentDate,
-    momentDateMonth,
-    momentDateDay,
-    locationText,
+    momentDate: ctx.momentDate,
+    momentDateMonth: ctx.momentDateMonth,
+    momentDateDay: ctx.momentDateDay,
+    locationText: ctx.locationText,
     circleName: circle.name,
     circleSlug: circle.slug,
     dateChanged,
@@ -518,19 +480,7 @@ async function sendMomentCancelledEmails(
 
   // Tous les destinataires sont des participants ≠ déclencheur Host → FR par défaut.
   const t = await resolver.defaultTranslations();
-  const locale = resolver.defaultLocale;
-  const dateFnsLocale = getDateFnsLocale(locale);
-
-  const momentDate = formatInTimeZone(moment.startsAt, PLATFORM_TIMEZONE, "EEEE d MMMM yyyy, HH:mm", { locale: dateFnsLocale });
-  const momentDateMonth = formatInTimeZone(moment.startsAt, PLATFORM_TIMEZONE, "MMM", { locale: dateFnsLocale }).toUpperCase();
-  const momentDateDay = formatInTimeZone(moment.startsAt, PLATFORM_TIMEZONE, "d");
-  const locationText = formatLocationText(
-    moment.locationType,
-    moment.locationName,
-    moment.locationAddress,
-    moment.videoLink,
-    locale
-  );
+  const ctx = buildMomentEmailContext(moment, DEFAULT_RECIPIENT_LOCALE);
 
   const strings = {
     subject: t("momentCancelled.subject", { momentTitle: moment.title }),
@@ -540,7 +490,6 @@ async function sendMomentCancelledEmails(
     footer: t("common.footer"),
   };
 
-  // Notifier REGISTERED et WAITLISTED (tous les participants actifs) en batch
   const recipients = registrations
     .filter((r) => r.user?.email)
     .map((r) => ({
@@ -552,10 +501,10 @@ async function sendMomentCancelledEmails(
     await emailService.sendMomentCancelledBatch({
       recipients,
       momentTitle: moment.title,
-      momentDate,
-      momentDateMonth,
-      momentDateDay,
-      locationText,
+      momentDate: ctx.momentDate,
+      momentDateMonth: ctx.momentDateMonth.toUpperCase(),
+      momentDateDay: ctx.momentDateDay,
+      locationText: ctx.locationText,
       circleName: circle.name,
       circleSlug: circle.slug,
       strings,
@@ -622,18 +571,7 @@ function sendMomentPublishedNotifications(
 
       // Le Host est le déclencheur : il garde la locale de la requête.
       const t = await resolver.translationsFor(userId);
-      const locale = resolver.resolveFor(userId);
-      const dateFnsLocale = getDateFnsLocale(locale);
-      const momentDate = formatInTimeZone(moment.startsAt, PLATFORM_TIMEZONE, "EEEE d MMMM yyyy, HH:mm", { locale: dateFnsLocale });
-      const momentDateMonth = formatInTimeZone(moment.startsAt, PLATFORM_TIMEZONE, "MMM", { locale: dateFnsLocale }).toUpperCase();
-      const momentDateDay = formatInTimeZone(moment.startsAt, PLATFORM_TIMEZONE, "d");
-      const locationText = formatLocationText(
-        moment.locationType,
-        moment.locationName,
-        moment.locationAddress,
-        moment.videoLink,
-        locale
-      );
+      const ctx = buildMomentEmailContext(moment, resolver.resolveFor(userId));
       const hostName = [host.firstName, host.lastName].filter(Boolean).join(" ") || host.email;
       const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
 
@@ -643,7 +581,7 @@ function sendMomentPublishedNotifications(
         description: moment.description,
         startsAt: moment.startsAt,
         endsAt: moment.endsAt,
-        location: locationText,
+        location: ctx.locationText,
         videoLink: moment.videoLink,
         url: `${appUrl}/m/${moment.slug}`,
         organizerName: circle.name,
@@ -657,10 +595,10 @@ function sendMomentPublishedNotifications(
         momentTitle: moment.title,
         momentSlug: moment.slug,
         circleSlug: circle.slug,
-        momentDate,
-        momentDateMonth,
-        momentDateDay,
-        locationText,
+        momentDate: ctx.momentDate,
+        momentDateMonth: ctx.momentDateMonth.toUpperCase(),
+        momentDateDay: ctx.momentDateDay,
+        locationText: ctx.locationText,
         circleName: circle.name,
         icsContent,
         strings: {

--- a/src/app/actions/registration.ts
+++ b/src/app/actions/registration.ts
@@ -1,11 +1,6 @@
 "use server";
 
 import * as Sentry from "@sentry/nextjs";
-import { formatInTimeZone } from "date-fns-tz";
-import { fr } from "date-fns/locale/fr";
-import { enUS } from "date-fns/locale/en-US";
-
-const PLATFORM_TIMEZONE = "Europe/Paris";
 import { auth } from "@/infrastructure/auth/auth.config";
 import { isAdminUser, resolveCircleRepository } from "@/lib/admin-host-mode";
 import {
@@ -30,31 +25,12 @@ import {
   buildEmailLocaleResolver,
   type EmailLocaleResolver,
 } from "@/lib/email/email-locale";
+import { buildMomentEmailContext } from "@/lib/email/format-moment-email";
 import type { Registration } from "@/domain/models/registration";
 import type { ActionResult } from "./types";
 
 const emailService = createResendEmailService();
 const paymentService = createStripePaymentService();
-
-function getDateFnsLocale(locale: string) {
-  return locale === "fr" ? fr : enUS;
-}
-
-function formatLocationText(
-  locationType: string,
-  locationName: string | null,
-  locationAddress: string | null,
-  videoLink: string | null,
-  locale: string
-): string {
-  if (locationType === "ONLINE") {
-    return videoLink ?? (locale === "fr" ? "En ligne" : "Online");
-  }
-  return (
-    [locationName, locationAddress].filter(Boolean).join(", ") ||
-    (locale === "fr" ? "À définir" : "TBD")
-  );
-}
 
 export async function joinMomentAction(
   momentId: string
@@ -75,24 +51,14 @@ export async function joinMomentAction(
       }
     );
 
-    if (!result.pendingApproval) {
+    if (!isAdminUser(session)) {
+      // Pas de after() : Vercel serverless peut couper la lambda avant que l'after se déclenche.
       const resolver = await buildEmailLocaleResolver(userId);
-      if (!isAdminUser(session)) sendRegistrationEmails(
-        momentId,
-        userId,
-        result.registration,
-        resolver
-      ).catch((err) => {
+      const fireAndForget = result.pendingApproval
+        ? notifyHostsPendingApproval(momentId, userId, resolver)
+        : sendRegistrationEmails(momentId, userId, result.registration, resolver);
+      fireAndForget.catch((err) => {
         console.error(err);
-        Sentry.captureException(err);
-      });
-    } else {
-      // Pending approval flow — fire-and-forget (pas de after() — peut être coupé par Vercel serverless)
-      const resolver = await buildEmailLocaleResolver(userId);
-      if (!isAdminUser(session)) notifyHostsPendingApproval(
-        momentId, userId, resolver
-      ).catch((err) => {
-        console.error("[approval-notification] Error:", err);
         Sentry.captureException(err);
       });
     }
@@ -222,22 +188,11 @@ export async function sendRegistrationEmails(
   const isWaitlisted = registration.status === "WAITLISTED";
   const stringPrefix = isWaitlisted ? "waitlist" : "registration";
 
-  // Bloc Player — locale dépend de la position du Player vs déclencheur
+  // Le Player peut être le déclencheur (self-join) ou non (Host qui approuve) — resolveFor() arbitre.
   const playerT = await resolver.translationsFor(userId);
   const playerLocale = resolver.resolveFor(userId);
-  const playerDateFns = getDateFnsLocale(playerLocale);
-  const playerMomentDate = formatInTimeZone(moment.startsAt, PLATFORM_TIMEZONE, "EEEE d MMMM yyyy, HH:mm", { locale: playerDateFns });
-  const playerMomentDateMonth = formatInTimeZone(moment.startsAt, PLATFORM_TIMEZONE, "MMM", { locale: playerDateFns });
-  const playerMomentDateDay = formatInTimeZone(moment.startsAt, PLATFORM_TIMEZONE, "d");
-  const playerLocationText = formatLocationText(
-    moment.locationType,
-    moment.locationName,
-    moment.locationAddress,
-    moment.videoLink,
-    playerLocale
-  );
+  const playerCtx = buildMomentEmailContext(moment, playerLocale);
 
-  // Generate .ics calendar attachment (REGISTERED only — not for waitlist)
   const baseUrl = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
   const icsContent = !isWaitlisted
     ? generateIcs({
@@ -246,7 +201,7 @@ export async function sendRegistrationEmails(
         description: moment.description,
         startsAt: moment.startsAt,
         endsAt: moment.endsAt,
-        location: playerLocationText,
+        location: playerCtx.locationText,
         videoLink: moment.videoLink,
         url: `${baseUrl}/m/${moment.slug}`,
         organizerName: circle.name,
@@ -260,10 +215,10 @@ export async function sendRegistrationEmails(
     playerName,
     momentTitle: moment.title,
     momentSlug: moment.slug,
-    momentDate: playerMomentDate,
-    momentDateMonth: playerMomentDateMonth,
-    momentDateDay: playerMomentDateDay,
-    locationText: playerLocationText,
+    momentDate: playerCtx.momentDate,
+    momentDateMonth: playerCtx.momentDateMonth,
+    momentDateDay: playerCtx.momentDateDay,
+    locationText: playerCtx.locationText,
     circleName: circle.name,
     circleSlug: circle.slug,
     status: registration.status,
@@ -289,18 +244,26 @@ export async function sendRegistrationEmails(
     },
   });
 
-  // Bloc Hosts — chaque destinataire reçoit dans sa locale (déclencheur garde sa locale, autres → FR)
-  const [hosts, registeredCount] = await Promise.all([
+  const [hosts, registeredCount, defaultT] = await Promise.all([
     prismaCircleRepository.findOrganizers(moment.circleId),
     prismaRegistrationRepository.countByMomentIdAndStatus(momentId, "REGISTERED"),
+    resolver.defaultTranslations(),
   ]);
 
   const filteredHosts = hosts.filter((host) => host.userId !== userId);
   const hostUserIds = filteredHosts.map((h) => h.userId);
   const prefsMap = await prismaUserRepository.findNotificationPreferencesByIds(hostUserIds);
 
-  await Promise.all(
-    filteredHosts.map(async (host) => {
+  // registrationInfo dans la locale par défaut, réutilisé pour Slack et pour les
+  // destinataires non-déclencheur (cas typique : tous les Hosts).
+  const formatRegistrationInfo = (t: typeof defaultT) =>
+    moment.capacity
+      ? t("hostNotification.registrationInfo", { count: registeredCount, capacity: moment.capacity })
+      : t("hostNotification.registrationInfoUnlimited", { count: registeredCount });
+  const defaultRegistrationInfo = formatRegistrationInfo(defaultT);
+
+  await Promise.all([
+    ...filteredHosts.map(async (host) => {
       const prefs = prefsMap.get(host.userId);
       if (!prefs?.notifyNewRegistration) return;
 
@@ -309,14 +272,8 @@ export async function sendRegistrationEmails(
         [host.user.firstName, host.user.lastName].filter(Boolean).join(" ") ||
         host.user.email;
 
-      const registrationInfo = moment.capacity
-        ? hostT("hostNotification.registrationInfo", {
-            count: registeredCount,
-            capacity: moment.capacity,
-          })
-        : hostT("hostNotification.registrationInfoUnlimited", {
-            count: registeredCount,
-          });
+      const registrationInfo =
+        hostT === defaultT ? defaultRegistrationInfo : formatRegistrationInfo(hostT);
 
       return emailService.sendHostNewRegistration({
         to: host.user.email,
@@ -327,40 +284,22 @@ export async function sendRegistrationEmails(
         circleSlug: circle.slug,
         registrationInfo,
         strings: {
-          subject: hostT("hostNotification.subject", {
-            playerName,
-            momentTitle: moment.title,
-          }),
+          subject: hostT("hostNotification.subject", { playerName, momentTitle: moment.title }),
           heading: hostT("hostNotification.heading"),
-          message: hostT("hostNotification.message", {
-            playerName,
-            momentTitle: moment.title,
-          }),
+          message: hostT("hostNotification.message", { playerName, momentTitle: moment.title }),
           manageRegistrationsCta: hostT("hostNotification.manageRegistrationsCta"),
           footer: hostT("common.footer"),
         },
       });
-    })
-  );
-
-  // Slack — toujours dans la locale par défaut (canal interne)
-  const slackT = await resolver.defaultTranslations();
-  const slackRegistrationInfo = moment.capacity
-    ? slackT("hostNotification.registrationInfo", {
-        count: registeredCount,
-        capacity: moment.capacity,
-      })
-    : slackT("hostNotification.registrationInfoUnlimited", {
-        count: registeredCount,
-      });
-
-  await notifySlackNewRegistration({
-    playerName,
-    momentTitle: moment.title,
-    circleName: circle.name,
-    registrationInfo: slackRegistrationInfo,
-    momentUrl: `${baseUrl}/m/${moment.slug}`,
-  });
+    }),
+    notifySlackNewRegistration({
+      playerName,
+      momentTitle: moment.title,
+      circleName: circle.name,
+      registrationInfo: defaultRegistrationInfo,
+      momentUrl: `${baseUrl}/m/${moment.slug}`,
+    }),
+  ]);
 }
 
 async function sendPromotionEmail(
@@ -378,21 +317,7 @@ async function sendPromotionEmail(
 
   const t = await resolver.translationsFor(promotedRegistration.userId);
   const locale = resolver.resolveFor(promotedRegistration.userId);
-  const dateFnsLocale = getDateFnsLocale(locale);
-  const momentDate = formatInTimeZone(moment.startsAt, PLATFORM_TIMEZONE, "EEEE d MMMM yyyy, HH:mm", {
-    locale: dateFnsLocale,
-  });
-  const momentDateMonth = formatInTimeZone(moment.startsAt, PLATFORM_TIMEZONE, "MMM", {
-    locale: dateFnsLocale,
-  });
-  const momentDateDay = formatInTimeZone(moment.startsAt, PLATFORM_TIMEZONE, "d");
-  const locationText = formatLocationText(
-    moment.locationType,
-    moment.locationName,
-    moment.locationAddress,
-    moment.videoLink,
-    locale
-  );
+  const ctx = buildMomentEmailContext(moment, locale);
   const playerName =
     [user.firstName, user.lastName].filter(Boolean).join(" ") || user.email;
 
@@ -405,7 +330,7 @@ async function sendPromotionEmail(
     description: moment.description,
     startsAt: moment.startsAt,
     endsAt: moment.endsAt,
-    location: locationText,
+    location: ctx.locationText,
     videoLink: moment.videoLink,
     url: `${promotionBaseUrl}/m/${moment.slug}`,
     organizerName: circle.name,
@@ -418,10 +343,10 @@ async function sendPromotionEmail(
     playerName,
     momentTitle: moment.title,
     momentSlug: moment.slug,
-    momentDate,
-    momentDateMonth,
-    momentDateDay,
-    locationText,
+    momentDate: ctx.momentDate,
+    momentDateMonth: ctx.momentDateMonth,
+    momentDateDay: ctx.momentDateDay,
+    locationText: ctx.locationText,
     circleName: circle.name,
     circleSlug: circle.slug,
     icsContent,
@@ -497,22 +422,7 @@ async function sendRemovedByHostEmail(
   if (!circle) return;
 
   const t = await resolver.translationsFor(userId);
-  const locale = resolver.resolveFor(userId);
-  const dateFnsLocale = getDateFnsLocale(locale);
-  const momentDate = formatInTimeZone(moment.startsAt, PLATFORM_TIMEZONE, "EEEE d MMMM yyyy, HH:mm", {
-    locale: dateFnsLocale,
-  });
-  const momentDateMonth = formatInTimeZone(moment.startsAt, PLATFORM_TIMEZONE, "MMM", {
-    locale: dateFnsLocale,
-  });
-  const momentDateDay = formatInTimeZone(moment.startsAt, PLATFORM_TIMEZONE, "d");
-  const locationText = formatLocationText(
-    moment.locationType,
-    moment.locationName,
-    moment.locationAddress,
-    moment.videoLink,
-    locale
-  );
+  const ctx = buildMomentEmailContext(moment, resolver.resolveFor(userId));
   const playerName = getDisplayName(user.firstName, user.lastName, user.email);
 
   await emailService.sendRegistrationRemovedByHost({
@@ -520,10 +430,10 @@ async function sendRemovedByHostEmail(
     playerName,
     momentTitle: moment.title,
     momentSlug: moment.slug,
-    momentDate,
-    momentDateMonth,
-    momentDateDay,
-    locationText,
+    momentDate: ctx.momentDate,
+    momentDateMonth: ctx.momentDateMonth,
+    momentDateDay: ctx.momentDateDay,
+    locationText: ctx.locationText,
     circleName: circle.name,
     circleSlug: circle.slug,
     strings: {

--- a/src/app/actions/registration.ts
+++ b/src/app/actions/registration.ts
@@ -6,7 +6,6 @@ import { fr } from "date-fns/locale/fr";
 import { enUS } from "date-fns/locale/en-US";
 
 const PLATFORM_TIMEZONE = "Europe/Paris";
-import { getLocale, getTranslations } from "next-intl/server";
 import { auth } from "@/infrastructure/auth/auth.config";
 import { isAdminUser, resolveCircleRepository } from "@/lib/admin-host-mode";
 import {
@@ -27,6 +26,10 @@ import { invalidateDashboardCache } from "@/lib/dashboard-cache";
 import { getDisplayName } from "@/lib/display-name";
 import { formatPrice } from "@/lib/format-price";
 import { notifySlackNewRegistration } from "@/infrastructure/services/slack/slack-notification-service";
+import {
+  buildEmailLocaleResolver,
+  type EmailLocaleResolver,
+} from "@/lib/email/email-locale";
 import type { Registration } from "@/domain/models/registration";
 import type { ActionResult } from "./types";
 
@@ -73,24 +76,21 @@ export async function joinMomentAction(
     );
 
     if (!result.pendingApproval) {
-      const locale = await getLocale();
-      const t = await getTranslations("Email");
-
+      const resolver = await buildEmailLocaleResolver(userId);
       if (!isAdminUser(session)) sendRegistrationEmails(
         momentId,
         userId,
         result.registration,
-        t,
-        locale
+        resolver
       ).catch((err) => {
         console.error(err);
         Sentry.captureException(err);
       });
     } else {
       // Pending approval flow — fire-and-forget (pas de after() — peut être coupé par Vercel serverless)
-      const t = await getTranslations("Email");
+      const resolver = await buildEmailLocaleResolver(userId);
       if (!isAdminUser(session)) notifyHostsPendingApproval(
-        momentId, userId, t
+        momentId, userId, resolver
       ).catch((err) => {
         console.error("[approval-notification] Error:", err);
         Sentry.captureException(err);
@@ -122,10 +122,10 @@ export async function cancelRegistrationAction(
       }
     );
 
+    const resolver = await buildEmailLocaleResolver(userId);
+
     if (result.promotedRegistration) {
-      const locale = await getLocale();
-      const t = await getTranslations("Email");
-      sendPromotionEmail(result.promotedRegistration, t, locale).catch((err) => {
+      sendPromotionEmail(result.promotedRegistration, resolver).catch((err) => {
         console.error(err);
         Sentry.captureException(err);
       });
@@ -133,7 +133,7 @@ export async function cancelRegistrationAction(
 
     const cancelledReg = result.registration;
     if (cancelledReg.paymentStatus === "PAID" || cancelledReg.paymentStatus === "REFUNDED") {
-      sendHostPaidCancellationEmail(registrationId, userId).catch((err) =>
+      sendHostPaidCancellationEmail(registrationId, userId, resolver).catch((err) =>
         Sentry.captureException(err)
       );
     }
@@ -149,7 +149,8 @@ export async function cancelRegistrationAction(
 
 async function sendHostPaidCancellationEmail(
   registrationId: string,
-  cancellingUserId: string
+  cancellingUserId: string,
+  resolver: EmailLocaleResolver
 ): Promise<void> {
   const registration = await prismaRegistrationRepository.findById(registrationId);
   if (!registration) return;
@@ -166,45 +167,44 @@ async function sendHostPaidCancellationEmail(
   const hosts = await prismaCircleRepository.findOrganizers(circle.id);
   if (hosts.length === 0) return;
 
-  const locale = await getLocale();
-  const t = await getTranslations("Email");
   const playerName = getDisplayName(player.firstName, player.lastName, player.email);
-
   const isRefundable = moment.refundable;
-  const amountFormatted = formatPrice(moment.price, moment.currency, locale);
 
-  for (const host of hosts) {
-    const hostName = getDisplayName(host.user.firstName, host.user.lastName, host.user.email);
-    await emailService.sendHostPaidCancellation({
-      to: host.user.email,
-      hostName,
-      playerName,
-      momentTitle: moment.title,
-      momentSlug: moment.slug,
-      circleSlug: circle.slug,
-      amountRefunded: isRefundable ? amountFormatted : null,
-      strings: {
-        subject: t("paidCancellation.subject", { playerName, momentTitle: moment.title }),
-        heading: t("paidCancellation.heading"),
-        message: t("paidCancellation.message", { playerName, momentTitle: moment.title }),
-        refundMessage: isRefundable
-          ? t("paidCancellation.refunded", { amount: amountFormatted })
-          : t("paidCancellation.notRefunded"),
-        manageRegistrationsCta: t("paidCancellation.manageCta"),
-        footer: t("common.footer"),
-      },
-    });
-  }
+  await Promise.all(
+    hosts.map(async (host) => {
+      const hostName = getDisplayName(host.user.firstName, host.user.lastName, host.user.email);
+      const t = await resolver.translationsFor(host.userId);
+      const hostLocale = resolver.resolveFor(host.userId);
+      const amountFormatted = formatPrice(moment.price, moment.currency, hostLocale);
+
+      return emailService.sendHostPaidCancellation({
+        to: host.user.email,
+        hostName,
+        playerName,
+        momentTitle: moment.title,
+        momentSlug: moment.slug,
+        circleSlug: circle.slug,
+        amountRefunded: isRefundable ? amountFormatted : null,
+        strings: {
+          subject: t("paidCancellation.subject", { playerName, momentTitle: moment.title }),
+          heading: t("paidCancellation.heading"),
+          message: t("paidCancellation.message", { playerName, momentTitle: moment.title }),
+          refundMessage: isRefundable
+            ? t("paidCancellation.refunded", { amount: amountFormatted })
+            : t("paidCancellation.notRefunded"),
+          manageRegistrationsCta: t("paidCancellation.manageCta"),
+          footer: t("common.footer"),
+        },
+      });
+    })
+  );
 }
-
-type TranslationFunction = Awaited<ReturnType<typeof getTranslations<"Email">>>;
 
 export async function sendRegistrationEmails(
   momentId: string,
   userId: string,
   registration: Registration,
-  t: TranslationFunction,
-  locale: string
+  resolver: EmailLocaleResolver
 ): Promise<void> {
   const [user, moment] = await Promise.all([
     prismaUserRepository.findById(userId),
@@ -216,26 +216,26 @@ export async function sendRegistrationEmails(
   const circle = await prismaCircleRepository.findById(moment.circleId);
   if (!circle) return;
 
-  const dateFnsLocale = getDateFnsLocale(locale);
-  const momentDate = formatInTimeZone(moment.startsAt, PLATFORM_TIMEZONE, "EEEE d MMMM yyyy, HH:mm", {
-    locale: dateFnsLocale,
-  });
-  const momentDateMonth = formatInTimeZone(moment.startsAt, PLATFORM_TIMEZONE, "MMM", {
-    locale: dateFnsLocale,
-  });
-  const momentDateDay = formatInTimeZone(moment.startsAt, PLATFORM_TIMEZONE, "d");
-  const locationText = formatLocationText(
-    moment.locationType,
-    moment.locationName,
-    moment.locationAddress,
-    moment.videoLink,
-    locale
-  );
   const playerName =
     [user.firstName, user.lastName].filter(Boolean).join(" ") || user.email;
 
   const isWaitlisted = registration.status === "WAITLISTED";
   const stringPrefix = isWaitlisted ? "waitlist" : "registration";
+
+  // Bloc Player — locale dépend de la position du Player vs déclencheur
+  const playerT = await resolver.translationsFor(userId);
+  const playerLocale = resolver.resolveFor(userId);
+  const playerDateFns = getDateFnsLocale(playerLocale);
+  const playerMomentDate = formatInTimeZone(moment.startsAt, PLATFORM_TIMEZONE, "EEEE d MMMM yyyy, HH:mm", { locale: playerDateFns });
+  const playerMomentDateMonth = formatInTimeZone(moment.startsAt, PLATFORM_TIMEZONE, "MMM", { locale: playerDateFns });
+  const playerMomentDateDay = formatInTimeZone(moment.startsAt, PLATFORM_TIMEZONE, "d");
+  const playerLocationText = formatLocationText(
+    moment.locationType,
+    moment.locationName,
+    moment.locationAddress,
+    moment.videoLink,
+    playerLocale
+  );
 
   // Generate .ics calendar attachment (REGISTERED only — not for waitlist)
   const baseUrl = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
@@ -246,7 +246,7 @@ export async function sendRegistrationEmails(
         description: moment.description,
         startsAt: moment.startsAt,
         endsAt: moment.endsAt,
-        location: locationText,
+        location: playerLocationText,
         videoLink: moment.videoLink,
         url: `${baseUrl}/m/${moment.slug}`,
         organizerName: circle.name,
@@ -255,57 +255,46 @@ export async function sendRegistrationEmails(
       })
     : undefined;
 
-  // Send confirmation to player
   await emailService.sendRegistrationConfirmation({
     to: user.email,
     playerName,
     momentTitle: moment.title,
     momentSlug: moment.slug,
-    momentDate,
-    momentDateMonth,
-    momentDateDay,
-    locationText,
+    momentDate: playerMomentDate,
+    momentDateMonth: playerMomentDateMonth,
+    momentDateDay: playerMomentDateDay,
+    locationText: playerLocationText,
     circleName: circle.name,
     circleSlug: circle.slug,
     status: registration.status,
     icsContent,
     ...(registration.paymentStatus === "PAID" && moment.price > 0 && {
-      amountPaid: formatPrice(moment.price, moment.currency, locale),
+      amountPaid: formatPrice(moment.price, moment.currency, playerLocale),
     }),
     ...(registration.stripeReceiptUrl && { receiptUrl: registration.stripeReceiptUrl }),
     strings: {
-      subject: t(`${stringPrefix}.subject`, { momentTitle: moment.title }),
-      heading: t(`${stringPrefix}.heading`),
-      statusMessage: t(`${stringPrefix}.statusMessage`, {
+      subject: playerT(`${stringPrefix}.subject`, { momentTitle: moment.title }),
+      heading: playerT(`${stringPrefix}.heading`),
+      statusMessage: playerT(`${stringPrefix}.statusMessage`, {
         momentTitle: moment.title,
       }),
-      dateLabel: t("common.dateLabel"),
-      locationLabel: t("common.locationLabel"),
-      viewMomentCta: t("common.viewMomentCta"),
-      cancelLink: t("common.cancelLink"),
-      dashboardLink: t("common.dashboardLink"),
-      paymentConfirmed: t("common.paymentConfirmed"),
-      viewReceipt: t("common.viewReceipt"),
-      footer: t("common.footer"),
+      dateLabel: playerT("common.dateLabel"),
+      locationLabel: playerT("common.locationLabel"),
+      viewMomentCta: playerT("common.viewMomentCta"),
+      cancelLink: playerT("common.cancelLink"),
+      dashboardLink: playerT("common.dashboardLink"),
+      paymentConfirmed: playerT("common.paymentConfirmed"),
+      viewReceipt: playerT("common.viewReceipt"),
+      footer: playerT("common.footer"),
     },
   });
 
-  // Send notification to each Host of the Circle (skip if host = player)
+  // Bloc Hosts — chaque destinataire reçoit dans sa locale (déclencheur garde sa locale, autres → FR)
   const [hosts, registeredCount] = await Promise.all([
     prismaCircleRepository.findOrganizers(moment.circleId),
     prismaRegistrationRepository.countByMomentIdAndStatus(momentId, "REGISTERED"),
   ]);
 
-  const registrationInfo = moment.capacity
-    ? t("hostNotification.registrationInfo", {
-        count: registeredCount,
-        capacity: moment.capacity,
-      })
-    : t("hostNotification.registrationInfoUnlimited", {
-        count: registeredCount,
-      });
-
-  // Récupère les préférences de tous les Hosts en une seule requête pour éviter le N+1
   const filteredHosts = hosts.filter((host) => host.userId !== userId);
   const hostUserIds = filteredHosts.map((h) => h.userId);
   const prefsMap = await prismaUserRepository.findNotificationPreferencesByIds(hostUserIds);
@@ -315,9 +304,19 @@ export async function sendRegistrationEmails(
       const prefs = prefsMap.get(host.userId);
       if (!prefs?.notifyNewRegistration) return;
 
+      const hostT = await resolver.translationsFor(host.userId);
       const hostName =
         [host.user.firstName, host.user.lastName].filter(Boolean).join(" ") ||
         host.user.email;
+
+      const registrationInfo = moment.capacity
+        ? hostT("hostNotification.registrationInfo", {
+            count: registeredCount,
+            capacity: moment.capacity,
+          })
+        : hostT("hostNotification.registrationInfoUnlimited", {
+            count: registeredCount,
+          });
 
       return emailService.sendHostNewRegistration({
         to: host.user.email,
@@ -328,35 +327,45 @@ export async function sendRegistrationEmails(
         circleSlug: circle.slug,
         registrationInfo,
         strings: {
-          subject: t("hostNotification.subject", {
+          subject: hostT("hostNotification.subject", {
             playerName,
             momentTitle: moment.title,
           }),
-          heading: t("hostNotification.heading"),
-          message: t("hostNotification.message", {
+          heading: hostT("hostNotification.heading"),
+          message: hostT("hostNotification.message", {
             playerName,
             momentTitle: moment.title,
           }),
-          manageRegistrationsCta: t("hostNotification.manageRegistrationsCta"),
-          footer: t("common.footer"),
+          manageRegistrationsCta: hostT("hostNotification.manageRegistrationsCta"),
+          footer: hostT("common.footer"),
         },
       });
     })
   );
 
+  // Slack — toujours dans la locale par défaut (canal interne)
+  const slackT = await resolver.defaultTranslations();
+  const slackRegistrationInfo = moment.capacity
+    ? slackT("hostNotification.registrationInfo", {
+        count: registeredCount,
+        capacity: moment.capacity,
+      })
+    : slackT("hostNotification.registrationInfoUnlimited", {
+        count: registeredCount,
+      });
+
   await notifySlackNewRegistration({
     playerName,
     momentTitle: moment.title,
     circleName: circle.name,
-    registrationInfo,
+    registrationInfo: slackRegistrationInfo,
     momentUrl: `${baseUrl}/m/${moment.slug}`,
   });
 }
 
 async function sendPromotionEmail(
   promotedRegistration: Registration,
-  t: TranslationFunction,
-  locale: string
+  resolver: EmailLocaleResolver
 ): Promise<void> {
   const [user, moment] = await Promise.all([
     prismaUserRepository.findById(promotedRegistration.userId),
@@ -367,6 +376,8 @@ async function sendPromotionEmail(
   const circle = await prismaCircleRepository.findById(moment.circleId);
   if (!circle) return;
 
+  const t = await resolver.translationsFor(promotedRegistration.userId);
+  const locale = resolver.resolveFor(promotedRegistration.userId);
   const dateFnsLocale = getDateFnsLocale(locale);
   const momentDate = formatInTimeZone(moment.startsAt, PLATFORM_TIMEZONE, "EEEE d MMMM yyyy, HH:mm", {
     locale: dateFnsLocale,
@@ -449,17 +460,16 @@ export async function removeRegistrationByHostAction(
       }
     );
 
-    const locale = await getLocale();
-    const t = await getTranslations("Email");
+    const resolver = await buildEmailLocaleResolver(hostUserId);
     const { momentId, userId } = result.cancelledRegistration;
 
-    sendRemovedByHostEmail(momentId, userId, t, locale).catch((err) => {
+    sendRemovedByHostEmail(momentId, userId, resolver).catch((err) => {
       console.error(err);
       Sentry.captureException(err);
     });
 
     if (result.promotedRegistration) {
-      sendPromotionEmail(result.promotedRegistration, t, locale).catch((err) => {
+      sendPromotionEmail(result.promotedRegistration, resolver).catch((err) => {
         console.error(err);
         Sentry.captureException(err);
       });
@@ -475,8 +485,7 @@ export async function removeRegistrationByHostAction(
 async function sendRemovedByHostEmail(
   momentId: string,
   userId: string,
-  t: TranslationFunction,
-  locale: string
+  resolver: EmailLocaleResolver
 ): Promise<void> {
   const [user, moment] = await Promise.all([
     prismaUserRepository.findById(userId),
@@ -487,6 +496,8 @@ async function sendRemovedByHostEmail(
   const circle = await prismaCircleRepository.findById(moment.circleId);
   if (!circle) return;
 
+  const t = await resolver.translationsFor(userId);
+  const locale = resolver.resolveFor(userId);
   const dateFnsLocale = getDateFnsLocale(locale);
   const momentDate = formatInTimeZone(moment.startsAt, PLATFORM_TIMEZONE, "EEEE d MMMM yyyy, HH:mm", {
     locale: dateFnsLocale,
@@ -546,9 +557,8 @@ export async function approveMomentRegistrationAction(
     );
 
     const reg = result.registration;
-    const locale = await getLocale();
-    const t = await getTranslations("Email");
-    sendRegistrationEmails(reg.momentId, reg.userId, reg, t, locale).catch((err) => {
+    const resolver = await buildEmailLocaleResolver(hostUserId);
+    sendRegistrationEmails(reg.momentId, reg.userId, reg, resolver).catch((err) => {
       console.error(err);
       Sentry.captureException(err);
     });
@@ -578,8 +588,8 @@ export async function rejectMomentRegistrationAction(
       }
     );
 
-    const t = await getTranslations("Email");
-    notifyPlayerRejection(result.userId, result.momentId, t).catch((err) => {
+    const resolver = await buildEmailLocaleResolver(hostUserId);
+    notifyPlayerRejection(result.userId, result.momentId, resolver).catch((err) => {
       console.error("[rejection-notification] Error:", err);
       Sentry.captureException(err);
     });
@@ -594,7 +604,7 @@ export async function rejectMomentRegistrationAction(
 async function notifyHostsPendingApproval(
   momentId: string,
   userId: string,
-  t: Awaited<ReturnType<typeof getTranslations<"Email">>>
+  resolver: EmailLocaleResolver
 ): Promise<void> {
   const [user, moment] = await Promise.all([
     prismaUserRepository.findById(userId),
@@ -616,6 +626,7 @@ async function notifyHostsPendingApproval(
     hosts.map(async (host) => {
       const prefs = prefsMap.get(host.userId);
       if (!prefs?.notifyNewRegistration) return;
+      const t = await resolver.translationsFor(host.userId);
       const hostName = getDisplayName(host.user.firstName, host.user.lastName, host.user.email);
       return emailService.sendApprovalNotification({
         to: host.user.email,
@@ -637,13 +648,14 @@ async function notifyHostsPendingApproval(
 async function notifyPlayerRejection(
   userId: string,
   momentId: string,
-  t: Awaited<ReturnType<typeof getTranslations<"Email">>>
+  resolver: EmailLocaleResolver
 ): Promise<void> {
   const [user, moment] = await Promise.all([
     prismaUserRepository.findById(userId),
     prismaMomentRepository.findById(momentId),
   ]);
   if (!user || !moment) return;
+  const t = await resolver.translationsFor(userId);
   const playerName = getDisplayName(user.firstName, user.lastName, user.email);
   await emailService.sendApprovalNotification({
     to: user.email,

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from "next/server";
 import * as Sentry from "@sentry/nextjs";
-import { getTranslations } from "next-intl/server";
 import {
   prismaCircleRepository,
   prismaMomentRepository,
@@ -9,6 +8,7 @@ import {
 import { createStripePaymentService } from "@/infrastructure/services";
 import { handlePaymentWebhook } from "@/domain/usecases/handle-payment-webhook";
 import { sendRegistrationEmails } from "@/app/actions/registration";
+import { buildEmailLocaleResolver } from "@/lib/email/email-locale";
 
 const paymentService = createStripePaymentService();
 
@@ -36,14 +36,15 @@ export async function POST(request: Request) {
     );
 
     if (result.handled) {
-      // Send confirmation email (fire-and-forget — don't block the webhook response)
-      const t = await getTranslations("Email");
+      // Webhook : pas de contexte i18n côté requête → resolver retombe sur la
+      // locale par défaut FR pour tous les destinataires (comportement
+      // historique préservé).
+      const resolver = await buildEmailLocaleResolver(result.registration.userId);
       sendRegistrationEmails(
         result.registration.momentId,
         result.registration.userId,
         result.registration,
-        t,
-        "fr" // Default locale for webhook-triggered emails
+        resolver
       ).catch((error) => Sentry.captureException(error));
 
       return NextResponse.json({

--- a/src/infrastructure/auth/auth.config.ts
+++ b/src/infrastructure/auth/auth.config.ts
@@ -4,12 +4,16 @@ import GitHub from "next-auth/providers/github";
 import Google from "next-auth/providers/google";
 import ResendProvider from "next-auth/providers/resend";
 import { PrismaAdapter } from "@auth/prisma-adapter";
+import { getTranslations } from "next-intl/server";
 import { prisma } from "@/infrastructure/db/prisma";
 import { createSafeResend } from "@/lib/email/safe-resend";
 import { MagicLinkEmail } from "@/infrastructure/services/email/templates/magic-link";
 import { isUploadedUrl } from "@/lib/blob";
 import { prismaUserRepository } from "@/infrastructure/repositories/prisma-user-repository";
-import { buildMagicLinkConfirmUrl } from "@/lib/auth/magic-link-url";
+import {
+  buildMagicLinkConfirmUrl,
+  detectLocaleFromRequest,
+} from "@/lib/auth/magic-link-url";
 import { classifyAuthError } from "@/lib/auth/error-kinds";
 
 export const { handlers, auth, signIn, signOut } = NextAuth({
@@ -44,11 +48,29 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         // POST sur le callback, déclenchable uniquement par un humain.
         const confirmUrl = buildMagicLinkConfirmUrl(url, request);
 
+        // Le déclencheur EST le destinataire (l'utilisateur qui demande le
+        // lien) → on lit la locale de la requête de sign-in pour lui répondre
+        // dans la même langue que l'UI où il a cliqué.
+        const locale = detectLocaleFromRequest(request);
+        const t = await getTranslations({ locale, namespace: "Email.magicLink" });
+
         const { error } = await resend.emails.send({
           from,
           to: identifier,
-          subject: "Votre lien de connexion — The Playground",
-          react: MagicLinkEmail({ url: confirmUrl, baseUrl }),
+          subject: t("subject"),
+          react: MagicLinkEmail({
+            url: confirmUrl,
+            baseUrl,
+            strings: {
+              preview: t("preview"),
+              heading: t("heading"),
+              bodyText: t("bodyText"),
+              ctaLabel: t("ctaLabel"),
+              expiryText: t("expiryText"),
+              securityText: t("securityText"),
+              footer: t("footer"),
+            },
+          }),
         });
 
         if (error) {

--- a/src/infrastructure/services/email/templates/magic-link.tsx
+++ b/src/infrastructure/services/email/templates/magic-link.tsx
@@ -2,17 +2,25 @@ import { Button, Hr, Img, Section, Text } from "@react-email/components";
 import * as React from "react";
 import { EmailLayout } from "./components/email-layout";
 
+export type MagicLinkEmailStrings = {
+  preview: string;
+  heading: string;
+  bodyText: string;
+  ctaLabel: string;
+  expiryText: string;
+  securityText: string;
+  footer: string;
+};
+
 type Props = {
   url: string;
   baseUrl: string;
+  strings: MagicLinkEmailStrings;
 };
 
-export function MagicLinkEmail({ url, baseUrl }: Props) {
+export function MagicLinkEmail({ url, baseUrl, strings }: Props) {
   return (
-    <EmailLayout
-      preview="Votre lien de connexion à The Playground"
-      footer="The Playground · Si vous n'avez pas demandé ce lien, ignorez cet email en toute sécurité."
-    >
+    <EmailLayout preview={strings.preview} footer={strings.footer}>
       <Section style={iconSection}>
         {/* Logo The Playground — PNG hébergé sur public/brand/icon.png.
             URL absolue obligatoire pour les clients email. */}
@@ -26,26 +34,20 @@ export function MagicLinkEmail({ url, baseUrl }: Props) {
         <Text style={brandName}>The Playground</Text>
       </Section>
 
-      <Text style={heading}>Votre lien de connexion</Text>
-      <Text style={bodyText}>
-        Cliquez sur le bouton ci-dessous pour vous connecter. Ce lien est valable{" "}
-        <strong>15 minutes</strong> et ne peut être utilisé qu'une seule fois.
-      </Text>
+      <Text style={heading}>{strings.heading}</Text>
+      <Text style={bodyText}>{strings.bodyText}</Text>
 
       <Section style={ctaSection}>
         <Button style={ctaButton} href={url}>
-          Se connecter →
+          {strings.ctaLabel}
         </Button>
       </Section>
 
-      <Text style={expiryText}>Expire dans 15 minutes · Usage unique</Text>
+      <Text style={expiryText}>{strings.expiryText}</Text>
 
       <Hr style={separator} />
 
-      <Text style={securityText}>
-        Vous n'avez pas demandé ce lien ? Votre compte reste sécurisé — ignorez
-        simplement cet email.
-      </Text>
+      <Text style={securityText}>{strings.securityText}</Text>
     </EmailLayout>
   );
 }

--- a/src/lib/auth/magic-link-url.ts
+++ b/src/lib/auth/magic-link-url.ts
@@ -13,14 +13,19 @@ const NEXT_LOCALE_COOKIE = /(?:^|;\s*)NEXT_LOCALE=([^;]+)/;
  */
 export function buildMagicLinkConfirmUrl(authJsUrl: string, request: Request): string {
   const original = new URL(authJsUrl);
-  const locale = detectLocale(request);
+  const locale = detectLocaleFromRequest(request);
   const prefix = locale === routing.defaultLocale ? "" : `/${locale}`;
   const confirm = new URL(`${prefix}/auth/confirm`, original.origin);
   confirm.search = original.search;
   return confirm.toString();
 }
 
-function detectLocale(request: Request): Locale {
+/**
+ * Détecte la locale d'une requête HTTP en dehors du contexte i18n Next.js
+ * (ex: callbacks Auth.js). Lit le cookie NEXT_LOCALE puis le header
+ * Accept-Language. Repli sur la locale par défaut.
+ */
+export function detectLocaleFromRequest(request: Request): Locale {
   const cookie = request.headers.get("cookie") ?? "";
   const match = cookie.match(NEXT_LOCALE_COOKIE);
   if (match && isSupportedLocale(match[1])) return match[1];

--- a/src/lib/email/__tests__/email-locale.test.ts
+++ b/src/lib/email/__tests__/email-locale.test.ts
@@ -28,8 +28,6 @@ describe("buildEmailLocaleResolver", () => {
 
       const resolver = await buildEmailLocaleResolver("trigger-user");
 
-      expect(resolver.triggerLocale).toBe("en");
-      expect(resolver.defaultLocale).toBe(DEFAULT_RECIPIENT_LOCALE);
       expect(resolver.resolveFor("trigger-user")).toBe("en");
       expect(resolver.resolveFor("host-user")).toBe(DEFAULT_RECIPIENT_LOCALE);
       expect(resolver.resolveFor(null)).toBe(DEFAULT_RECIPIENT_LOCALE);
@@ -59,7 +57,7 @@ describe("buildEmailLocaleResolver", () => {
   });
 
   describe("given a Host triggers from /fr (locale 'fr')", () => {
-    it("falls all recipients on FR (trigger + others)", async () => {
+    it("falls back all recipients to FR (trigger + others)", async () => {
       getLocaleMock.mockResolvedValue("fr");
 
       const resolver = await buildEmailLocaleResolver("host-user");

--- a/src/lib/email/__tests__/email-locale.test.ts
+++ b/src/lib/email/__tests__/email-locale.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const getLocaleMock = vi.fn();
+const getTranslationsMock = vi.fn();
+
+vi.mock("next-intl/server", () => ({
+  getLocale: () => getLocaleMock(),
+  getTranslations: (opts: unknown) => getTranslationsMock(opts),
+}));
+
+import {
+  buildEmailLocaleResolver,
+  DEFAULT_RECIPIENT_LOCALE,
+} from "../email-locale";
+
+describe("buildEmailLocaleResolver", () => {
+  beforeEach(() => {
+    getLocaleMock.mockReset();
+    getTranslationsMock.mockReset();
+    getTranslationsMock.mockImplementation(({ locale }: { locale: string }) =>
+      Promise.resolve(((key: string) => `[${locale}]${key}`) as unknown),
+    );
+  });
+
+  describe("given a Player triggers from /en (locale 'en')", () => {
+    it("resolves the trigger to 'en' and any other recipient to FR", async () => {
+      getLocaleMock.mockResolvedValue("en");
+
+      const resolver = await buildEmailLocaleResolver("trigger-user");
+
+      expect(resolver.triggerLocale).toBe("en");
+      expect(resolver.defaultLocale).toBe(DEFAULT_RECIPIENT_LOCALE);
+      expect(resolver.resolveFor("trigger-user")).toBe("en");
+      expect(resolver.resolveFor("host-user")).toBe(DEFAULT_RECIPIENT_LOCALE);
+      expect(resolver.resolveFor(null)).toBe(DEFAULT_RECIPIENT_LOCALE);
+      expect(resolver.resolveFor(undefined)).toBe(DEFAULT_RECIPIENT_LOCALE);
+    });
+
+    it("loads translations only once per locale (cache)", async () => {
+      getLocaleMock.mockResolvedValue("en");
+      const resolver = await buildEmailLocaleResolver("trigger-user");
+
+      await resolver.translationsFor("trigger-user");
+      await resolver.translationsFor("trigger-user");
+      await resolver.translationsFor("host-1");
+      await resolver.translationsFor("host-2");
+
+      // 2 locales distinctes (en + fr) → 2 appels seulement
+      expect(getTranslationsMock).toHaveBeenCalledTimes(2);
+      expect(getTranslationsMock).toHaveBeenCalledWith({
+        locale: "en",
+        namespace: "Email",
+      });
+      expect(getTranslationsMock).toHaveBeenCalledWith({
+        locale: DEFAULT_RECIPIENT_LOCALE,
+        namespace: "Email",
+      });
+    });
+  });
+
+  describe("given a Host triggers from /fr (locale 'fr')", () => {
+    it("falls all recipients on FR (trigger + others)", async () => {
+      getLocaleMock.mockResolvedValue("fr");
+
+      const resolver = await buildEmailLocaleResolver("host-user");
+
+      expect(resolver.resolveFor("host-user")).toBe("fr");
+      expect(resolver.resolveFor("player-en")).toBe(DEFAULT_RECIPIENT_LOCALE);
+    });
+  });
+
+  describe("given no trigger user (null)", () => {
+    it("treats every recipient as 'tier' → default locale", async () => {
+      getLocaleMock.mockResolvedValue("en");
+
+      const resolver = await buildEmailLocaleResolver(null);
+
+      expect(resolver.resolveFor("any-user")).toBe(DEFAULT_RECIPIENT_LOCALE);
+      expect(resolver.resolveFor(null)).toBe(DEFAULT_RECIPIENT_LOCALE);
+    });
+  });
+
+  describe("given a Host triggers from /en and approves another user", () => {
+    it("returns 'en' for the host (trigger) and FR for the approved member", async () => {
+      getLocaleMock.mockResolvedValue("en");
+
+      const resolver = await buildEmailLocaleResolver("host-user");
+
+      expect(resolver.resolveFor("host-user")).toBe("en");
+      expect(resolver.resolveFor("approved-member")).toBe(
+        DEFAULT_RECIPIENT_LOCALE,
+      );
+    });
+  });
+});

--- a/src/lib/email/email-locale.ts
+++ b/src/lib/email/email-locale.ts
@@ -1,0 +1,72 @@
+import { getLocale, getTranslations } from "next-intl/server";
+
+/**
+ * Locale appliquée à tout destinataire qui n'est pas le déclencheur de l'action.
+ * En l'absence de préférence de langue stockée par utilisateur, on retombe sur
+ * le défaut de la plateforme. À remplacer par une lecture de `User.preferredLocale`
+ * lorsque le champ existera.
+ */
+export const DEFAULT_RECIPIENT_LOCALE = "fr";
+
+type EmailTranslations = Awaited<ReturnType<typeof getTranslations<"Email">>>;
+
+/**
+ * Résolveur de locale email "par destinataire".
+ *
+ * Règle unique :
+ * - Le **déclencheur** de l'action garde la locale de la requête HTTP courante
+ *   (= `getLocale()`, dérivée du préfixe d'URL `/fr` ou `/en`).
+ * - Tout **autre destinataire** reçoit l'email dans la locale par défaut FR,
+ *   indépendamment de l'URL où le déclencheur se trouvait au moment d'agir.
+ *
+ * Évite ainsi qu'un Player anglophone qui s'inscrit depuis `/en/m/...` envoie
+ * une notification EN à des Hosts francophones — et le cas symétrique.
+ */
+export type EmailLocaleResolver = {
+  triggerLocale: string;
+  defaultLocale: string;
+  resolveFor: (recipientUserId: string | null | undefined) => string;
+  translationsFor: (
+    recipientUserId: string | null | undefined,
+  ) => Promise<EmailTranslations>;
+  defaultTranslations: () => Promise<EmailTranslations>;
+  triggerTranslations: () => Promise<EmailTranslations>;
+};
+
+/**
+ * Construit un resolver pour une action déclenchée par `triggerUserId`.
+ * Mémoïse les deux instances `t` (déclencheur + défaut) pour éviter les
+ * rechargements lors d'un envoi vers plusieurs destinataires.
+ */
+export async function buildEmailLocaleResolver(
+  triggerUserId: string | null | undefined,
+): Promise<EmailLocaleResolver> {
+  const triggerLocale = await getLocale();
+  const cache = new Map<string, Promise<EmailTranslations>>();
+
+  const loadTranslations = (locale: string) => {
+    let cached = cache.get(locale);
+    if (!cached) {
+      cached = getTranslations({ locale, namespace: "Email" });
+      cache.set(locale, cached);
+    }
+    return cached;
+  };
+
+  const resolveFor = (recipientUserId: string | null | undefined): string => {
+    if (triggerUserId && recipientUserId && recipientUserId === triggerUserId) {
+      return triggerLocale;
+    }
+    return DEFAULT_RECIPIENT_LOCALE;
+  };
+
+  return {
+    triggerLocale,
+    defaultLocale: DEFAULT_RECIPIENT_LOCALE,
+    resolveFor,
+    translationsFor: (recipientUserId) =>
+      loadTranslations(resolveFor(recipientUserId)),
+    defaultTranslations: () => loadTranslations(DEFAULT_RECIPIENT_LOCALE),
+    triggerTranslations: () => loadTranslations(triggerLocale),
+  };
+}

--- a/src/lib/email/email-locale.ts
+++ b/src/lib/email/email-locale.ts
@@ -1,4 +1,7 @@
 import { getLocale, getTranslations } from "next-intl/server";
+import { routing } from "@/i18n/routing";
+
+type Locale = (typeof routing.locales)[number];
 
 /**
  * Locale appliquée à tout destinataire qui n'est pas le déclencheur de l'action.
@@ -6,7 +9,7 @@ import { getLocale, getTranslations } from "next-intl/server";
  * le défaut de la plateforme. À remplacer par une lecture de `User.preferredLocale`
  * lorsque le champ existera.
  */
-export const DEFAULT_RECIPIENT_LOCALE = "fr";
+export const DEFAULT_RECIPIENT_LOCALE: Locale = routing.defaultLocale;
 
 type EmailTranslations = Awaited<ReturnType<typeof getTranslations<"Email">>>;
 
@@ -23,28 +26,25 @@ type EmailTranslations = Awaited<ReturnType<typeof getTranslations<"Email">>>;
  * une notification EN à des Hosts francophones — et le cas symétrique.
  */
 export type EmailLocaleResolver = {
-  triggerLocale: string;
-  defaultLocale: string;
-  resolveFor: (recipientUserId: string | null | undefined) => string;
+  resolveFor: (recipientUserId: string | null | undefined) => Locale;
   translationsFor: (
     recipientUserId: string | null | undefined,
   ) => Promise<EmailTranslations>;
   defaultTranslations: () => Promise<EmailTranslations>;
-  triggerTranslations: () => Promise<EmailTranslations>;
 };
 
 /**
  * Construit un resolver pour une action déclenchée par `triggerUserId`.
- * Mémoïse les deux instances `t` (déclencheur + défaut) pour éviter les
- * rechargements lors d'un envoi vers plusieurs destinataires.
+ * Mémoïse les traductions chargées par locale pour éviter les rechargements
+ * lors d'un envoi vers plusieurs destinataires.
  */
 export async function buildEmailLocaleResolver(
   triggerUserId: string | null | undefined,
 ): Promise<EmailLocaleResolver> {
-  const triggerLocale = await getLocale();
-  const cache = new Map<string, Promise<EmailTranslations>>();
+  const triggerLocale = (await getLocale()) as Locale;
+  const cache = new Map<Locale, Promise<EmailTranslations>>();
 
-  const loadTranslations = (locale: string) => {
+  const loadTranslations = (locale: Locale) => {
     let cached = cache.get(locale);
     if (!cached) {
       cached = getTranslations({ locale, namespace: "Email" });
@@ -53,7 +53,7 @@ export async function buildEmailLocaleResolver(
     return cached;
   };
 
-  const resolveFor = (recipientUserId: string | null | undefined): string => {
+  const resolveFor = (recipientUserId: string | null | undefined): Locale => {
     if (triggerUserId && recipientUserId && recipientUserId === triggerUserId) {
       return triggerLocale;
     }
@@ -61,12 +61,9 @@ export async function buildEmailLocaleResolver(
   };
 
   return {
-    triggerLocale,
-    defaultLocale: DEFAULT_RECIPIENT_LOCALE,
     resolveFor,
     translationsFor: (recipientUserId) =>
       loadTranslations(resolveFor(recipientUserId)),
     defaultTranslations: () => loadTranslations(DEFAULT_RECIPIENT_LOCALE),
-    triggerTranslations: () => loadTranslations(triggerLocale),
   };
 }

--- a/src/lib/email/format-moment-email.ts
+++ b/src/lib/email/format-moment-email.ts
@@ -1,0 +1,68 @@
+import { formatInTimeZone } from "date-fns-tz";
+import { fr } from "date-fns/locale/fr";
+import { enUS } from "date-fns/locale/en-US";
+import type { LocationType } from "@/domain/models/moment";
+
+const PLATFORM_TIMEZONE = "Europe/Paris";
+
+export function getDateFnsLocale(locale: string) {
+  return locale === "fr" ? fr : enUS;
+}
+
+export function formatLocationText(
+  locationType: LocationType | string,
+  locationName: string | null,
+  locationAddress: string | null,
+  videoLink: string | null,
+  locale: string,
+): string {
+  if (locationType === "ONLINE") {
+    return videoLink ?? (locale === "fr" ? "En ligne" : "Online");
+  }
+  if (locationType === "HYBRID") {
+    return (
+      [locationName, locationAddress].filter(Boolean).join(", ") ||
+      (locale === "fr" ? "Hybride" : "Hybrid")
+    );
+  }
+  return (
+    [locationName, locationAddress].filter(Boolean).join(", ") ||
+    (locale === "fr" ? "À définir" : "TBD")
+  );
+}
+
+export type MomentForEmail = {
+  startsAt: Date;
+  locationType: LocationType | string;
+  locationName: string | null;
+  locationAddress: string | null;
+  videoLink: string | null;
+};
+
+/**
+ * Pré-formate les chaînes de date et de lieu d'un événement pour un email,
+ * dans la locale du destinataire. Évite la duplication des 4 appels
+ * `formatInTimeZone` + `formatLocationText` dans chaque sender.
+ */
+export function buildMomentEmailContext(moment: MomentForEmail, locale: string) {
+  const dateFnsLocale = getDateFnsLocale(locale);
+  return {
+    momentDate: formatInTimeZone(
+      moment.startsAt,
+      PLATFORM_TIMEZONE,
+      "EEEE d MMMM yyyy, HH:mm",
+      { locale: dateFnsLocale },
+    ),
+    momentDateMonth: formatInTimeZone(moment.startsAt, PLATFORM_TIMEZONE, "MMM", {
+      locale: dateFnsLocale,
+    }),
+    momentDateDay: formatInTimeZone(moment.startsAt, PLATFORM_TIMEZONE, "d"),
+    locationText: formatLocationText(
+      moment.locationType,
+      moment.locationName,
+      moment.locationAddress,
+      moment.videoLink,
+      locale,
+    ),
+  };
+}


### PR DESCRIPTION
## Summary

- **Quick-win locale par destinataire** : nouveau helper `buildEmailLocaleResolver` (`src/lib/email/email-locale.ts`) qui applique la règle « le déclencheur garde sa locale d'URL, tout autre destinataire → FR ». Refactor de 6 actions (`registration`, `comment`, `circle`, `moment`, `broadcast-moment`, webhook Stripe) pour utiliser ce resolver. Corrige le bug où un Player anglophone qui s'inscrit depuis `/en/m/...` envoyait des notifications EN aux Hosts francophones (et le cas symétrique).
- **Magic link i18n** : sujet et template entièrement traduits via le namespace `Email.magicLink` (FR/EN sync, 8 clés). La locale de la requête de sign-in est détectée via `detectLocaleFromRequest` (helper privé déjà existant, exporté). Un user qui clique « Se connecter » depuis `/en/auth/sign-in` reçoit désormais son lien en anglais.
- **Refactor post-/simplify** : extraction de `buildMomentEmailContext`, `getDateFnsLocale` et `formatLocationText` vers `src/lib/email/format-moment-email.ts` (déduplique 2× registration/moment + 1 inline broadcast). Drop d'API morte sur le resolver. Slack parallélisé avec le batch Hosts dans `sendRegistrationEmails`. Net : −168 lignes.

## Périmètre couvert

Actions où la locale est désormais résolue par destinataire (déclencheur garde sa locale, autres → FR par défaut) :
- inscription / annulation / approbation / rejet d'événement
- promotion / désinscription depuis la liste d'attente
- annulation payante (host paid cancellation)
- modification / annulation d'événement
- publication d'événement (auto-confirmation Host)
- broadcast manuel
- nouveau commentaire
- nouveau membre / approbation / rejet d'adhésion à une Communauté
- retrait d'un membre
- promotion / désignation co-host
- magic link (cas spécial : déclencheur = destinataire, locale URL conservée)

Hors scope (nécessitent `User.preferredLocale` en DB, suivront dans une PR future) :
- rappel 24h avant événement (cron)
- lettre du fondateur J+1 (cron, contenu FR-only à traduire)
- notification automatique « nouvel événement publié » aux membres (`notifyNewMoment`)

## Changement de comportement intentionnel

Pour les événements **HYBRID sans location précisée** (rare en prod), le repli passe de `"À définir"` à `"Hybride"` (FR) / `"Hybrid"` (EN). Aligne sur ce que `notify-new-moment.ts` faisait déjà.

## Test plan

- [x] `pnpm typecheck` ✅
- [x] `pnpm test --run` ✅ (1035/1035)
- [x] `pnpm build` ✅
- [x] Sync FR/EN namespace `Email` (121 clés des deux côtés) ✅
- [x] Sous-clés `coHostPromoted.*` / `coHostDemoted.*` toutes présentes FR + EN ✅
- [ ] Smoke test sur preview : sign-in depuis `/en/auth/sign-in` → magic link en anglais
- [ ] Smoke test sur preview : `/en/m/<slug>` → s'inscrire → email Player en EN, email Host en FR
- [ ] Smoke test sur preview : Host modifie un événement depuis `/fr/dashboard/...` → tous les Players reçoivent en FR (statu quo)

## Commits

- `3a94f27` quick-win locale par destinataire
- `1484e54` magic link i18n
- `c6c6b9d` nettoyage post-/simplify

🤖 Generated with [Claude Code](https://claude.com/claude-code)