### PR TITLE
feat(share): bouton de partage natif sur pages mobile

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -125,7 +125,11 @@
     "copyLink": "Copy link",
     "copied": "Copied!",
     "close": "Close",
-    "openInNewTab": "Open in new tab"
+    "openInNewTab": "Open in new tab",
+    "share": {
+      "eventLabel": "Share this event",
+      "communityLabel": "Share this community"
+    }
   },
   "Auth": {
     "signIn": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -125,7 +125,11 @@
     "copyLink": "Copier le lien",
     "copied": "Copié !",
     "close": "Fermer",
-    "openInNewTab": "Ouvrir dans un nouvel onglet"
+    "openInNewTab": "Ouvrir dans un nouvel onglet",
+    "share": {
+      "eventLabel": "Partager cet événement",
+      "communityLabel": "Partager cette communauté"
+    }
   },
   "Auth": {
     "signIn": {

--- a/src/app/[locale]/(routes)/circles/[slug]/page.tsx
+++ b/src/app/[locale]/(routes)/circles/[slug]/page.tsx
@@ -30,6 +30,7 @@ import { CircleMomentTabs } from "@/components/circles/circle-moment-tabs";
 import { PaginatedMomentList } from "@/components/circles/paginated-moment-list";
 import { DemoBadge } from "@/components/badges/demo-badge";
 import { CoverBlock } from "@/components/circles/cover-block";
+import { CircleShareButton } from "@/components/circles/circle-share-button";
 import { isValidSlug } from "@/lib/slug";
 import {
   Globe,
@@ -112,12 +113,13 @@ export default async function PublicCirclePage({
   const { slug, locale } = await params;
   if (!isValidSlug(slug)) notFound();
 
-  const [t, tExplorer, tCategory, tNetwork, session] =
+  const [t, tExplorer, tCategory, tNetwork, tCommon, session] =
     await Promise.all([
       getTranslations("Circle"),
       getTranslations("Explorer"),
       getTranslations("CircleCategory"),
       getTranslations("Network"),
+      getTranslations("Common"),
       // Session optionnelle — les pages publiques sont accessibles sans auth
       measureTime("circle-page:auth", () => auth()),
     ]);
@@ -245,6 +247,13 @@ export default async function PublicCirclePage({
               altText={circle.name}
             >
               {circle.isDemo && <DemoBadge label={tExplorer("circleCard.demo")} size="lg" />}
+              <CircleShareButton
+                url={`${appUrl}/circles/${circle.slug}`}
+                ariaLabel={tCommon("share.communityLabel")}
+                circleId={circle.id}
+                circleSlug={circle.slug}
+                circleName={circle.name}
+              />
             </CoverBlock>
           </div>
 

--- a/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/page.tsx
+++ b/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/page.tsx
@@ -24,6 +24,7 @@ import { CircleMembersDialog } from "@/components/circles/circle-members-dialog"
 import { CircleShareInviteCard } from "@/components/circles/circle-share-invite-card";
 import { PendingMembershipsList } from "@/components/circles/pending-requests-list";
 import { CoverBlock } from "@/components/circles/cover-block";
+import { CircleShareButton } from "@/components/circles/circle-share-button";
 import { getMomentGradient } from "@/lib/gradient";
 import { getDisplayName } from "@/lib/display-name";
 import { CollapsibleDescription } from "@/components/moments/collapsible-description";
@@ -161,7 +162,15 @@ export default async function CircleDetailPage({
               coverImageAttribution={circle.coverImageAttribution}
               gradient={gradient}
               altText={circle.name}
-            />
+            >
+              <CircleShareButton
+                url={publicUrl}
+                ariaLabel={tCommon("share.communityLabel")}
+                circleId={circle.id}
+                circleSlug={circle.slug}
+                circleName={circle.name}
+              />
+            </CoverBlock>
           </div>
 
           {/* Groupe 2 — Organisateurs + Stats + CTA (mobile: order-4) */}

--- a/src/components/circles/circle-share-button.tsx
+++ b/src/components/circles/circle-share-button.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import posthog from "posthog-js";
+
+import { ShareButton } from "@/components/share-button";
+
+type Props = {
+  url: string;
+  ariaLabel: string;
+  circleId: string;
+  circleSlug: string;
+  circleName: string;
+};
+
+export function CircleShareButton({
+  url,
+  ariaLabel,
+  circleId,
+  circleSlug,
+  circleName,
+}: Props) {
+  return (
+    <ShareButton
+      url={url}
+      ariaLabel={ariaLabel}
+      onShared={() => {
+        posthog.capture("circle_shared", {
+          circle_id: circleId,
+          circle_slug: circleSlug,
+          circle_name: circleName,
+        });
+      }}
+    />
+  );
+}

--- a/src/components/moments/moment-detail-view.tsx
+++ b/src/components/moments/moment-detail-view.tsx
@@ -295,18 +295,17 @@ export async function MomentDetailView(props: MomentDetailViewProps) {
               sizes="(max-width: 1024px) 100vw, 340px"
               demoLabel={tCommon("demo")}
             >
-              {props.variant === "public" &&
-                (moment.status === "PUBLISHED" || moment.status === "PAST") && (
-                  <MomentShareButton
-                    url={`${props.appUrl}/m/${moment.slug}`}
-                    ariaLabel={tCommon("share.eventLabel")}
-                    momentId={moment.id}
-                    momentSlug={moment.slug}
-                    circleId={circle.id}
-                    circleName={circle.name}
-                    momentStatus={moment.status}
-                  />
-                )}
+              {(moment.status === "PUBLISHED" || moment.status === "PAST") && props.appUrl && (
+                <MomentShareButton
+                  url={`${props.appUrl}/m/${moment.slug}`}
+                  ariaLabel={tCommon("share.eventLabel")}
+                  momentId={moment.id}
+                  momentSlug={moment.slug}
+                  circleId={circle.id}
+                  circleName={circle.name}
+                  momentStatus={moment.status}
+                />
+              )}
             </MomentCoverBlock>
           </div>
 

--- a/src/components/moments/moment-detail-view.tsx
+++ b/src/components/moments/moment-detail-view.tsx
@@ -10,6 +10,7 @@ import { PendingRegistrationsList } from "@/components/circles/pending-requests-
 import { MomentRegistrationsDialog } from "@/components/moments/moment-registrations-dialog";
 import { ParticipantAvatarStack } from "@/components/moments/participant-avatar-stack";
 import { CopyLinkButton } from "@/components/moments/copy-link-button";
+import { MomentShareButton } from "@/components/moments/moment-share-button";
 import { CommentThread } from "@/components/moments/comment-thread";
 import { getMomentGradient } from "@/lib/gradient";
 import { getDisplayName } from "@/lib/display-name";
@@ -100,6 +101,7 @@ type MomentCoverBlockProps = {
   gradient: string;
   sizes: string;
   demoLabel: string;
+  children?: React.ReactNode;
 };
 
 const breadcrumbStatusStyle: Record<string, string> = {
@@ -111,7 +113,7 @@ const breadcrumbStatusStyle: Record<string, string> = {
 
 function MomentCoverBlock({
   coverImage, coverImageAttribution, title, status, isDemo, gradient,
-  sizes, demoLabel,
+  sizes, demoLabel, children,
 }: MomentCoverBlockProps) {
   return (
     <div className="relative">
@@ -141,6 +143,8 @@ function MomentCoverBlock({
             </span>
           </div>
         )}
+
+        {children}
 
         {coverImageAttribution && (
           <div className="absolute inset-x-0 bottom-0 z-10 bg-gradient-to-t from-black/60 to-transparent px-3 pt-8 pb-2">
@@ -290,7 +294,20 @@ export async function MomentDetailView(props: MomentDetailViewProps) {
               gradient={gradient}
               sizes="(max-width: 1024px) 100vw, 340px"
               demoLabel={tCommon("demo")}
-            />
+            >
+              {props.variant === "public" &&
+                (moment.status === "PUBLISHED" || moment.status === "PAST") && (
+                  <MomentShareButton
+                    url={`${props.appUrl}/m/${moment.slug}`}
+                    ariaLabel={tCommon("share.eventLabel")}
+                    momentId={moment.id}
+                    momentSlug={moment.slug}
+                    circleId={circle.id}
+                    circleName={circle.name}
+                    momentStatus={moment.status}
+                  />
+                )}
+            </MomentCoverBlock>
           </div>
 
           {/* Groupe 2 — Circle info "Proposé par" (mobile: order-16, vers le bas après Documents) */}

--- a/src/components/moments/moment-share-button.tsx
+++ b/src/components/moments/moment-share-button.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import posthog from "posthog-js";
+
+import { ShareButton } from "@/components/share-button";
+import type { MomentStatus } from "@/domain/models/moment";
+
+type Props = {
+  url: string;
+  ariaLabel: string;
+  momentId: string;
+  momentSlug: string;
+  circleId: string;
+  circleName: string;
+  momentStatus: MomentStatus;
+};
+
+export function MomentShareButton({
+  url,
+  ariaLabel,
+  momentId,
+  momentSlug,
+  circleId,
+  circleName,
+  momentStatus,
+}: Props) {
+  return (
+    <ShareButton
+      url={url}
+      ariaLabel={ariaLabel}
+      onShared={() => {
+        posthog.capture("moment_shared", {
+          moment_id: momentId,
+          moment_slug: momentSlug,
+          circle_id: circleId,
+          circle_name: circleName,
+          moment_status: momentStatus,
+        });
+      }}
+    />
+  );
+}

--- a/src/components/share-button.tsx
+++ b/src/components/share-button.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { isShareSupported, tryShare } from "@/lib/share";
+
+type ShareButtonProps = {
+  url: string;
+  ariaLabel: string;
+  onShared?: () => void;
+};
+
+export function ShareButton({ url, ariaLabel, onShared }: ShareButtonProps) {
+  const [canShare, setCanShare] = useState(false);
+
+  useEffect(() => {
+    setCanShare(isShareSupported());
+  }, []);
+
+  if (!canShare) return null;
+
+  async function handleClick() {
+    const outcome = await tryShare(url);
+    if (outcome === "shared") onShared?.();
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      aria-label={ariaLabel}
+      className="absolute top-3 right-3 z-10 flex size-9 items-center justify-center rounded-full border border-white/20 bg-black/45 text-white backdrop-blur-sm transition-transform hover:scale-105 hover:bg-black/60 active:scale-95 lg:hidden"
+    >
+      <svg
+        aria-hidden="true"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className="size-[17px] -translate-y-px"
+      >
+        <path d="M12 3v13" />
+        <path d="M16 7l-4-4-4 4" />
+        <path d="M21 14v5a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-5" />
+      </svg>
+    </button>
+  );
+}

--- a/src/lib/__tests__/share.test.ts
+++ b/src/lib/__tests__/share.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from "vitest";
+
+import { isShareSupported, tryShare } from "../share";
+
+function makeNavigator(share?: (data: ShareData) => Promise<void>): Navigator {
+  return { share } as unknown as Navigator;
+}
+
+describe("isShareSupported", () => {
+  describe("given a navigator with share function", () => {
+    it("should return true", () => {
+      expect(isShareSupported(makeNavigator(vi.fn(async () => {})))).toBe(true);
+    });
+  });
+
+  describe("given a navigator without share function", () => {
+    it("should return false", () => {
+      expect(isShareSupported(makeNavigator())).toBe(false);
+    });
+  });
+
+  describe("given no navigator (SSR)", () => {
+    it("should return false", () => {
+      expect(isShareSupported(undefined)).toBe(false);
+    });
+  });
+});
+
+describe("tryShare", () => {
+  describe("given the share API is unsupported", () => {
+    it("should return 'unsupported' without throwing", async () => {
+      expect(await tryShare("https://example.com", undefined)).toBe("unsupported");
+      expect(await tryShare("https://example.com", makeNavigator())).toBe("unsupported");
+    });
+  });
+
+  describe("given navigator.share resolves successfully", () => {
+    it("should call navigator.share with the url and return 'shared'", async () => {
+      const share = vi.fn(async () => {});
+      const result = await tryShare("https://the-playground.fr/m/foo", makeNavigator(share));
+
+      expect(result).toBe("shared");
+      expect(share).toHaveBeenCalledWith({ url: "https://the-playground.fr/m/foo" });
+    });
+  });
+
+  describe("given navigator.share rejects with AbortError (user cancels)", () => {
+    it("should return 'cancelled'", async () => {
+      const share = vi.fn(async () => {
+        throw new DOMException("user cancelled", "AbortError");
+      });
+
+      expect(await tryShare("https://example.com", makeNavigator(share))).toBe("cancelled");
+    });
+  });
+
+  describe("given navigator.share rejects with another error", () => {
+    it("should return 'error' and not propagate", async () => {
+      const share = vi.fn(async () => {
+        throw new Error("permission denied");
+      });
+
+      expect(await tryShare("https://example.com", makeNavigator(share))).toBe("error");
+    });
+
+    it("should treat unknown DOMExceptions as errors", async () => {
+      const share = vi.fn(async () => {
+        throw new DOMException("nope", "NotAllowedError");
+      });
+
+      expect(await tryShare("https://example.com", makeNavigator(share))).toBe("error");
+    });
+  });
+});

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -1,12 +1,16 @@
 export type ShareOutcome = "shared" | "cancelled" | "unsupported" | "error";
 
-export function isShareSupported(nav: Navigator | undefined = typeof navigator !== "undefined" ? navigator : undefined): boolean {
+function defaultNavigator(): Navigator | undefined {
+  return typeof navigator !== "undefined" ? navigator : undefined;
+}
+
+export function isShareSupported(nav: Navigator | undefined = defaultNavigator()): boolean {
   return typeof nav?.share === "function";
 }
 
 export async function tryShare(
   url: string,
-  nav: Navigator | undefined = typeof navigator !== "undefined" ? navigator : undefined,
+  nav: Navigator | undefined = defaultNavigator(),
 ): Promise<ShareOutcome> {
   if (!isShareSupported(nav)) return "unsupported";
 

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -1,0 +1,22 @@
+export type ShareOutcome = "shared" | "cancelled" | "unsupported" | "error";
+
+export function isShareSupported(nav: Navigator | undefined = typeof navigator !== "undefined" ? navigator : undefined): boolean {
+  return typeof nav?.share === "function";
+}
+
+export async function tryShare(
+  url: string,
+  nav: Navigator | undefined = typeof navigator !== "undefined" ? navigator : undefined,
+): Promise<ShareOutcome> {
+  if (!isShareSupported(nav)) return "unsupported";
+
+  try {
+    await nav!.share({ url });
+    return "shared";
+  } catch (err) {
+    if (err instanceof DOMException && err.name === "AbortError") {
+      return "cancelled";
+    }
+    return "error";
+  }
+}


### PR DESCRIPTION
## Summary

Ajoute un bouton de partage en overlay top-right de la cover sur **toutes les pages mobile** qui affichent un événement ou une Communauté. Utilise la Web Share API pour ouvrir le sheet natif iOS/Android (WhatsApp, Messages, AirDrop, Instagram, etc.).

**Quatre surfaces couvertes** :
- `/m/[slug]` (page publique événement)
- `/circles/[slug]` (page publique Communauté)
- `/dashboard/circles/[slug]/moments/[momentSlug]` (page dashboard événement, Host + Participant)
- `/dashboard/circles/[slug]` (page dashboard Communauté, Host + Participant)

**Mobile uniquement** (`lg:hidden`, < 1024 px). Sur desktop, l'URL dans la barre suffit, et la card complète "Partager mon événement / cette Communauté" du dashboard reste pour les Hosts.

**Décisions clés** (spec complète : `spec/features/share-button-participant.md`) :
- `navigator.share({ url })` uniquement, **sans `title` ni `text`** (évite la pollution du presse-papier sur Android)
- URL absolue construite côté server avec `NEXT_PUBLIC_APP_URL`
- Masqué tant que `navigator.share` n'est pas hydraté (~2-3 % des navigateurs mobiles)
- Gating sur statut événement : visible pour `PUBLISHED` et `PAST`, caché pour `DRAFT` et `CANCELLED`
- Tracking PostHog `moment_shared` / `circle_shared` uniquement au **succès** (pas sur `AbortError`)

**Architecture** :
- Logique pure dans `src/lib/share.ts` + 8 tests Vitest
- Composant générique `<ShareButton>` (mobile-only, icône iOS-style en SVG custom)
- Wrappers spécialisés `MomentShareButton` / `CircleShareButton` pour le tracking PostHog (nécessaires car les pages parent sont des server components)

Mockup réaliste : `spec/mockups/share-button-mobile.mockup.html`

Closes #430

## Test plan

- [ ] Ouvrir `/m/<slug>` sur viewport < 1024 px → bouton visible top-right de la cover
- [ ] Ouvrir `/circles/<slug>` sur viewport < 1024 px → bouton visible
- [ ] Idem depuis le dashboard sur les deux pages dashboard
- [ ] Sur desktop ≥ 1024 px → bouton caché (volontaire)
- [ ] Click bouton sur mobile réel → ouvre le sheet natif iOS/Android
- [ ] Annuler le sheet → aucune erreur, pas de tracking
- [ ] Partager avec succès → event `moment_shared` ou `circle_shared` capturé dans PostHog
- [ ] Page événement `DRAFT` ou `CANCELLED` → bouton caché
- [ ] Tester en PWA installée si possible

🤖 Generated with [Claude Code](https://claude.com/claude-code)