### PR TITLE
fix(circles): load all members past page 1 in modal infinite scroll

### DIFF
--- a/scripts/db-seed-test-data.ts
+++ b/scripts/db-seed-test-data.ts
@@ -529,6 +529,53 @@ async function main() {
     }
   }
 
+  // ── Large members Circle (test pagination modale, PAGE_SIZE = 20) ──────────
+  // 1 HOST + 21 PLAYERS = 22 memberships → le 21e PLAYER tombe sur la page 2
+  console.log("\n⭕ Circle: Test Large Members (pagination)");
+  const largeCircle = await prisma.circle.upsert({
+    where: { slug: "test-large-members" },
+    create: {
+      slug: "test-large-members",
+      name: "Test Large Members",
+      description:
+        "Communauté de test avec 22 membres pour valider la pagination de la modale (PAGE_SIZE = 20).",
+      visibility: "PUBLIC",
+      requiresApproval: false,
+    },
+    update: {},
+  });
+
+  await prisma.circleMembership.upsert({
+    where: { userId_circleId: { userId: userMap["host"], circleId: largeCircle.id } },
+    create: { userId: userMap["host"], circleId: largeCircle.id, role: "HOST" },
+    update: { role: "HOST" },
+  });
+
+  for (let i = 1; i <= 21; i++) {
+    const idx = String(i).padStart(2, "0");
+    const email = `large-member-${idx}@test.playground`;
+    const firstName = `LargeMember${idx}`;
+    const lastName = "Test";
+    const user = await prisma.user.upsert({
+      where: { email },
+      create: {
+        email,
+        name: `${firstName} ${lastName}`,
+        firstName,
+        lastName,
+        onboardingCompleted: true,
+        emailVerified: new Date(),
+      },
+      update: {},
+    });
+    await prisma.circleMembership.upsert({
+      where: { userId_circleId: { userId: user.id, circleId: largeCircle.id } },
+      create: { userId: user.id, circleId: largeCircle.id, role: "PLAYER" },
+      update: {},
+    });
+  }
+  console.log(`  ✓ 1 HOST + 21 PLAYERS = 22 memberships`);
+
   // Récapitulatif
   console.log("\n✅ Données test injectées avec succès.\n");
   console.log("Impersonation (dev uniquement) :");

--- a/scripts/db-seed-test-data.ts
+++ b/scripts/db-seed-test-data.ts
@@ -532,10 +532,11 @@ async function main() {
   // ── Large members Circle (test pagination modale, PAGE_SIZE = 20) ──────────
   // 1 HOST + 21 PLAYERS = 22 memberships → le 21e PLAYER tombe sur la page 2
   console.log("\n⭕ Circle: Test Large Members (pagination)");
+  const LARGE_MEMBERS_SLUG = "test-large-members";
   const largeCircle = await prisma.circle.upsert({
-    where: { slug: "test-large-members" },
+    where: { slug: LARGE_MEMBERS_SLUG },
     create: {
-      slug: "test-large-members",
+      slug: LARGE_MEMBERS_SLUG,
       name: "Test Large Members",
       description:
         "Communauté de test avec 22 membres pour valider la pagination de la modale (PAGE_SIZE = 20).",

--- a/src/components/circles/circle-members-dialog.tsx
+++ b/src/components/circles/circle-members-dialog.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { toast } from "sonner";
 import { Link } from "@/i18n/navigation";
+import { useInfiniteScroll } from "@/hooks/use-infinite-scroll";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -79,11 +80,6 @@ export function CircleMembersDialog({
   const [hasMore, setHasMore] = useState(initialHasMore);
   const [isLoading, startLoad] = useTransition();
   const [isExporting, startExport] = useTransition();
-  // Callback refs (useState) plutôt que useRef : Radix monte le DialogContent dans
-  // un Portal de manière différée, et un useRef ne déclenche pas de re-run d'effect
-  // quand le node est attaché. Avec useState, l'effect re-tourne dès que le node est prêt.
-  const [sentinelEl, setSentinelEl] = useState<HTMLDivElement | null>(null);
-  const [scrollContainerEl, setScrollContainerEl] = useState<HTMLDivElement | null>(null);
   const canExport = callerRole === "HOST" || callerRole === "CO_HOST";
 
   function handleExportCsv() {
@@ -158,21 +154,11 @@ export function CircleMembersDialog({
     setMembers((prev) => prev.map((m) => (m.user.id === userId ? { ...m, role } : m)));
   }, []);
 
-  useEffect(() => {
-    if (!open || !hasMore || !sentinelEl || !scrollContainerEl) return;
-    // `root: scrollContainerEl` est essentiel : sans ça, l'observer regarde le
-    // viewport global au lieu du conteneur scrollable de la modale → le sentinel
-    // n'intersecte jamais quand on scrolle DANS la modale, et loadMore n'est
-    // jamais appelé.
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries[0]?.isIntersecting) loadMore();
-      },
-      { root: scrollContainerEl, rootMargin: "120px" },
-    );
-    observer.observe(sentinelEl);
-    return () => observer.disconnect();
-  }, [open, hasMore, loadMore, sentinelEl, scrollContainerEl]);
+  const { scrollContainerRef, sentinelRef } = useInfiniteScroll({
+    enabled: open,
+    hasMore,
+    onLoadMore: loadMore,
+  });
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
@@ -217,7 +203,7 @@ export function CircleMembersDialog({
         </DialogHeader>
 
         <div
-          ref={setScrollContainerEl}
+          ref={scrollContainerRef}
           data-testid="circle-members-scroll-container"
           className="min-h-0 flex-1 overflow-y-auto px-6 pt-2 pb-6"
         >
@@ -236,7 +222,7 @@ export function CircleMembersDialog({
           </ul>
           {hasMore && (
             <div
-              ref={setSentinelEl}
+              ref={sentinelRef}
               data-testid="circle-members-sentinel"
               className="text-muted-foreground py-4 text-center text-xs"
             >

--- a/src/components/circles/circle-members-dialog.tsx
+++ b/src/components/circles/circle-members-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState, useTransition } from "react";
+import { useCallback, useEffect, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { toast } from "sonner";
@@ -79,7 +79,11 @@ export function CircleMembersDialog({
   const [hasMore, setHasMore] = useState(initialHasMore);
   const [isLoading, startLoad] = useTransition();
   const [isExporting, startExport] = useTransition();
-  const sentinelRef = useRef<HTMLDivElement>(null);
+  // Callback refs (useState) plutôt que useRef : Radix monte le DialogContent dans
+  // un Portal de manière différée, et un useRef ne déclenche pas de re-run d'effect
+  // quand le node est attaché. Avec useState, l'effect re-tourne dès que le node est prêt.
+  const [sentinelEl, setSentinelEl] = useState<HTMLDivElement | null>(null);
+  const [scrollContainerEl, setScrollContainerEl] = useState<HTMLDivElement | null>(null);
   const canExport = callerRole === "HOST" || callerRole === "CO_HOST";
 
   function handleExportCsv() {
@@ -155,17 +159,20 @@ export function CircleMembersDialog({
   }, []);
 
   useEffect(() => {
-    if (!open || !hasMore || !sentinelRef.current) return;
-    const sentinel = sentinelRef.current;
+    if (!open || !hasMore || !sentinelEl || !scrollContainerEl) return;
+    // `root: scrollContainerEl` est essentiel : sans ça, l'observer regarde le
+    // viewport global au lieu du conteneur scrollable de la modale → le sentinel
+    // n'intersecte jamais quand on scrolle DANS la modale, et loadMore n'est
+    // jamais appelé.
     const observer = new IntersectionObserver(
       (entries) => {
         if (entries[0]?.isIntersecting) loadMore();
       },
-      { rootMargin: "120px" },
+      { root: scrollContainerEl, rootMargin: "120px" },
     );
-    observer.observe(sentinel);
+    observer.observe(sentinelEl);
     return () => observer.disconnect();
-  }, [open, hasMore, loadMore]);
+  }, [open, hasMore, loadMore, sentinelEl, scrollContainerEl]);
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
@@ -209,7 +216,11 @@ export function CircleMembersDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <div className="min-h-0 flex-1 overflow-y-auto px-6 pt-2 pb-6">
+        <div
+          ref={setScrollContainerEl}
+          data-testid="circle-members-scroll-container"
+          className="min-h-0 flex-1 overflow-y-auto px-6 pt-2 pb-6"
+        >
           <ul className="divide-border divide-y">
             {members.map((member) => (
               <MemberRow
@@ -224,7 +235,11 @@ export function CircleMembersDialog({
             ))}
           </ul>
           {hasMore && (
-            <div ref={sentinelRef} className="text-muted-foreground py-4 text-center text-xs">
+            <div
+              ref={setSentinelEl}
+              data-testid="circle-members-sentinel"
+              className="text-muted-foreground py-4 text-center text-xs"
+            >
               {isLoading ? "…" : ""}
             </div>
           )}

--- a/src/components/moments/moment-registrations-dialog.tsx
+++ b/src/components/moments/moment-registrations-dialog.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState, useTransition } from "react";
+import { useCallback, useEffect, useState, useTransition } from "react";
 import { useTranslations } from "next-intl";
 import { Link } from "@/i18n/navigation";
+import { useInfiniteScroll } from "@/hooks/use-infinite-scroll";
 import {
   Dialog,
   DialogContent,
@@ -82,7 +83,6 @@ export function MomentRegistrationsDialog({
     name: string;
     isPaid: boolean;
   } | null>(null);
-  const sentinelRef = useRef<HTMLDivElement>(null);
 
   function handleExportCsv() {
     const eventDate = momentStartsAt.toISOString().slice(0, 10);
@@ -136,18 +136,11 @@ export function MomentRegistrationsDialog({
     });
   }, [momentId, participants.length, hasMore, isLoading]);
 
-  useEffect(() => {
-    if (!open || !hasMore || !sentinelRef.current) return;
-    const sentinel = sentinelRef.current;
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries[0]?.isIntersecting) loadMore();
-      },
-      { rootMargin: "120px" },
-    );
-    observer.observe(sentinel);
-    return () => observer.disconnect();
-  }, [open, hasMore, loadMore]);
+  const { scrollContainerRef, sentinelRef } = useInfiniteScroll({
+    enabled: open,
+    hasMore,
+    onLoadMore: loadMore,
+  });
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
@@ -194,7 +187,10 @@ export function MomentRegistrationsDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <div className="min-h-0 flex-1 overflow-y-auto px-6 pt-2 pb-6">
+        <div
+          ref={scrollContainerRef}
+          className="min-h-0 flex-1 overflow-y-auto px-6 pt-2 pb-6"
+        >
           <ul className="divide-border divide-y">
             {participants.map((r) => (
               <ParticipantRow

--- a/src/hooks/use-infinite-scroll.ts
+++ b/src/hooks/use-infinite-scroll.ts
@@ -1,0 +1,57 @@
+import { useEffect, useState } from "react";
+
+type Options = {
+  /** Active l'observer (typiquement : la modale est ouverte). */
+  enabled: boolean;
+  /** Reste-t-il des éléments à charger ? Si false, le sentinel n'est pas observé. */
+  hasMore: boolean;
+  /** Callback déclenché quand le sentinel devient visible. */
+  onLoadMore: () => void;
+  /** Marge déclenchant le pré-chargement (défaut 120px). */
+  rootMargin?: string;
+};
+
+/**
+ * Infinite scroll via IntersectionObserver, conçu pour fonctionner dans une
+ * modale Radix Dialog (Portal asynchrone).
+ *
+ * Deux subtilités encapsulées ici :
+ *
+ * - Callback refs (`useState`) plutôt que `useRef` : Radix monte le
+ *   DialogContent dans un Portal de manière différée. Un `useRef` ne
+ *   déclencherait pas de re-run d'effect quand le node est enfin attaché.
+ *
+ * - `root: scrollContainer` sur l'observer : sans cette option, l'observer
+ *   regarde le viewport global au lieu du conteneur scrollable de la modale.
+ *   Le sentinel n'intersecte alors jamais quand on scrolle DANS la modale,
+ *   et `onLoadMore` n'est jamais appelé.
+ */
+export function useInfiniteScroll({
+  enabled,
+  hasMore,
+  onLoadMore,
+  rootMargin = "120px",
+}: Options): {
+  scrollContainerRef: (node: HTMLDivElement | null) => void;
+  sentinelRef: (node: HTMLDivElement | null) => void;
+} {
+  const [scrollContainer, setScrollContainer] = useState<HTMLDivElement | null>(null);
+  const [sentinel, setSentinel] = useState<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!enabled || !hasMore || !scrollContainer || !sentinel) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) onLoadMore();
+      },
+      { root: scrollContainer, rootMargin },
+    );
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [enabled, hasMore, onLoadMore, scrollContainer, sentinel, rootMargin]);
+
+  return {
+    scrollContainerRef: setScrollContainer,
+    sentinelRef: setSentinel,
+  };
+}

--- a/tests/e2e/circle-members-modal-pagination.spec.ts
+++ b/tests/e2e/circle-members-modal-pagination.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from "@playwright/test";
+import { SLUGS, AUTH } from "./fixtures";
+
+/**
+ * Tests E2E — Pagination de la modale CircleMembersDialog
+ *
+ * Régression : sur un Circle avec > PAGE_SIZE (20) membres, la première page
+ * était la seule chargée. L'IntersectionObserver de l'infinite scroll observait
+ * le viewport global au lieu du conteneur scrollable de la modale, donc le
+ * sentinel ne devenait jamais "intersecting" et loadMore() n'était jamais
+ * déclenché.
+ *
+ * Ce test exerce le scénario : Circle "test-large-members" avec 22 membres
+ * (1 HOST + 21 PLAYERS) → le 21e PLAYER (LargeMember21) tombe en page 2 et
+ * doit apparaître après scroll dans le conteneur de la modale.
+ */
+
+test.describe("Modale membres — pagination infinite scroll", () => {
+  test.use({ storageState: AUTH.HOST });
+
+  test("should load all members of a Circle with > PAGE_SIZE members via infinite scroll", async ({ page }) => {
+    await page.goto(`/fr/circles/${SLUGS.LARGE_MEMBERS_CIRCLE}`);
+
+    // Ouvre la modale via le bloc stats "22 Membres"
+    const trigger = page.getByRole("button", { name: /\d+ membres?/i }).first();
+    await expect(trigger).toBeVisible();
+    await trigger.click();
+
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toContainText("22 membres");
+
+    // À l'ouverture, seule la page 1 est chargée (20 membres)
+    // → LargeMember21 (en page 2) ne doit pas être présent dans le DOM
+    await expect(dialog.getByText("LargeMember21", { exact: false })).toHaveCount(0);
+
+    // Scroll le conteneur de la modale jusqu'en bas pour déclencher l'observer
+    const scrollContainer = dialog.getByTestId("circle-members-scroll-container");
+    await expect(scrollContainer).toBeVisible();
+    await scrollContainer.evaluate((el) => {
+      el.scrollTop = el.scrollHeight;
+    });
+
+    // LargeMember21 (21e PLAYER, donc 22e dans la liste avec le HOST) doit
+    // maintenant apparaître. Si l'infinite scroll est cassé, ce test timeout.
+    await expect(dialog.getByText("LargeMember21", { exact: false })).toBeVisible();
+
+    // Et le sentinel disparaît (hasMore = false) une fois tous les membres chargés
+    await expect(dialog.getByTestId("circle-members-sentinel")).toHaveCount(0);
+  });
+});

--- a/tests/e2e/circle-members-modal-pagination.spec.ts
+++ b/tests/e2e/circle-members-modal-pagination.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "@playwright/test";
 import { SLUGS, AUTH } from "./fixtures";
+import { openCircleMembersDialog } from "./helpers/circle-members";
 
 /**
  * Tests E2E — Pagination de la modale CircleMembersDialog
@@ -21,29 +22,24 @@ test.describe("Modale membres — pagination infinite scroll", () => {
   test("should load all members of a Circle with > PAGE_SIZE members via infinite scroll", async ({ page }) => {
     await page.goto(`/fr/circles/${SLUGS.LARGE_MEMBERS_CIRCLE}`);
 
-    // Ouvre la modale via le bloc stats "22 Membres"
-    const trigger = page.getByRole("button", { name: /\d+ membres?/i }).first();
-    await expect(trigger).toBeVisible();
-    await trigger.click();
-
-    const dialog = page.getByRole("dialog");
-    await expect(dialog).toBeVisible();
+    const dialog = await openCircleMembersDialog(page);
     await expect(dialog).toContainText("22 membres");
 
-    // À l'ouverture, seule la page 1 est chargée (20 membres)
-    // → LargeMember21 (en page 2) ne doit pas être présent dans le DOM
-    await expect(dialog.getByText("LargeMember21", { exact: false })).toHaveCount(0);
+    // À l'ouverture, seule la page 1 est chargée (20 membres) → LargeMember21
+    // (en page 2) ne doit pas être présent dans le DOM. Match exact pour
+    // éviter qu'un futur LargeMember210 ne fasse passer l'assertion par erreur.
+    const lastMember = dialog.getByText("LargeMember21 Test", { exact: true });
+    await expect(lastMember).toHaveCount(0);
 
     // Scroll le conteneur de la modale jusqu'en bas pour déclencher l'observer
     const scrollContainer = dialog.getByTestId("circle-members-scroll-container");
-    await expect(scrollContainer).toBeVisible();
     await scrollContainer.evaluate((el) => {
       el.scrollTop = el.scrollHeight;
     });
 
-    // LargeMember21 (21e PLAYER, donc 22e dans la liste avec le HOST) doit
-    // maintenant apparaître. Si l'infinite scroll est cassé, ce test timeout.
-    await expect(dialog.getByText("LargeMember21", { exact: false })).toBeVisible();
+    // LargeMember21 doit maintenant apparaître. Si l'infinite scroll est
+    // cassé, ce test timeout.
+    await expect(lastMember).toBeVisible();
 
     // Et le sentinel disparaît (hasMore = false) une fois tous les membres chargés
     await expect(dialog.getByTestId("circle-members-sentinel")).toHaveCount(0);

--- a/tests/e2e/co-host.spec.ts
+++ b/tests/e2e/co-host.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "@playwright/test";
 import { SLUGS, AUTH } from "./fixtures";
+import { openCircleMembersDialog } from "./helpers/circle-members";
 
 /**
  * Tests E2E — Feature co-organisateurs
@@ -20,16 +21,6 @@ import { SLUGS, AUTH } from "./fixtures";
  * Les tests E2E se concentrent sur la surface UI.
  */
 
-/** Ouvre la modale Membres via le bloc stats "X Membres" et retourne le dialog. */
-async function openMembersDialog(page: Parameters<Parameters<typeof test>[2]>[0]["page"]) {
-  const trigger = page.getByRole("button", { name: /\d+ membres?/i }).first();
-  await expect(trigger).toBeVisible();
-  await trigger.click();
-  const dialog = page.getByRole("dialog");
-  await expect(dialog).toBeVisible();
-  return dialog;
-}
-
 test.describe("Co-organisateurs — UI HOST", () => {
   test.use({ storageState: AUTH.HOST });
 
@@ -37,14 +28,14 @@ test.describe("Co-organisateurs — UI HOST", () => {
     await page.goto(`/fr/dashboard/circles/${SLUGS.CIRCLE}`);
 
     // La modale membres est accessible via le bloc stats
-    const dialog = await openMembersDialog(page);
+    const dialog = await openCircleMembersDialog(page);
     await expect(dialog).toContainText(/Membres/i);
   });
 
   test("should show the contextual menu trigger for PLAYER members", async ({ page }) => {
     await page.goto(`/fr/dashboard/circles/${SLUGS.CIRCLE}`);
 
-    const dialog = await openMembersDialog(page);
+    const dialog = await openCircleMembersDialog(page);
     // Au moins un bouton d'actions doit être présent pour les PLAYERs de la Communauté seed
     // On exclut les boutons disabled (HOST principal qui ne peut pas s'auto-promouvoir)
     const actionButtons = dialog.locator('button[aria-label="Actions"]:not([disabled])');
@@ -54,7 +45,7 @@ test.describe("Co-organisateurs — UI HOST", () => {
   test("should expose the Promote to co-organizer action in the menu", async ({ page }) => {
     await page.goto(`/fr/dashboard/circles/${SLUGS.CIRCLE}`);
 
-    const dialog = await openMembersDialog(page);
+    const dialog = await openCircleMembersDialog(page);
     // On exclut les boutons disabled (HOST principal)
     const firstActionButton = dialog
       .locator('button[aria-label="Actions"]:not([disabled])')
@@ -68,7 +59,7 @@ test.describe("Co-organisateurs — UI HOST", () => {
   test("should show the single Organisateur badge on the Circle HOST", async ({ page }) => {
     await page.goto(`/fr/dashboard/circles/${SLUGS.CIRCLE}`);
 
-    const dialog = await openMembersDialog(page);
+    const dialog = await openCircleMembersDialog(page);
     // Badge unique "Organisateur" pour HOST et CO_HOST, partout (D8 simplifié)
     await expect(dialog).toContainText(/Organisateur/);
   });
@@ -82,7 +73,7 @@ test.describe("Co-organisateurs — UI public", () => {
 
     // Badge unique "Organisateur" côté public comme dashboard — HOST et CO_HOST confondus.
     // Depuis la refonte, le badge est dans la modale Membres (la section inline a été retirée).
-    const dialog = await openMembersDialog(page);
+    const dialog = await openCircleMembersDialog(page);
     await expect(dialog).toContainText(/Organisateur/);
   });
 });

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -36,6 +36,8 @@ export const SLUGS = {
   MOMENT_BOTH_APPROVAL: "test-moment-both-approval",
   /** Circle Network (réseau de test contenant paris-creative-tech) */
   NETWORK: "test-network",
+  /** Circle avec 22 membres (1 HOST + 21 PLAYERS) — test pagination modale (PAGE_SIZE=20) */
+  LARGE_MEMBERS_CIRCLE: "test-large-members",
 } as const;
 
 // ── Chemins auth (générés par globalSetup) ────────────────────────────────────

--- a/tests/e2e/helpers/circle-members.ts
+++ b/tests/e2e/helpers/circle-members.ts
@@ -1,0 +1,14 @@
+import { type Locator, type Page, expect } from "@playwright/test";
+
+/**
+ * Ouvre la modale Membres via le bloc stats "X Membres" et retourne le dialog.
+ * Fonctionne aussi bien sur la page publique du Circle que sur le dashboard.
+ */
+export async function openCircleMembersDialog(page: Page): Promise<Locator> {
+  const trigger = page.getByRole("button", { name: /\d+ membres?/i }).first();
+  await expect(trigger).toBeVisible();
+  await trigger.click();
+  const dialog = page.getByRole("dialog");
+  await expect(dialog).toBeVisible();
+  return dialog;
+}


### PR DESCRIPTION
## Summary

- **Bug** : sur les Communautés > 20 membres, la modale plafonnait silencieusement à 20 entrées affichées. Le `IntersectionObserver` du sentinel n'avait pas d'option `root` → il observait le viewport global au lieu du conteneur scrollable de la modale, donc le scroll interne ne déclenchait jamais `loadMore()`.
- **Impact prod** : Tech Speak'Her (24 membres), Agile Bordeaux (21), et toute communauté qui dépasse 20 après une nouvelle inscription. Le compteur global affichait le bon total mais la liste paginée était amputée. Découvert via le cas `ghembaza.aicha@gmail.com` (21ᵉ membre d'Agile Bordeaux, invisible dans la modale).
- **Fix** : passer `root: scrollContainer` à l'observer + remplacer `useRef` par des callback refs (`useState`) pour gérer le timing du Portal Radix qui monte le `DialogContent` de manière différée.
- **Refactor** : la même logique était dupliquée dans `MomentRegistrationsDialog` avec exactement le même bug latent. Extraction d'un hook `useInfiniteScroll` partagé qui fixe les deux modales et encapsule les deux subtilités.

## Files

- `src/hooks/use-infinite-scroll.ts` (new) — hook partagé
- `src/components/circles/circle-members-dialog.tsx` — utilise le hook + `data-testid` pour le test E2E
- `src/components/moments/moment-registrations-dialog.tsx` — utilise le hook (fix latent inclus)
- `tests/e2e/helpers/circle-members.ts` (new) — `openCircleMembersDialog` partagé
- `tests/e2e/co-host.spec.ts` — utilise le helper
- `tests/e2e/circle-members-modal-pagination.spec.ts` (new) — régression
- `scripts/db-seed-test-data.ts` — seed Circle `test-large-members` (1 HOST + 21 PLAYERS)
- `tests/e2e/fixtures.ts` — slug `LARGE_MEMBERS_CIRCLE`

## Test plan

- [x] `pnpm typecheck` passe
- [ ] CI vert
- [ ] Test E2E `circle-members-modal-pagination.spec.ts` passe (ouvre la modale, scroll, vérifie que `LargeMember21 Test` apparaît + sentinel disparaît)
- [ ] Test manuel sur preview : ouvrir la modale d'une Communauté > 20 membres, scroller jusqu'au bas, vérifier que tous les membres apparaissent
- [ ] Test manuel : ouvrir la modale "X inscrits" sur un Moment > 20 inscrits, idem

## Notes

Aucun changement de schema Prisma → pas de `db:push:prod` requis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)