### PR TITLE
chore(docs): add .env.example + contributor setup guide in README

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,135 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# The Playground — variables d'environnement
+#
+# Copier ce fichier en .env.local et remplir les valeurs.
+# .env et .env.local sont gitignorés — n'engage jamais de secrets dans le repo.
+#
+# Légende :
+#   [REQUIS]   — l'app ne démarre pas sans
+#   [AUTH]     — au moins UN bloc d'auth doit être complété
+#   [OPTION]   — feature dégradée ou off si manquante, app fonctionnelle
+#   [INTERNE]  — réservé maintainers (accès prod, scripts admin) — NE PAS configurer
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+# ── [REQUIS] Base de données ─────────────────────────────────────────────────
+# Crée TA PROPRE branche Neon (https://neon.tech, free tier) ou un Postgres local.
+# ⛔ N'utilise JAMAIS l'URL de prod en local.
+DATABASE_URL="postgresql://user:password@host/dbname?sslmode=require"
+
+
+# ── [REQUIS] App ─────────────────────────────────────────────────────────────
+NEXT_PUBLIC_APP_URL="http://localhost:3000"
+
+
+# ── [REQUIS] Auth.js — secret ────────────────────────────────────────────────
+# Génère avec : npx auth secret
+AUTH_SECRET=""
+
+
+# ── [REQUIS] Email — adresses d'expéditeur ───────────────────────────────────
+# En local, garder onboarding@resend.dev (pas besoin de domaine vérifié).
+AUTH_EMAIL_FROM="onboarding@resend.dev"
+EMAIL_FROM="onboarding@resend.dev"
+ONBOARDING_EMAIL_FROM="onboarding@resend.dev"
+
+
+# ── [AUTH] Choisir AU MOINS UN provider de connexion ─────────────────────────
+#
+# Option A — Magic link (Resend) — RECOMMANDÉE
+#   1. Crée un compte gratuit sur https://resend.com (100 emails/jour)
+#   2. Récupère ta clé API (commence par "re_")
+#   3. Renseigne ton email dans STAGING_EMAIL_ALLOWLIST ci-dessous
+#      → seule cette adresse recevra les emails en local. Tout le reste est bloqué
+#        par safe-resend.ts (cf spec/email-testing.md).
+AUTH_RESEND_KEY=""
+STAGING_EMAIL_ALLOWLIST="ton.email@example.com"
+
+# Option B — Google OAuth
+#   1. https://console.cloud.google.com/apis/credentials → "OAuth client ID" type Web
+#   2. Authorized redirect URI : http://localhost:3000/api/auth/callback/google
+AUTH_GOOGLE_ID=""
+AUTH_GOOGLE_SECRET=""
+
+# Option C — GitHub OAuth
+#   1. https://github.com/settings/developers → "New OAuth App"
+#   2. Authorization callback URL : http://localhost:3000/api/auth/callback/github
+AUTH_GITHUB_ID=""
+AUTH_GITHUB_SECRET=""
+
+
+# ── [OPTION] Stripe Connect (paiements événements) ───────────────────────────
+# Sans ces clés, les événements payants sont KO (mais les gratuits fonctionnent).
+# Utiliser les clés TEST MODE uniquement (commencent par sk_test_ / pk_test_).
+# https://dashboard.stripe.com/test/apikeys
+STRIPE_SECRET_KEY=""
+STRIPE_PUBLISHABLE_KEY=""
+STRIPE_WEBHOOK_SECRET=""
+
+
+# ── [OPTION] Anthropic Claude (assistant IA) ─────────────────────────────────
+# Sans cette clé, les features IA sont off (descriptions, suggestions, radar).
+# https://console.anthropic.com/settings/keys
+ANTHROPIC_API_KEY=""
+
+
+# ── [OPTION] Vercel Blob (upload images) ─────────────────────────────────────
+# Sans ce token, l'upload d'images de couverture / avatars ne marche pas.
+# https://vercel.com/dashboard → Storage → Blob → créer un store
+BLOB_READ_WRITE_TOKEN=""
+
+
+# ── [OPTION] Google Maps (autocomplete adresses) ─────────────────────────────
+# Sans ces clés, le champ adresse devient un input texte simple.
+# https://console.cloud.google.com/google/maps-apis
+NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=""
+GOOGLE_PLACES_API_KEY=""
+
+
+# ── [OPTION] Unsplash (recherche d'images de couverture) ─────────────────────
+# Sans cette clé, la recherche Unsplash est désactivée (upload direct OK).
+# https://unsplash.com/developers
+UNSPLASH_ACCESS_KEY=""
+
+
+# ── [OPTION] PostHog (analytics) ─────────────────────────────────────────────
+# Sans ces clés, aucun event n'est tracké en local — sans impact fonctionnel.
+NEXT_PUBLIC_POSTHOG_KEY=""
+POSTHOG_PERSONAL_API_KEY=""
+
+
+# ── [OPTION] Sentry (error monitoring) ───────────────────────────────────────
+# Sans ces clés, les erreurs ne sont pas remontées à Sentry — sans impact fonctionnel.
+NEXT_PUBLIC_SENTRY_DSN=""
+SENTRY_ORG=""
+SENTRY_PROJECT=""
+SENTRY_AUTH_TOKEN=""
+SENTRY_WEBHOOK_SECRET=""
+SENTRY_ALERT_EMAIL=""
+
+
+# ── [OPTION] Cron jobs / E2E secrets ─────────────────────────────────────────
+# Nécessaires uniquement si tu travailles sur les cron jobs ou des tests E2E custom.
+# Génère avec : openssl rand -hex 32
+CRON_SECRET=""
+E2E_SECRET=""
+
+
+# ── [OPTION] Admin / notifications internes ──────────────────────────────────
+# Pour les notifications admin de la plateforme (création de Communauté, rapport quotidien).
+# En local : laisser vide ou mettre ta propre adresse pour tester.
+ADMIN_NOTIFICATIONS_EMAIL=""
+DAILY_REPORT_RECIPIENT=""
+SLACK_ADMIN_WEBHOOK_URL=""
+
+
+# ── [INTERNE] Ne PAS renseigner sauf si tu es maintainer ─────────────────────
+# Ces variables donnent accès à la production / aux scripts admin.
+# Un contributeur externe ne doit JAMAIS les configurer.
+#
+# NEON_API_KEY=""                # accès API Neon (prod + staging)
+# NEON_PROJECT_ID=""             # projet Neon
+# NEON_PROD_BRANCH_ID=""         # branche prod (db:push:prod, db:studio:prod)
+# NEON_STAGING_BRANCH_ID=""      # branche staging
+# VERCEL_TOKEN=""                # API Vercel
+# IS_STAGING=""                  # défini côté Vercel uniquement

--- a/.env.example
+++ b/.env.example
@@ -28,9 +28,14 @@ AUTH_SECRET=""
 
 
 # ── [REQUIS] Email — adresses d'expéditeur ───────────────────────────────────
-# En local, garder onboarding@resend.dev (pas besoin de domaine vérifié).
-AUTH_EMAIL_FROM="onboarding@resend.dev"
+# En local, garder onboarding@resend.dev (adresse publique de test Resend,
+# pas besoin de domaine vérifié). En prod, utiliser un domaine vérifié.
+#
+# Hiérarchie des fallbacks dans le code :
+#   EMAIL_FROM (primaire) → AUTH_EMAIL_FROM (legacy) → "onboarding@resend.dev"
+#   ONBOARDING_EMAIL_FROM est utilisé spécifiquement pour les emails d'onboarding.
 EMAIL_FROM="onboarding@resend.dev"
+AUTH_EMAIL_FROM="onboarding@resend.dev"
 ONBOARDING_EMAIL_FROM="onboarding@resend.dev"
 
 
@@ -42,6 +47,11 @@ ONBOARDING_EMAIL_FROM="onboarding@resend.dev"
 #   3. Renseigne ton email dans STAGING_EMAIL_ALLOWLIST ci-dessous
 #      → seule cette adresse recevra les emails en local. Tout le reste est bloqué
 #        par safe-resend.ts (cf spec/email-testing.md).
+#
+# AUTH_RESEND_KEY est utilisée non seulement pour le magic link mais aussi pour
+# TOUS les autres envois (notifications, broadcast, confirmations). Sans clé,
+# le client Resend échouera silencieusement côté API ; le guard local masque
+# l'erreur tant que les destinataires ne sont pas allowlistés.
 AUTH_RESEND_KEY=""
 STAGING_EMAIL_ALLOWLIST="ton.email@example.com"
 
@@ -60,10 +70,10 @@ AUTH_GITHUB_SECRET=""
 
 # ── [OPTION] Stripe Connect (paiements événements) ───────────────────────────
 # Sans ces clés, les événements payants sont KO (mais les gratuits fonctionnent).
-# Utiliser les clés TEST MODE uniquement (commencent par sk_test_ / pk_test_).
+# Utiliser les clés TEST MODE uniquement (commencent par sk_test_).
 # https://dashboard.stripe.com/test/apikeys
+# STRIPE_WEBHOOK_SECRET vient de `stripe listen --forward-to localhost:3000/api/...`
 STRIPE_SECRET_KEY=""
-STRIPE_PUBLISHABLE_KEY=""
 STRIPE_WEBHOOK_SECRET=""
 
 
@@ -113,6 +123,16 @@ SENTRY_ALERT_EMAIL=""
 # Génère avec : openssl rand -hex 32
 CRON_SECRET=""
 E2E_SECRET=""
+
+
+# ── [OPTION] Tests E2E — overrides ───────────────────────────────────────────
+# Override de l'URL ciblée par Playwright (par défaut : http://localhost:3000).
+# BASE_URL=""
+
+# Slugs ciblés par les tests mobile (tests/mobile/dashboard.spec.ts).
+# Si non définis, les tests concernés sont skip (test.skip).
+# MOBILE_TEST_CIRCLE_SLUG=""
+# MOBILE_TEST_MOMENT_SLUG=""
 
 
 # ── [OPTION] Admin / notifications internes ──────────────────────────────────

--- a/README.md
+++ b/README.md
@@ -81,10 +81,10 @@ Architecture hexagonale (Ports & Adapters), TypeScript strict, tout déployé en
 
 | | |
 | --- | --- |
-| **1 400+** | commits |
-| **300+** | pull requests |
-| **65** | cas d'usage (domain usecases) |
-| **880+** | tests (unit + integration + E2E) |
+| **2 000+** | commits |
+| **400+** | pull requests |
+| **80+** | cas d'usage (domain usecases) |
+| **1 000+** | tests (unit + integration + E2E) |
 
 ## Architecture
 
@@ -104,10 +104,10 @@ Voir `CLAUDE.md` pour le contrat strict d'architecture et les règles de dépend
 
 ### Prérequis
 
-- **Node.js** ≥ 24 (LTS recommandée)
-- **pnpm** ≥ 9 (`npm install -g pnpm`)
+- **Node.js** ≥ 24 LTS (aligné avec le runtime Vercel de production)
+- **pnpm** ≥ 10 (le projet déclare `pnpm@10.30.0` via `packageManager`) — `npm install -g pnpm`
 - **PostgreSQL** : un compte gratuit [Neon](https://neon.tech) ou un Postgres local
-- **Compte Resend** (gratuit, 100 emails/jour) : [resend.com](https://resend.com) — pour le magic link
+- **Compte Resend** (gratuit, 100 emails/jour) : [resend.com](https://resend.com) — pour le magic link et les autres emails
 
 ### Setup local (5 minutes)
 
@@ -158,13 +158,9 @@ pnpm db:studio        # UI de visualisation Prisma
 pnpm db:seed-test-data    # injecte les données de test
 ```
 
-## Versions récentes
+## Changelog
 
-Les 3 dernières versions majeures (voir le [changelog complet](https://the-playground.fr/changelog)) :
-
-- **v2.6.0** — Réseaux de communautés, profils enrichis, site web des communautés
-- **v2.5.0** — Blog et landing page enrichis
-- **v2.0.0** — Événements payants et billetterie intégrée (Stripe Connect)
+L'historique complet des versions est publié sur [the-playground.fr/changelog](https://the-playground.fr/changelog).
 
 ## Auteur
 

--- a/README.md
+++ b/README.md
@@ -102,16 +102,61 @@ Voir `CLAUDE.md` pour le contrat strict d'architecture et les règles de dépend
 
 ## Développement
 
+### Prérequis
+
+- **Node.js** ≥ 24 (LTS recommandée)
+- **pnpm** ≥ 9 (`npm install -g pnpm`)
+- **PostgreSQL** : un compte gratuit [Neon](https://neon.tech) ou un Postgres local
+- **Compte Resend** (gratuit, 100 emails/jour) : [resend.com](https://resend.com) — pour le magic link
+
+### Setup local (5 minutes)
+
 ```bash
+# 1. Cloner et installer
+git clone https://github.com/DragosDreptate/the-playground.git
+cd the-playground
 pnpm install
-pnpm dev              # Démarre le serveur de développement
-pnpm test             # Lance les tests (unit + integration)
-pnpm test:e2e         # Tests E2E Playwright
-pnpm typecheck        # Vérifie les types TypeScript
-pnpm db:push          # Applique le schema sur la DB dev
+
+# 2. Configurer les variables d'environnement
+cp .env.example .env.local
+# Édite .env.local : voir le fichier pour la liste détaillée. Au minimum :
+#   - DATABASE_URL  (ta branche Neon)
+#   - AUTH_SECRET   (génère avec : npx auth secret)
+#   - un provider d'auth (Resend recommandé, sinon Google/GitHub OAuth)
+
+# 3. Initialiser la DB
+pnpm db:push          # applique le schema Prisma sur ta DB
+
+# 4. (Optionnel) Seed des données de test
+pnpm db:seed-test-data
+
+# 5. Lancer
+pnpm dev              # http://localhost:3000
 ```
 
-Variables d'environnement requises : voir `.env.example`.
+### Authentification en local
+
+Trois options, **au moins une** doit être configurée dans `.env.local` :
+
+| Option | Effort | Avantages |
+|---|---|---|
+| **Resend (magic link)** | 2 min | recommandée — c'est le flow par défaut de l'app. Crée un compte resend.com, mets ta clé dans `AUTH_RESEND_KEY` et ton email dans `STAGING_EMAIL_ALLOWLIST`. |
+| **Google OAuth** | 5 min | Crée un OAuth client sur console.cloud.google.com avec callback `http://localhost:3000/api/auth/callback/google` |
+| **GitHub OAuth** | 5 min | Idem sur github.com/settings/developers, callback `http://localhost:3000/api/auth/callback/github` |
+
+> **Garde-fou email** : `safe-resend.ts` bloque tous les envois vers de vraies adresses dès que `VERCEL_ENV !== "production"`. En local, seuls les emails listés dans `STAGING_EMAIL_ALLOWLIST` (ou se terminant par `@test.playground` / `@demo.playground`) sont effectivement envoyés. Voir `spec/email-testing.md`.
+
+### Commandes courantes
+
+```bash
+pnpm dev              # serveur de développement
+pnpm test             # tests unitaires + intégration (Vitest)
+pnpm test:e2e         # tests E2E (Playwright)
+pnpm typecheck        # vérification TypeScript
+pnpm db:push          # applique le schema sur la DB dev
+pnpm db:studio        # UI de visualisation Prisma
+pnpm db:seed-test-data    # injecte les données de test
+```
 
 ## Versions récentes
 


### PR DESCRIPTION
## Summary

- **Problème** : pas de `.env.example` ni de section setup dans le README. Un contributeur externe devait deviner la liste des variables et la stratégie du garde-fou Resend.
- **Fix** :
  - Nouveau `.env.example` structuré en 4 blocs (`[REQUIS]` / `[AUTH]` / `[OPTION]` / `[INTERNE]`) avec commentaires explicatifs et liens vers chaque service.
  - Section README *Développement* étoffée : prérequis, setup en 5 étapes, tableau des 3 options d'auth (Resend / Google / GitHub), mention du garde-fou `safe-resend.ts` avec renvoi vers `spec/email-testing.md`.
- **Audit** : 3 commits pour arriver à un état propre — création, correction du `.env.example` (croisement avec le grep `process.env` du code), refresh du README (chiffres actualisés, changelog simplifié, prérequis corrigés).

## Détail des commits

1. `add .env.example + contributor setup section` — création initiale
2. `correct .env.example after audit` :
   - Retiré `STRIPE_PUBLISHABLE_KEY` (aucune occurrence dans le code, projet utilise Stripe Checkout côté serveur uniquement)
   - Ajouté `BASE_URL`, `MOBILE_TEST_CIRCLE_SLUG`, `MOBILE_TEST_MOMENT_SLUG` (tests E2E mobile)
   - Clarifié `AUTH_RESEND_KEY` : sert au magic link **et** à tous les autres emails
   - Clarifié la hiérarchie `EMAIL_FROM > AUTH_EMAIL_FROM > ONBOARDING_EMAIL_FROM`
3. `refresh README` :
   - Chiffres "En chiffres" actualisés (commits 1400+ → 2000+, PRs 300+ → 400+, usecases 65 → 80+, tests 880+ → 1000+)
   - "Versions récentes" (figée sur v2.6/v2.5/v2.0 alors qu'on est à v2.11) → simplifiée en lien vers le changelog publié
   - Prérequis `pnpm ≥ 9` → `pnpm ≥ 10` (le repo déclare `packageManager: pnpm@10.30.0`)
   - Précisé que Node 24 LTS est aligné avec le runtime Vercel de prod

## Sécurité

Aucune valeur sensible commitée. Toutes les valeurs non-vides du `.env.example` sont des placeholders publics (`postgresql://user:password@host/...`, `ton.email@example.com`, `onboarding@resend.dev` — adresse publique de test Resend documentée par Resend lui-même).

Vérifié par grep des patterns de secrets typiques (`sk_live`, `re_…`, `npg_…`, `AIza…`, `GOCSPX-…`, `Ov23…`, `whsec_…`) → 0 match.

## Test plan

- [x] `pnpm typecheck` passe (doc-only mais validé par précaution)
- [ ] CI vert
- [ ] Relire `.env.example` (rien ne doit ressembler à un secret réel)
- [ ] Relire la section *Développement* du README

## Notes

- Pas de schema Prisma changé → pas de `db:push:prod` requis au merge.
- Aucune dépendance code → pas de risque de régression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)