### PR TITLE
fix(ui): compteur "et X autres" sur la stack d'avatars en mobile

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -339,7 +339,7 @@
       "publicCircle": "Public community",
       "privateCircle": "Private community",
       "memberCount": "{count} members",
-      "andOthers": "and {count} others",
+      "andOthers": "{count, plural, =1 {and 1 other} other {and # others}}",
       "upcomingMoments": "Upcoming Events",
       "pastMoments": "Past Events",
       "noUpcomingMoments": "No upcoming Events.",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -339,7 +339,7 @@
       "publicCircle": "Communauté publique",
       "privateCircle": "Communauté privée",
       "memberCount": "{count} membres",
-      "andOthers": "et {count} autres",
+      "andOthers": "{count, plural, =1 {et 1 autre} other {et # autres}}",
       "upcomingMoments": "Prochains événements",
       "pastMoments": "Événements passés",
       "noUpcomingMoments": "Aucun événement à venir.",

--- a/src/components/moments/moment-detail-view.tsx
+++ b/src/components/moments/moment-detail-view.tsx
@@ -13,6 +13,7 @@ import { CopyLinkButton } from "@/components/moments/copy-link-button";
 import { CommentThread } from "@/components/moments/comment-thread";
 import { getMomentGradient } from "@/lib/gradient";
 import { getDisplayName } from "@/lib/display-name";
+import { computeAvatarStackMeta } from "@/lib/avatar-stack-meta";
 import type { Moment } from "@/domain/models/moment";
 import type { MomentAttachment } from "@/domain/models/moment-attachment";
 import type { Circle, CircleMemberWithUser } from "@/domain/models/circle";
@@ -233,29 +234,12 @@ export async function MomentDetailView(props: MomentDetailViewProps) {
       ? `https://maps.google.com/?q=${encodeURIComponent(moment.locationAddress)}`
       : null;
 
-  const PARTICIPANT_AVATARS_MAX = 5;
-  const PARTICIPANT_NAMES_TO_SHOW = 2;
   const registeredParticipants = registrations.filter((r) => r.status === "REGISTERED");
-  const visibleParticipantAvatars = registeredParticipants.slice(0, PARTICIPANT_AVATARS_MAX);
-  const participantNamesToShow = registeredParticipants
-    .slice(0, PARTICIPANT_NAMES_TO_SHOW)
-    .map((r) => getDisplayName(r.user.firstName, r.user.lastName, r.user.email));
-
-  // Desktop affiche les noms ; mobile n'affiche que les avatars. Le compteur
-  // "et X autres" doit donc référencer ce qui est visible dans chaque contexte
-  // pour éviter qu'un mobile lise "5 avatars + et 4 autres = 9" au lieu de 6.
-  const desktopOthersCount = Math.max(0, registeredCount - participantNamesToShow.length);
-  const desktopOthersText = desktopOthersCount > 0
-    ? tCircle("detail.andOthers", { count: desktopOthersCount })
-    : "";
-  const participantsMetaText = desktopOthersText
-    ? `${participantNamesToShow.join(", ")} ${desktopOthersText}`
-    : participantNamesToShow.join(", ");
-
-  const mobileOthersCount = Math.max(0, registeredCount - visibleParticipantAvatars.length);
-  const participantsMetaMobileText = mobileOthersCount > 0
-    ? tCircle("detail.andOthers", { count: mobileOthersCount })
-    : "";
+  const {
+    visibleAvatars: visibleParticipantAvatars,
+    metaText: participantsMetaText,
+    metaMobileText: participantsMetaMobileText,
+  } = computeAvatarStackMeta(registeredParticipants, registeredCount, tCircle);
 
   const circleHref = isHostView
     ? `/dashboard/circles/${props.circleSlug}`

--- a/src/components/moments/moment-detail-view.tsx
+++ b/src/components/moments/moment-detail-view.tsx
@@ -234,19 +234,28 @@ export async function MomentDetailView(props: MomentDetailViewProps) {
       : null;
 
   const PARTICIPANT_AVATARS_MAX = 5;
+  const PARTICIPANT_NAMES_TO_SHOW = 2;
   const registeredParticipants = registrations.filter((r) => r.status === "REGISTERED");
   const visibleParticipantAvatars = registeredParticipants.slice(0, PARTICIPANT_AVATARS_MAX);
   const participantNamesToShow = registeredParticipants
-    .slice(0, 2)
+    .slice(0, PARTICIPANT_NAMES_TO_SHOW)
     .map((r) => getDisplayName(r.user.firstName, r.user.lastName, r.user.email));
-  const participantOthersCount = Math.max(0, registeredCount - participantNamesToShow.length);
-  const participantOthersText = participantOthersCount > 0
-    ? tCircle("detail.andOthers", { count: participantOthersCount })
+
+  // Desktop affiche les noms ; mobile n'affiche que les avatars. Le compteur
+  // "et X autres" doit donc référencer ce qui est visible dans chaque contexte
+  // pour éviter qu'un mobile lise "5 avatars + et 4 autres = 9" au lieu de 6.
+  const desktopOthersCount = Math.max(0, registeredCount - participantNamesToShow.length);
+  const desktopOthersText = desktopOthersCount > 0
+    ? tCircle("detail.andOthers", { count: desktopOthersCount })
     : "";
-  const participantsMetaText = participantOthersText
-    ? `${participantNamesToShow.join(", ")} ${participantOthersText}`
+  const participantsMetaText = desktopOthersText
+    ? `${participantNamesToShow.join(", ")} ${desktopOthersText}`
     : participantNamesToShow.join(", ");
-  const participantsMetaMobileText = participantOthersText || participantNamesToShow.join(", ");
+
+  const mobileOthersCount = Math.max(0, registeredCount - visibleParticipantAvatars.length);
+  const participantsMetaMobileText = mobileOthersCount > 0
+    ? tCircle("detail.andOthers", { count: mobileOthersCount })
+    : "";
 
   const circleHref = isHostView
     ? `/dashboard/circles/${props.circleSlug}`

--- a/src/lib/__tests__/circle-helpers.test.ts
+++ b/src/lib/__tests__/circle-helpers.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from "vitest";
+import { computeMembersMeta } from "@/lib/circle-helpers";
+import { MEMBER_AVATARS_MAX } from "@/lib/circle-constants";
+import type { CircleMemberWithUser } from "@/domain/models/circle";
+
+function makeMember(overrides: {
+  id: string;
+  firstName?: string | null;
+  joinedAtMs?: number;
+}): CircleMemberWithUser {
+  return {
+    id: overrides.id,
+    userId: overrides.id,
+    circleId: "circle-1",
+    role: "PLAYER",
+    status: "ACTIVE",
+    joinedAt: new Date(overrides.joinedAtMs ?? 1_700_000_000_000),
+    user: {
+      id: overrides.id,
+      firstName: overrides.firstName ?? overrides.id,
+      lastName: null,
+      email: `${overrides.id}@test.playground`,
+      image: null,
+      publicId: null,
+    },
+  };
+}
+
+// Translator factice qui rend l'ICU plural manuellement pour tester l'usage de
+// `count` côté caller. Le rendu réel est testé par next-intl.
+const translate: Parameters<typeof computeMembersMeta>[3] = (key, values) => {
+  if (key === "detail.andOthers") {
+    const count = (values?.count as number) ?? 0;
+    return count === 1 ? "et 1 autre" : `et ${count} autres`;
+  }
+  return key;
+};
+
+describe("computeMembersMeta", () => {
+  describe("given fewer members than the avatars cap", () => {
+    it("renders all avatars and no mobile 'others' suffix", () => {
+      const members = [
+        makeMember({ id: "alice", firstName: "Alice" }),
+        makeMember({ id: "bob", firstName: "Bob" }),
+        makeMember({ id: "carol", firstName: "Carol" }),
+      ];
+
+      const result = computeMembersMeta([], members, members.length, translate);
+
+      expect(result.visibleAvatars).toHaveLength(3);
+      expect(result.metaText).toBe("Alice, Bob et 1 autre");
+      expect(result.metaMobileText).toBe("");
+    });
+
+    it("renders only the names when total equals NAMES_TO_SHOW", () => {
+      const members = [
+        makeMember({ id: "alice", firstName: "Alice" }),
+        makeMember({ id: "bob", firstName: "Bob" }),
+      ];
+
+      const result = computeMembersMeta([], members, members.length, translate);
+
+      expect(result.metaText).toBe("Alice, Bob");
+      expect(result.metaMobileText).toBe("");
+    });
+  });
+
+  describe("given total exactly equals MEMBER_AVATARS_MAX", () => {
+    it("shows all avatars and no mobile suffix", () => {
+      const members = Array.from({ length: MEMBER_AVATARS_MAX }, (_, i) =>
+        makeMember({ id: `m${i}`, firstName: `M${i}` }),
+      );
+
+      const result = computeMembersMeta([], members, members.length, translate);
+
+      expect(result.visibleAvatars).toHaveLength(MEMBER_AVATARS_MAX);
+      expect(result.metaMobileText).toBe("");
+    });
+  });
+
+  describe("given total exceeds MEMBER_AVATARS_MAX by one (the bug case)", () => {
+    it("references avatars in mobile text, not desktop names", () => {
+      const totalCount = MEMBER_AVATARS_MAX + 1;
+      const members = Array.from({ length: totalCount }, (_, i) =>
+        makeMember({ id: `m${i}`, firstName: `M${i}` }),
+      );
+
+      const result = computeMembersMeta([], members, totalCount, translate);
+
+      expect(result.visibleAvatars).toHaveLength(MEMBER_AVATARS_MAX);
+      expect(result.metaText).toBe(`M0, M1 et ${totalCount - 2} autres`);
+      expect(result.metaMobileText).toBe("et 1 autre");
+    });
+  });
+
+  describe("given total far exceeds MEMBER_AVATARS_MAX", () => {
+    it("computes mobile suffix from avatar count, not name count", () => {
+      const totalCount = MEMBER_AVATARS_MAX + 7;
+      const members = Array.from({ length: MEMBER_AVATARS_MAX + 2 }, (_, i) =>
+        makeMember({ id: `m${i}`, firstName: `M${i}` }),
+      );
+
+      const result = computeMembersMeta([], members, totalCount, translate);
+
+      expect(result.metaText).toBe(`M0, M1 et ${totalCount - 2} autres`);
+      expect(result.metaMobileText).toBe("et 7 autres");
+    });
+  });
+
+  describe("given hosts and players mixed", () => {
+    it("sorts by joinedAt ascending and picks the earliest as visible avatars", () => {
+      const earlyHost = makeMember({
+        id: "early-host",
+        firstName: "Early",
+        joinedAtMs: 1_000,
+      });
+      const lateHost = makeMember({
+        id: "late-host",
+        firstName: "Late",
+        joinedAtMs: 9_000,
+      });
+      const midPlayer = makeMember({
+        id: "mid-player",
+        firstName: "Mid",
+        joinedAtMs: 5_000,
+      });
+
+      const result = computeMembersMeta(
+        [earlyHost, lateHost],
+        [midPlayer],
+        3,
+        translate,
+      );
+
+      expect(result.visibleAvatars.map((m) => m.id)).toEqual([
+        "early-host",
+        "mid-player",
+        "late-host",
+      ]);
+    });
+  });
+});

--- a/src/lib/__tests__/circle-helpers.test.ts
+++ b/src/lib/__tests__/circle-helpers.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect } from "vitest";
 import { computeMembersMeta } from "@/lib/circle-helpers";
-import { MEMBER_AVATARS_MAX } from "@/lib/circle-constants";
+import { AVATAR_STACK_MAX } from "@/lib/avatar-stack-meta";
 import type { CircleMemberWithUser } from "@/domain/models/circle";
 
 function makeMember(overrides: {
   id: string;
   firstName?: string | null;
-  joinedAtMs?: number;
+  joinedAt?: Date;
 }): CircleMemberWithUser {
   return {
     id: overrides.id,
@@ -14,7 +14,7 @@ function makeMember(overrides: {
     circleId: "circle-1",
     role: "PLAYER",
     status: "ACTIVE",
-    joinedAt: new Date(overrides.joinedAtMs ?? 1_700_000_000_000),
+    joinedAt: overrides.joinedAt ?? new Date("2024-01-01"),
     user: {
       id: overrides.id,
       firstName: overrides.firstName ?? overrides.id,
@@ -26,8 +26,6 @@ function makeMember(overrides: {
   };
 }
 
-// Translator factice qui rend l'ICU plural manuellement pour tester l'usage de
-// `count` côté caller. Le rendu réel est testé par next-intl.
 const translate: Parameters<typeof computeMembersMeta>[3] = (key, values) => {
   if (key === "detail.andOthers") {
     const count = (values?.count as number) ?? 0;
@@ -52,7 +50,7 @@ describe("computeMembersMeta", () => {
       expect(result.metaMobileText).toBe("");
     });
 
-    it("renders only the names when total equals NAMES_TO_SHOW", () => {
+    it("renders only the names when total equals the names-to-show count", () => {
       const members = [
         makeMember({ id: "alice", firstName: "Alice" }),
         makeMember({ id: "bob", firstName: "Bob" }),
@@ -65,38 +63,38 @@ describe("computeMembersMeta", () => {
     });
   });
 
-  describe("given total exactly equals MEMBER_AVATARS_MAX", () => {
+  describe("given total exactly equals AVATAR_STACK_MAX", () => {
     it("shows all avatars and no mobile suffix", () => {
-      const members = Array.from({ length: MEMBER_AVATARS_MAX }, (_, i) =>
+      const members = Array.from({ length: AVATAR_STACK_MAX }, (_, i) =>
         makeMember({ id: `m${i}`, firstName: `M${i}` }),
       );
 
       const result = computeMembersMeta([], members, members.length, translate);
 
-      expect(result.visibleAvatars).toHaveLength(MEMBER_AVATARS_MAX);
+      expect(result.visibleAvatars).toHaveLength(AVATAR_STACK_MAX);
       expect(result.metaMobileText).toBe("");
     });
   });
 
-  describe("given total exceeds MEMBER_AVATARS_MAX by one (the bug case)", () => {
+  describe("given total exceeds AVATAR_STACK_MAX by one (the bug case)", () => {
     it("references avatars in mobile text, not desktop names", () => {
-      const totalCount = MEMBER_AVATARS_MAX + 1;
+      const totalCount = AVATAR_STACK_MAX + 1;
       const members = Array.from({ length: totalCount }, (_, i) =>
         makeMember({ id: `m${i}`, firstName: `M${i}` }),
       );
 
       const result = computeMembersMeta([], members, totalCount, translate);
 
-      expect(result.visibleAvatars).toHaveLength(MEMBER_AVATARS_MAX);
+      expect(result.visibleAvatars).toHaveLength(AVATAR_STACK_MAX);
       expect(result.metaText).toBe(`M0, M1 et ${totalCount - 2} autres`);
       expect(result.metaMobileText).toBe("et 1 autre");
     });
   });
 
-  describe("given total far exceeds MEMBER_AVATARS_MAX", () => {
+  describe("given total far exceeds AVATAR_STACK_MAX", () => {
     it("computes mobile suffix from avatar count, not name count", () => {
-      const totalCount = MEMBER_AVATARS_MAX + 7;
-      const members = Array.from({ length: MEMBER_AVATARS_MAX + 2 }, (_, i) =>
+      const totalCount = AVATAR_STACK_MAX + 7;
+      const members = Array.from({ length: AVATAR_STACK_MAX + 2 }, (_, i) =>
         makeMember({ id: `m${i}`, firstName: `M${i}` }),
       );
 
@@ -112,17 +110,17 @@ describe("computeMembersMeta", () => {
       const earlyHost = makeMember({
         id: "early-host",
         firstName: "Early",
-        joinedAtMs: 1_000,
+        joinedAt: new Date("2024-01-01"),
       });
       const lateHost = makeMember({
         id: "late-host",
         firstName: "Late",
-        joinedAtMs: 9_000,
+        joinedAt: new Date("2024-03-01"),
       });
       const midPlayer = makeMember({
         id: "mid-player",
         firstName: "Mid",
-        joinedAtMs: 5_000,
+        joinedAt: new Date("2024-02-01"),
       });
 
       const result = computeMembersMeta(

--- a/src/lib/avatar-stack-meta.ts
+++ b/src/lib/avatar-stack-meta.ts
@@ -1,0 +1,68 @@
+import { getDisplayName } from "@/lib/display-name";
+
+export const AVATAR_STACK_MAX = 5;
+export const AVATAR_STACK_NAMES_TO_SHOW = 2;
+
+type WithDisplayUser = {
+  user: {
+    firstName: string | null;
+    lastName: string | null;
+    email: string;
+  };
+};
+
+type Translator = (key: string, values?: Record<string, number | string>) => string;
+
+type Options = {
+  avatarsMax?: number;
+  namesToShow?: number;
+};
+
+/**
+ * Aperçu "stack d'avatars + et X autres" partagé entre la page Communauté
+ * et la page événement.
+ *
+ * Le compteur "et X autres" est calculé par rapport à ce qui est *visible*
+ * dans chaque contexte d'affichage, pour éviter une lecture fausse :
+ * - desktop affiche les noms → compteur = total − noms affichés
+ * - mobile n'affiche que les avatars → compteur = total − avatars visibles
+ *
+ * Sans cette distinction, un mobile à 5 avatars affichait "et 4 autres" pour
+ * 6 inscrits (calcul desktop appliqué au mobile), donnant l'illusion de 9.
+ *
+ * Les `items` doivent être déjà triés par le caller dans l'ordre voulu —
+ * la fonction se contente de slicer.
+ */
+export function computeAvatarStackMeta<T extends WithDisplayUser>(
+  items: T[],
+  totalCount: number,
+  t: Translator,
+  options: Options = {},
+): {
+  visibleAvatars: T[];
+  metaText: string;
+  metaMobileText: string;
+} {
+  const avatarsMax = options.avatarsMax ?? AVATAR_STACK_MAX;
+  const namesToShow = options.namesToShow ?? AVATAR_STACK_NAMES_TO_SHOW;
+
+  const visibleAvatars = items.slice(0, avatarsMax);
+  const names = items
+    .slice(0, namesToShow)
+    .map((item) => getDisplayName(item.user.firstName, item.user.lastName, item.user.email));
+
+  const desktopOthersCount = Math.max(0, totalCount - names.length);
+  const desktopOthersText = desktopOthersCount > 0
+    ? t("detail.andOthers", { count: desktopOthersCount })
+    : "";
+  const metaText = desktopOthersText
+    ? `${names.join(", ")} ${desktopOthersText}`
+    : names.join(", ");
+
+  const mobileOthersCount = Math.max(0, totalCount - visibleAvatars.length);
+  const metaMobileText = mobileOthersCount > 0
+    ? t("detail.andOthers", { count: mobileOthersCount })
+    : "";
+
+  return { visibleAvatars, metaText, metaMobileText };
+}

--- a/src/lib/circle-constants.ts
+++ b/src/lib/circle-constants.ts
@@ -1,2 +1,0 @@
-/** Nombre maximum d'avatars membres affichés en aperçu sur la page Circle (avant "et X autres"). */
-export const MEMBER_AVATARS_MAX = 5;

--- a/src/lib/circle-helpers.ts
+++ b/src/lib/circle-helpers.ts
@@ -25,10 +25,15 @@ export function sortCircleOrganizers(
 }
 
 /**
- * Prépare les données d'aperçu "Membres" pour la colonne meta des pages Circle :
- * - avatars visibles (jusqu'à MEMBER_AVATARS_MAX, triés par joinedAt)
- * - texte desktop ("Alice, Bob et X autres")
- * - texte mobile ("et X autres" seul, ou les noms si pas d'autres)
+ * Prépare les données d'aperçu "Membres" pour la colonne meta des pages Circle.
+ *
+ * Le compteur "et X autres" est calculé par rapport à ce qui est *visible*
+ * dans chaque contexte d'affichage, pour éviter une lecture fausse :
+ * - desktop affiche `NAMES_TO_SHOW` noms → compteur = total − noms affichés
+ * - mobile n'affiche que les avatars → compteur = total − avatars visibles
+ *
+ * Sans cette distinction, un mobile à 5 avatars affichait "et 4 autres" pour
+ * 6 inscrits (calcul desktop appliqué au mobile), donnant l'illusion de 9.
  */
 export function computeMembersMeta(
   hosts: CircleMemberWithUser[],
@@ -47,11 +52,19 @@ export function computeMembersMeta(
   const namesToShow = allMembers
     .slice(0, NAMES_TO_SHOW)
     .map((m) => getDisplayName(m.user.firstName, m.user.lastName, m.user.email));
-  const othersCount = Math.max(0, totalCount - namesToShow.length);
-  const othersText = othersCount > 0 ? t("detail.andOthers", { count: othersCount }) : "";
-  const metaText = othersText
-    ? `${namesToShow.join(", ")} ${othersText}`
+
+  const desktopOthersCount = Math.max(0, totalCount - namesToShow.length);
+  const desktopOthersText = desktopOthersCount > 0
+    ? t("detail.andOthers", { count: desktopOthersCount })
+    : "";
+  const metaText = desktopOthersText
+    ? `${namesToShow.join(", ")} ${desktopOthersText}`
     : namesToShow.join(", ");
-  const metaMobileText = othersText || namesToShow.join(", ");
+
+  const mobileOthersCount = Math.max(0, totalCount - visibleAvatars.length);
+  const metaMobileText = mobileOthersCount > 0
+    ? t("detail.andOthers", { count: mobileOthersCount })
+    : "";
+
   return { visibleAvatars, metaText, metaMobileText };
 }

--- a/src/lib/circle-helpers.ts
+++ b/src/lib/circle-helpers.ts
@@ -1,10 +1,8 @@
 import type { CircleMemberWithUser } from "@/domain/models/circle";
 import { getDisplayName } from "@/lib/display-name";
-import { MEMBER_AVATARS_MAX } from "@/lib/circle-constants";
+import { computeAvatarStackMeta } from "@/lib/avatar-stack-meta";
 
-const NAMES_TO_SHOW = 2;
-
-type Translator = (key: string, values?: Record<string, number>) => string;
+type Translator = (key: string, values?: Record<string, number | string>) => string;
 
 /**
  * Trie les organisateurs d'un Circle : HOST en premier, puis CO_HOST, chaque groupe
@@ -25,15 +23,9 @@ export function sortCircleOrganizers(
 }
 
 /**
- * Prépare les données d'aperçu "Membres" pour la colonne meta des pages Circle.
- *
- * Le compteur "et X autres" est calculé par rapport à ce qui est *visible*
- * dans chaque contexte d'affichage, pour éviter une lecture fausse :
- * - desktop affiche `NAMES_TO_SHOW` noms → compteur = total − noms affichés
- * - mobile n'affiche que les avatars → compteur = total − avatars visibles
- *
- * Sans cette distinction, un mobile à 5 avatars affichait "et 4 autres" pour
- * 6 inscrits (calcul desktop appliqué au mobile), donnant l'illusion de 9.
+ * Aperçu "Membres" pour la colonne meta des pages Communauté : merge
+ * hosts + players, trie par `joinedAt` ascendant, puis délègue le rendu
+ * de la stack à `computeAvatarStackMeta`.
  */
 export function computeMembersMeta(
   hosts: CircleMemberWithUser[],
@@ -48,23 +40,5 @@ export function computeMembersMeta(
   const allMembers = [...hosts, ...players].sort(
     (a, b) => a.joinedAt.getTime() - b.joinedAt.getTime(),
   );
-  const visibleAvatars = allMembers.slice(0, MEMBER_AVATARS_MAX);
-  const namesToShow = allMembers
-    .slice(0, NAMES_TO_SHOW)
-    .map((m) => getDisplayName(m.user.firstName, m.user.lastName, m.user.email));
-
-  const desktopOthersCount = Math.max(0, totalCount - namesToShow.length);
-  const desktopOthersText = desktopOthersCount > 0
-    ? t("detail.andOthers", { count: desktopOthersCount })
-    : "";
-  const metaText = desktopOthersText
-    ? `${namesToShow.join(", ")} ${desktopOthersText}`
-    : namesToShow.join(", ");
-
-  const mobileOthersCount = Math.max(0, totalCount - visibleAvatars.length);
-  const metaMobileText = mobileOthersCount > 0
-    ? t("detail.andOthers", { count: mobileOthersCount })
-    : "";
-
-  return { visibleAvatars, metaText, metaMobileText };
+  return computeAvatarStackMeta(allMembers, totalCount, t);
 }


### PR DESCRIPTION
## Summary

- **Bug** : sur mobile, la stack d'avatars d'un événement (et d'une Communauté) affichait jusqu'à 5 avatars + un texte "et X autres" où X était calculé sur les 2 noms du rendu desktop. Pour un événement à 6 inscrits, ça donnait "5 avatars + et 4 autres" → l'utilisateur perçoit 9 personnes au lieu de 6. Cf. capture initiale.
- **Fix** : le compteur "et X autres" référence maintenant ce qui est *visible* dans chaque contexte. Mobile = `total − avatars visibles` ; desktop reste = `total − noms affichés`. Le texte mobile devient vide quand tous les inscrits tiennent dans les avatars.
- **Bonus** : `Circle.detail.andOthers` passe en pluralisation ICU pour gérer "et 1 autre" vs "et N autres" (jusqu'ici "et 1 autres" était affiché pour un seul absent).
- **Refactor post-/simplify** : extraction d'un helper générique `computeAvatarStackMeta` (`src/lib/avatar-stack-meta.ts`) consommé par `circle-helpers.ts` et `moment-detail-view.tsx`, qui auparavant dupliquaient la même logique inline. Net : −46 lignes.

## Effet sur l'exemple de la capture (6 inscrits)

| Avant | Après |
|---|---|
| 5 avatars + "et 4 autres" → **9 perçu** ❌ | 5 avatars + "et 1 autre" → **6 perçu** ✅ |

Idem pour les pages Communauté (mêmes blocs `[avatars] [texte]` en colonne meta).

## Périmètre

- `src/lib/avatar-stack-meta.ts` (nouveau) — helper générique + constantes `AVATAR_STACK_MAX = 5`, `AVATAR_STACK_NAMES_TO_SHOW = 2`
- `src/lib/circle-helpers.ts` — `computeMembersMeta` devient un wrapper qui merge hosts+players, trie par `joinedAt`, délègue
- `src/components/moments/moment-detail-view.tsx` — bloc inline remplacé par un appel au helper
- `src/lib/circle-constants.ts` — supprimé (ne contenait que `MEMBER_AVATARS_MAX`, désormais centralisé en `AVATAR_STACK_MAX`)
- `messages/{fr,en}.json` — `Circle.detail.andOthers` en ICU plural
- `src/lib/__tests__/circle-helpers.test.ts` — 6 tests couvrant total < max, total = max, total = max+1 (le bug initial), total >> max, tri hosts+players par joinedAt

## Test plan

- [x] `pnpm typecheck` ✅
- [x] `pnpm test:unit` ✅ (1041/1041, +6 nouveaux)
- [x] `pnpm build` (CI)
- [x] Sync FR/EN sur `Circle.detail.andOthers` ICU ✅
- [ ] Smoke preview : page événement avec 6 inscrits → mobile affiche "et 1 autre" et desktop "Alice, Bob et 4 autres"
- [ ] Smoke preview : page événement avec 5 inscrits → mobile n'affiche plus de texte "et X autres"
- [ ] Smoke preview : page Communauté avec ≥ 6 membres → même cohérence

## Commits

- `342d980` fix(ui): corriger le compteur "et X autres" sur la stack d'avatars en mobile
- `2c704eb` refactor(ui): nettoyage post-/simplify

🤖 Generated with [Claude Code](https://claude.com/claude-code)