### PR TITLE
feat(og): refonte cover-style 1:1 des og:image (event + Communauté)

### DIFF
--- a/src/app/[locale]/(routes)/circles/[slug]/opengraph-image.tsx
+++ b/src/app/[locale]/(routes)/circles/[slug]/opengraph-image.tsx
@@ -1,14 +1,25 @@
 import { ImageResponse } from "next/og";
+import { getTranslations } from "next-intl/server";
 import { prismaCircleRepository } from "@/infrastructure/repositories";
 import { getCircleBySlug } from "@/domain/usecases/get-circle";
 import { CircleNotFoundError } from "@/domain/errors";
 import { getMomentGradient } from "@/lib/gradient";
 import { loadOgCoverAsDataUrl } from "@/lib/og-image-loader";
+import { truncate } from "@/lib/text";
+import {
+  OG_COLORS,
+  OgBrandingPill,
+  OgCoverBackground,
+  OgScrim,
+} from "@/lib/og/components";
 
 export const runtime = "nodejs";
 export const alt = "Community — The Playground";
 export const size = { width: 1200, height: 1200 };
 export const contentType = "image/png";
+
+const NAME_MAX = 50;
+const META_MAX = 56;
 
 export default async function OgImage({
   params,
@@ -33,170 +44,75 @@ export default async function OgImage({
     return new Response("Not found", { status: 404 });
   }
 
-  const memberCount = await prismaCircleRepository.countMembers(circle.id);
+  const [memberCount, coverDataUrl, t] = await Promise.all([
+    prismaCircleRepository.countMembers(circle.id),
+    circle.coverImage
+      ? loadOgCoverAsDataUrl(circle.coverImage)
+      : Promise.resolve(null),
+    getTranslations({ locale, namespace: "Explorer.circleCard" }),
+  ]);
 
-  const truncatedName =
-    circle.name.length > 50 ? circle.name.slice(0, 47) + "…" : circle.name;
-
-  const memberLabel =
-    locale === "fr"
-      ? `${memberCount} membre${memberCount !== 1 ? "s" : ""}`
-      : `${memberCount} member${memberCount !== 1 ? "s" : ""}`;
+  const memberLabel = t("members", { count: memberCount });
   const metaText = circle.city ? `${memberLabel} · ${circle.city}` : memberLabel;
-  const truncatedMeta =
-    metaText.length > 56 ? metaText.slice(0, 53) + "…" : metaText;
 
-  const gradient = getMomentGradient(circle.id);
-  const coverDataUrl = circle.coverImage
-    ? await loadOgCoverAsDataUrl(circle.coverImage)
-    : null;
-
-  return new ImageResponse(
-    (
-      <div
-        style={{
-          width: "100%",
-          height: "100%",
-          display: "flex",
-          position: "relative",
-          background: "#0c0a14",
-        }}
-      >
-        {coverDataUrl ? (
-          // eslint-disable-next-line @next/next/no-img-element
-          <img
-            src={coverDataUrl}
-            alt=""
-            width={size.width}
-            height={size.height}
-            style={{
-              position: "absolute",
-              inset: 0,
-              width: "100%",
-              height: "100%",
-              objectFit: "cover",
-            }}
-          />
-        ) : (
-          <div
-            style={{
-              position: "absolute",
-              inset: 0,
-              background: gradient,
-              display: "flex",
-            }}
-          />
-        )}
-
-        {/* Bottom scrim — gradient noir → transparent pour lisibilité du bloc info */}
-        {coverDataUrl && (
-          <div
-            style={{
-              position: "absolute",
-              left: 0,
-              right: 0,
-              bottom: 0,
-              height: "55%",
-              background:
-                "linear-gradient(0deg, rgba(0,0,0,0.92) 0%, rgba(0,0,0,0.55) 50%, rgba(0,0,0,0) 100%)",
-              display: "flex",
-            }}
-          />
-        )}
-
-        {/* Branding pill — haut-droite */}
+  return (
+    new ImageResponse(
+      (
         <div
           style={{
-            position: "absolute",
-            top: 36,
-            right: 36,
+            width: "100%",
+            height: "100%",
             display: "flex",
-            alignItems: "center",
-            gap: 12,
-            background: "rgba(8, 6, 16, 0.55)",
-            padding: "12px 20px",
-            borderRadius: 999,
-            border: "1px solid rgba(255, 255, 255, 0.1)",
+            position: "relative",
+            background: OG_COLORS.bgDark,
           }}
         >
-          <div
-            style={{
-              width: 36,
-              height: 36,
-              borderRadius: 9,
-              background: "linear-gradient(135deg, #ec4899, #a855f7)",
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-            }}
-          >
-            <svg width="14" height="16" viewBox="0 0 13 15" fill="none">
-              <polygon points="0,0 0,15 13,7.5" fill="white" />
-            </svg>
-          </div>
-          <div style={{ display: "flex", alignItems: "baseline" }}>
-            <span
-              style={{
-                fontSize: 22,
-                fontWeight: 700,
-                color: "rgba(255, 255, 255, 0.5)",
-                letterSpacing: "-0.5px",
-              }}
-            >
-              {"the "}
-            </span>
-            <span
-              style={{
-                fontSize: 22,
-                fontWeight: 700,
-                color: "#ff6097",
-                letterSpacing: "-0.5px",
-              }}
-            >
-              playground
-            </span>
-          </div>
-        </div>
+          <OgCoverBackground
+            coverDataUrl={coverDataUrl}
+            gradient={getMomentGradient(circle.id)}
+          />
+          {coverDataUrl && <OgScrim />}
+          <OgBrandingPill />
 
-        {/* Bottom content : titre + meta */}
-        <div
-          style={{
-            position: "absolute",
-            left: 56,
-            right: 56,
-            bottom: 56,
-            display: "flex",
-            flexDirection: "column",
-            alignItems: coverDataUrl ? "flex-start" : "center",
-            textAlign: coverDataUrl ? "left" : "center",
-          }}
-        >
           <div
             style={{
-              fontSize: 64,
-              fontWeight: 700,
-              color: "white",
-              lineHeight: 1.06,
-              letterSpacing: "-1.7px",
+              position: "absolute",
+              left: 56,
+              right: 56,
+              bottom: 56,
               display: "flex",
+              flexDirection: "column",
+              alignItems: coverDataUrl ? "flex-start" : "center",
+              textAlign: coverDataUrl ? "left" : "center",
             }}
           >
-            {truncatedName}
-          </div>
-          <div
-            style={{
-              fontSize: 26,
-              fontWeight: 500,
-              color: "rgba(255, 255, 255, 0.78)",
-              marginTop: 18,
-              display: "flex",
-            }}
-          >
-            {truncatedMeta}
+            <div
+              style={{
+                fontSize: 64,
+                fontWeight: 700,
+                color: "white",
+                lineHeight: 1.06,
+                letterSpacing: "-1.7px",
+                display: "flex",
+              }}
+            >
+              {truncate(circle.name, NAME_MAX)}
+            </div>
+            <div
+              style={{
+                fontSize: 26,
+                fontWeight: 500,
+                color: "rgba(255, 255, 255, 0.78)",
+                marginTop: 18,
+                display: "flex",
+              }}
+            >
+              {truncate(metaText, META_MAX)}
+            </div>
           </div>
         </div>
-      </div>
-    ),
-    { ...size },
+      ),
+      { ...size },
+    )
   );
 }

--- a/src/app/[locale]/(routes)/circles/[slug]/opengraph-image.tsx
+++ b/src/app/[locale]/(routes)/circles/[slug]/opengraph-image.tsx
@@ -7,11 +7,8 @@ import { loadOgCoverAsDataUrl } from "@/lib/og-image-loader";
 
 export const runtime = "nodejs";
 export const alt = "Community — The Playground";
-export const size = { width: 1200, height: 630 };
+export const size = { width: 1200, height: 1200 };
 export const contentType = "image/png";
-
-const COVER_SIZE = 630;
-const CONTENT_WIDTH = size.width - COVER_SIZE;
 
 export default async function OgImage({
   params,
@@ -38,11 +35,16 @@ export default async function OgImage({
 
   const memberCount = await prismaCircleRepository.countMembers(circle.id);
 
-  const description = circle.description
-    ? circle.description.length > 140
-      ? circle.description.slice(0, 137) + "..."
-      : circle.description
-    : "";
+  const truncatedName =
+    circle.name.length > 50 ? circle.name.slice(0, 47) + "…" : circle.name;
+
+  const memberLabel =
+    locale === "fr"
+      ? `${memberCount} membre${memberCount !== 1 ? "s" : ""}`
+      : `${memberCount} member${memberCount !== 1 ? "s" : ""}`;
+  const metaText = circle.city ? `${memberLabel} · ${circle.city}` : memberLabel;
+  const truncatedMeta =
+    metaText.length > 56 ? metaText.slice(0, 53) + "…" : metaText;
 
   const gradient = getMomentGradient(circle.id);
   const coverDataUrl = circle.coverImage
@@ -56,239 +58,145 @@ export default async function OgImage({
           width: "100%",
           height: "100%",
           display: "flex",
-          flexDirection: "row",
-          background: "linear-gradient(180deg, #0c0a14 0%, #1a1028 100%)",
           position: "relative",
+          background: "#0c0a14",
         }}
       >
-        {/* Top gradient bar, full width */}
+        {coverDataUrl ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={coverDataUrl}
+            alt=""
+            width={size.width}
+            height={size.height}
+            style={{
+              position: "absolute",
+              inset: 0,
+              width: "100%",
+              height: "100%",
+              objectFit: "cover",
+            }}
+          />
+        ) : (
+          <div
+            style={{
+              position: "absolute",
+              inset: 0,
+              background: gradient,
+              display: "flex",
+            }}
+          />
+        )}
+
+        {/* Bottom scrim — gradient noir → transparent pour lisibilité du bloc info */}
+        {coverDataUrl && (
+          <div
+            style={{
+              position: "absolute",
+              left: 0,
+              right: 0,
+              bottom: 0,
+              height: "55%",
+              background:
+                "linear-gradient(0deg, rgba(0,0,0,0.92) 0%, rgba(0,0,0,0.55) 50%, rgba(0,0,0,0) 100%)",
+              display: "flex",
+            }}
+          />
+        )}
+
+        {/* Branding pill — haut-droite */}
         <div
           style={{
             position: "absolute",
-            top: 0,
-            left: 0,
-            right: 0,
-            height: "6px",
-            background: "linear-gradient(90deg, #ec4899, #a855f7, #ec4899)",
-          }}
-        />
-
-        {/* Left: square cover (or gradient fallback) */}
-        <div
-          style={{
-            width: COVER_SIZE,
-            height: COVER_SIZE,
+            top: 36,
+            right: 36,
             display: "flex",
-            flexShrink: 0,
-            position: "relative",
+            alignItems: "center",
+            gap: 12,
+            background: "rgba(8, 6, 16, 0.55)",
+            padding: "12px 20px",
+            borderRadius: 999,
+            border: "1px solid rgba(255, 255, 255, 0.1)",
           }}
         >
-          {coverDataUrl ? (
-            // eslint-disable-next-line @next/next/no-img-element
-            <img
-              src={coverDataUrl}
-              alt=""
-              width={COVER_SIZE}
-              height={COVER_SIZE}
-              style={{ width: COVER_SIZE, height: COVER_SIZE, objectFit: "cover" }}
-            />
-          ) : (
-            <div
-              style={{
-                width: COVER_SIZE,
-                height: COVER_SIZE,
-                background: gradient,
-              }}
-            />
-          )}
-        </div>
-
-        {/* Right: content */}
-        <div
-          style={{
-            width: CONTENT_WIDTH,
-            height: "100%",
-            display: "flex",
-            flexDirection: "column",
-            padding: "40px 48px 44px 48px",
-          }}
-        >
-          {/* Top: branding, aligned to the right */}
           <div
             style={{
+              width: 36,
+              height: 36,
+              borderRadius: 9,
+              background: "linear-gradient(135deg, #ec4899, #a855f7)",
               display: "flex",
-              justifyContent: "flex-end",
               alignItems: "center",
-            }}
-          >
-            <div
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: "12px",
-              }}
-            >
-              <div
-                style={{
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  width: "36px",
-                  height: "36px",
-                  borderRadius: "9px",
-                  background: "linear-gradient(135deg, #ec4899, #a855f7)",
-                }}
-              >
-                <svg width="14" height="16" viewBox="0 0 13 15" fill="none">
-                  <polygon points="0,0 0,15 13,7.5" fill="white" />
-                </svg>
-              </div>
-              <div style={{ display: "flex", alignItems: "baseline" }}>
-                <span
-                  style={{
-                    fontSize: "22px",
-                    fontWeight: 700,
-                    color: "rgba(255, 255, 255, 0.4)",
-                    letterSpacing: "-0.5px",
-                  }}
-                >
-                  {"the "}
-                </span>
-                <span
-                  style={{
-                    fontSize: "22px",
-                    fontWeight: 700,
-                    color: "#e8457a",
-                    letterSpacing: "-0.5px",
-                  }}
-                >
-                  playground
-                </span>
-              </div>
-            </div>
-          </div>
-
-          {/* Middle: community label + name + description, centered vertically */}
-          <div
-            style={{
-              flex: 1,
-              display: "flex",
-              flexDirection: "column",
               justifyContent: "center",
             }}
           >
-            <div
-              style={{
-                display: "flex",
-                alignItems: "center",
-                fontSize: "18px",
-                fontWeight: 600,
-                color: "#ec4899",
-                textTransform: "uppercase",
-                letterSpacing: "2.5px",
-                marginBottom: "18px",
-              }}
-            >
-              {locale === "fr" ? "Communauté" : "Community"}
-            </div>
-
-            <div
-              style={{
-                fontSize: "52px",
-                fontWeight: 700,
-                color: "white",
-                lineHeight: 1.12,
-                letterSpacing: "-1.2px",
-                marginBottom: description ? "18px" : "0",
-                display: "flex",
-              }}
-            >
-              {circle.name.length > 60
-                ? circle.name.slice(0, 57) + "..."
-                : circle.name}
-            </div>
-
-            {description && (
-              <div
-                style={{
-                  fontSize: "22px",
-                  color: "rgba(255, 255, 255, 0.65)",
-                  lineHeight: 1.4,
-                  display: "flex",
-                }}
-              >
-                {description}
-              </div>
-            )}
+            <svg width="14" height="16" viewBox="0 0 13 15" fill="none">
+              <polygon points="0,0 0,15 13,7.5" fill="white" />
+            </svg>
           </div>
+          <div style={{ display: "flex", alignItems: "baseline" }}>
+            <span
+              style={{
+                fontSize: 22,
+                fontWeight: 700,
+                color: "rgba(255, 255, 255, 0.5)",
+                letterSpacing: "-0.5px",
+              }}
+            >
+              {"the "}
+            </span>
+            <span
+              style={{
+                fontSize: 22,
+                fontWeight: 700,
+                color: "#ff6097",
+                letterSpacing: "-0.5px",
+              }}
+            >
+              playground
+            </span>
+          </div>
+        </div>
 
-          {/* Bottom: members + city */}
+        {/* Bottom content : titre + meta */}
+        <div
+          style={{
+            position: "absolute",
+            left: 56,
+            right: 56,
+            bottom: 56,
+            display: "flex",
+            flexDirection: "column",
+            alignItems: coverDataUrl ? "flex-start" : "center",
+            textAlign: coverDataUrl ? "left" : "center",
+          }}
+        >
           <div
             style={{
+              fontSize: 64,
+              fontWeight: 700,
+              color: "white",
+              lineHeight: 1.06,
+              letterSpacing: "-1.7px",
               display: "flex",
-              flexDirection: "column",
-              gap: "12px",
             }}
           >
-            <div
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: "12px",
-                fontSize: "26px",
-                color: "rgba(255, 255, 255, 0.85)",
-              }}
-            >
-              <svg
-                width="26"
-                height="26"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="rgba(255,255,255,0.6)"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              >
-                <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
-                <circle cx="9" cy="7" r="4" />
-                <path d="M22 21v-2a4 4 0 0 0-3-3.87" />
-                <path d="M16 3.13a4 4 0 0 1 0 7.75" />
-              </svg>
-              {locale === "fr"
-                ? `${memberCount} membre${memberCount !== 1 ? "s" : ""}`
-                : `${memberCount} member${memberCount !== 1 ? "s" : ""}`}
-            </div>
-
-            {circle.city && (
-              <div
-                style={{
-                  display: "flex",
-                  alignItems: "center",
-                  gap: "12px",
-                  fontSize: "22px",
-                  color: "rgba(255, 255, 255, 0.6)",
-                }}
-              >
-                <svg
-                  width="22"
-                  height="22"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="rgba(255,255,255,0.5)"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                >
-                  <path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0Z" />
-                  <circle cx="12" cy="10" r="3" />
-                </svg>
-                {circle.city}
-              </div>
-            )}
+            {truncatedName}
+          </div>
+          <div
+            style={{
+              fontSize: 26,
+              fontWeight: 500,
+              color: "rgba(255, 255, 255, 0.78)",
+              marginTop: 18,
+              display: "flex",
+            }}
+          >
+            {truncatedMeta}
           </div>
         </div>
       </div>
     ),
-    { ...size }
+    { ...size },
   );
 }

--- a/src/app/[locale]/(routes)/m/[slug]/opengraph-image.tsx
+++ b/src/app/[locale]/(routes)/m/[slug]/opengraph-image.tsx
@@ -11,11 +11,8 @@ import { loadOgCoverAsDataUrl } from "@/lib/og-image-loader";
 
 export const runtime = "nodejs";
 export const alt = "Event — The Playground";
-export const size = { width: 1200, height: 630 };
+export const size = { width: 1200, height: 1200 };
 export const contentType = "image/png";
-
-const COVER_SIZE = 630;
-const CONTENT_WIDTH = size.width - COVER_SIZE;
 
 export default async function OgImage({
   params,
@@ -44,16 +41,20 @@ export default async function OgImage({
   const circle = await prismaCircleRepository.findById(moment.circleId);
 
   const dateLocale = locale === "fr" ? "fr-FR" : "en-US";
-  const date = moment.startsAt.toLocaleDateString(dateLocale, {
-    weekday: "long",
-    day: "numeric",
-    month: "long",
-    year: "numeric",
-  });
+  const month = moment.startsAt
+    .toLocaleDateString(dateLocale, { month: "short" })
+    .replace(/\.$/, "")
+    .toUpperCase();
+  const day = moment.startsAt.toLocaleDateString(dateLocale, { day: "numeric" });
+  const weekday = moment.startsAt
+    .toLocaleDateString(dateLocale, { weekday: "short" })
+    .replace(/\.$/, "")
+    .toUpperCase();
   const time = moment.startsAt.toLocaleTimeString(dateLocale, {
     hour: "2-digit",
     minute: "2-digit",
   });
+
   const onlineLabel = locale === "fr" ? "En ligne" : "Online";
   const hybridLabel = locale === "fr" ? "Hybride" : "Hybrid";
   const location =
@@ -62,6 +63,15 @@ export default async function OgImage({
       : moment.locationType === "HYBRID"
         ? hybridLabel
         : moment.locationName ?? moment.locationAddress ?? "";
+
+  const metaText = location
+    ? `${weekday} ${time} · ${location}`
+    : `${weekday} ${time}`;
+  const truncatedMeta =
+    metaText.length > 56 ? metaText.slice(0, 53) + "…" : metaText;
+
+  const truncatedTitle =
+    moment.title.length > 70 ? moment.title.slice(0, 67) + "…" : moment.title;
 
   const gradient = getMomentGradient(moment.id);
   const coverDataUrl = moment.coverImage
@@ -75,225 +85,204 @@ export default async function OgImage({
           width: "100%",
           height: "100%",
           display: "flex",
-          flexDirection: "row",
-          background: "linear-gradient(180deg, #0c0a14 0%, #1a1028 100%)",
           position: "relative",
+          background: "#0c0a14",
         }}
       >
-        {/* Top gradient bar, full width */}
+        {coverDataUrl ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={coverDataUrl}
+            alt=""
+            width={size.width}
+            height={size.height}
+            style={{
+              position: "absolute",
+              inset: 0,
+              width: "100%",
+              height: "100%",
+              objectFit: "cover",
+            }}
+          />
+        ) : (
+          <div
+            style={{
+              position: "absolute",
+              inset: 0,
+              background: gradient,
+              display: "flex",
+            }}
+          />
+        )}
+
+        {/* Bottom scrim — gradient noir → transparent pour lisibilité du bloc info */}
         <div
           style={{
             position: "absolute",
-            top: 0,
             left: 0,
             right: 0,
-            height: "6px",
-            background: "linear-gradient(90deg, #ec4899, #a855f7, #ec4899)",
+            bottom: 0,
+            height: "55%",
+            background:
+              "linear-gradient(0deg, rgba(0,0,0,0.92) 0%, rgba(0,0,0,0.55) 50%, rgba(0,0,0,0) 100%)",
+            display: "flex",
           }}
         />
 
-        {/* Left: square cover (or gradient fallback) */}
+        {/* Branding pill — haut-droite */}
         <div
           style={{
-            width: COVER_SIZE,
-            height: COVER_SIZE,
+            position: "absolute",
+            top: 36,
+            right: 36,
             display: "flex",
-            flexShrink: 0,
-            position: "relative",
+            alignItems: "center",
+            gap: 12,
+            background: "rgba(8, 6, 16, 0.55)",
+            padding: "12px 20px",
+            borderRadius: 999,
+            border: "1px solid rgba(255, 255, 255, 0.1)",
           }}
         >
-          {coverDataUrl ? (
-            // eslint-disable-next-line @next/next/no-img-element
-            <img
-              src={coverDataUrl}
-              alt=""
-              width={COVER_SIZE}
-              height={COVER_SIZE}
-              style={{ width: COVER_SIZE, height: COVER_SIZE, objectFit: "cover" }}
-            />
-          ) : (
-            <div
-              style={{
-                width: COVER_SIZE,
-                height: COVER_SIZE,
-                background: gradient,
-              }}
-            />
-          )}
-        </div>
-
-        {/* Right: content */}
-        <div
-          style={{
-            width: CONTENT_WIDTH,
-            height: "100%",
-            display: "flex",
-            flexDirection: "column",
-            padding: "40px 48px 44px 48px",
-          }}
-        >
-          {/* Top: branding, aligned to the right */}
           <div
             style={{
+              width: 36,
+              height: 36,
+              borderRadius: 9,
+              background: "linear-gradient(135deg, #ec4899, #a855f7)",
               display: "flex",
-              justifyContent: "flex-end",
               alignItems: "center",
+              justifyContent: "center",
             }}
           >
-            <div
+            <svg width="14" height="16" viewBox="0 0 13 15" fill="none">
+              <polygon points="0,0 0,15 13,7.5" fill="white" />
+            </svg>
+          </div>
+          <div style={{ display: "flex", alignItems: "baseline" }}>
+            <span
               style={{
-                display: "flex",
-                alignItems: "center",
-                gap: "12px",
+                fontSize: 22,
+                fontWeight: 700,
+                color: "rgba(255, 255, 255, 0.5)",
+                letterSpacing: "-0.5px",
               }}
             >
-              <div
-                style={{
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  width: "36px",
-                  height: "36px",
-                  borderRadius: "9px",
-                  background: "linear-gradient(135deg, #ec4899, #a855f7)",
-                }}
-              >
-                <svg width="14" height="16" viewBox="0 0 13 15" fill="none">
-                  <polygon points="0,0 0,15 13,7.5" fill="white" />
-                </svg>
-              </div>
-              <div style={{ display: "flex", alignItems: "baseline" }}>
-                <span
-                  style={{
-                    fontSize: "22px",
-                    fontWeight: 700,
-                    color: "rgba(255, 255, 255, 0.4)",
-                    letterSpacing: "-0.5px",
-                  }}
-                >
-                  {"the "}
-                </span>
-                <span
-                  style={{
-                    fontSize: "22px",
-                    fontWeight: 700,
-                    color: "#e8457a",
-                    letterSpacing: "-0.5px",
-                  }}
-                >
-                  playground
-                </span>
-              </div>
-            </div>
+              {"the "}
+            </span>
+            <span
+              style={{
+                fontSize: 22,
+                fontWeight: 700,
+                color: "#ff6097",
+                letterSpacing: "-0.5px",
+              }}
+            >
+              playground
+            </span>
           </div>
+        </div>
 
-          {/* Middle: Circle name + title, centered vertically */}
+        {/* Bottom content : date pill + Circle name + title + meta */}
+        <div
+          style={{
+            position: "absolute",
+            left: 56,
+            right: 56,
+            bottom: 56,
+            display: "flex",
+            gap: 32,
+            alignItems: "flex-end",
+          }}
+        >
           <div
             style={{
-              flex: 1,
               display: "flex",
               flexDirection: "column",
+              alignItems: "center",
               justifyContent: "center",
+              background: "white",
+              borderRadius: 18,
+              padding: "16px 22px",
+              flexShrink: 0,
+              boxShadow: "0 12px 36px rgba(0,0,0,0.5)",
+            }}
+          >
+            <span
+              style={{
+                fontSize: 18,
+                fontWeight: 700,
+                color: "#ec4899",
+                textTransform: "uppercase",
+                letterSpacing: "2.4px",
+                lineHeight: 1,
+                marginBottom: 8,
+              }}
+            >
+              {month}
+            </span>
+            <span
+              style={{
+                fontSize: 56,
+                fontWeight: 800,
+                color: "#18181b",
+                letterSpacing: "-1.5px",
+                lineHeight: 1,
+              }}
+            >
+              {day}
+            </span>
+          </div>
+
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              flex: 1,
+              minWidth: 0,
             }}
           >
             {circle && (
               <div
                 style={{
-                  fontSize: "26px",
+                  fontSize: 26,
                   fontWeight: 600,
-                  color: "#ec4899",
-                  marginBottom: "20px",
+                  color: "#ff8eb6",
+                  letterSpacing: "0.2px",
+                  marginBottom: 10,
                   display: "flex",
-                  alignItems: "center",
                 }}
               >
                 {circle.name}
               </div>
             )}
-
             <div
               style={{
-                fontSize: "52px",
+                fontSize: 56,
                 fontWeight: 700,
                 color: "white",
-                lineHeight: 1.12,
-                letterSpacing: "-1.2px",
+                lineHeight: 1.08,
+                letterSpacing: "-1.5px",
                 display: "flex",
               }}
             >
-              {moment.title.length > 90
-                ? moment.title.slice(0, 87) + "..."
-                : moment.title}
+              {truncatedTitle}
             </div>
-          </div>
-
-          {/* Bottom: date + location */}
-          <div
-            style={{
-              display: "flex",
-              flexDirection: "column",
-              gap: "12px",
-            }}
-          >
             <div
               style={{
+                fontSize: 24,
+                fontWeight: 500,
+                color: "rgba(255, 255, 255, 0.78)",
+                marginTop: 14,
                 display: "flex",
-                alignItems: "center",
-                gap: "12px",
-                fontSize: "26px",
-                color: "rgba(255, 255, 255, 0.85)",
               }}
             >
-              <svg
-                width="26"
-                height="26"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="rgba(255,255,255,0.6)"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              >
-                <rect width="18" height="18" x="3" y="4" rx="2" ry="2" />
-                <line x1="16" x2="16" y1="2" y2="6" />
-                <line x1="8" x2="8" y1="2" y2="6" />
-                <line x1="3" x2="21" y1="10" y2="10" />
-              </svg>
-              {date} · {time}
+              {truncatedMeta}
             </div>
-
-            {location && (
-              <div
-                style={{
-                  display: "flex",
-                  alignItems: "center",
-                  gap: "12px",
-                  fontSize: "22px",
-                  color: "rgba(255, 255, 255, 0.6)",
-                }}
-              >
-                <svg
-                  width="22"
-                  height="22"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="rgba(255,255,255,0.5)"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                >
-                  <path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0Z" />
-                  <circle cx="12" cy="10" r="3" />
-                </svg>
-                {location.length > 36
-                  ? location.slice(0, 33) + "..."
-                  : location}
-              </div>
-            )}
           </div>
         </div>
       </div>
     ),
-    { ...size }
+    { ...size },
   );
 }

--- a/src/app/[locale]/(routes)/m/[slug]/opengraph-image.tsx
+++ b/src/app/[locale]/(routes)/m/[slug]/opengraph-image.tsx
@@ -8,11 +8,34 @@ import { MomentNotFoundError } from "@/domain/errors";
 import { isValidSlug } from "@/lib/slug";
 import { getMomentGradient } from "@/lib/gradient";
 import { loadOgCoverAsDataUrl } from "@/lib/og-image-loader";
+import { formatOgDateBadge } from "@/lib/format-date";
+import { truncate } from "@/lib/text";
+import {
+  OG_COLORS,
+  OgBrandingPill,
+  OgCoverBackground,
+  OgScrim,
+} from "@/lib/og/components";
+import type { LocationType } from "@/domain/models/moment";
 
 export const runtime = "nodejs";
 export const alt = "Event — The Playground";
 export const size = { width: 1200, height: 1200 };
 export const contentType = "image/png";
+
+const TITLE_MAX = 70;
+const META_MAX = 56;
+
+function formatLocationLabel(
+  locationType: LocationType,
+  locationName: string | null,
+  locationAddress: string | null,
+  locale: string,
+): string {
+  if (locationType === "ONLINE") return locale === "fr" ? "En ligne" : "Online";
+  if (locationType === "HYBRID") return locale === "fr" ? "Hybride" : "Hybrid";
+  return locationName ?? locationAddress ?? "";
+}
 
 export default async function OgImage({
   params,
@@ -38,45 +61,21 @@ export default async function OgImage({
     return new Response("Not found", { status: 404 });
   }
 
-  const circle = await prismaCircleRepository.findById(moment.circleId);
+  const [circle, coverDataUrl] = await Promise.all([
+    prismaCircleRepository.findById(moment.circleId),
+    moment.coverImage
+      ? loadOgCoverAsDataUrl(moment.coverImage)
+      : Promise.resolve(null),
+  ]);
 
-  const dateLocale = locale === "fr" ? "fr-FR" : "en-US";
-  const month = moment.startsAt
-    .toLocaleDateString(dateLocale, { month: "short" })
-    .replace(/\.$/, "")
-    .toUpperCase();
-  const day = moment.startsAt.toLocaleDateString(dateLocale, { day: "numeric" });
-  const weekday = moment.startsAt
-    .toLocaleDateString(dateLocale, { weekday: "short" })
-    .replace(/\.$/, "")
-    .toUpperCase();
-  const time = moment.startsAt.toLocaleTimeString(dateLocale, {
-    hour: "2-digit",
-    minute: "2-digit",
-  });
-
-  const onlineLabel = locale === "fr" ? "En ligne" : "Online";
-  const hybridLabel = locale === "fr" ? "Hybride" : "Hybrid";
-  const location =
-    moment.locationType === "ONLINE"
-      ? onlineLabel
-      : moment.locationType === "HYBRID"
-        ? hybridLabel
-        : moment.locationName ?? moment.locationAddress ?? "";
-
-  const metaText = location
-    ? `${weekday} ${time} · ${location}`
-    : `${weekday} ${time}`;
-  const truncatedMeta =
-    metaText.length > 56 ? metaText.slice(0, 53) + "…" : metaText;
-
-  const truncatedTitle =
-    moment.title.length > 70 ? moment.title.slice(0, 67) + "…" : moment.title;
-
-  const gradient = getMomentGradient(moment.id);
-  const coverDataUrl = moment.coverImage
-    ? await loadOgCoverAsDataUrl(moment.coverImage)
-    : null;
+  const { month, day, weekday, time } = formatOgDateBadge(moment.startsAt, locale);
+  const location = formatLocationLabel(
+    moment.locationType,
+    moment.locationName,
+    moment.locationAddress,
+    locale,
+  );
+  const metaText = location ? `${weekday} ${time} · ${location}` : `${weekday} ${time}`;
 
   return new ImageResponse(
     (
@@ -86,104 +85,16 @@ export default async function OgImage({
           height: "100%",
           display: "flex",
           position: "relative",
-          background: "#0c0a14",
+          background: OG_COLORS.bgDark,
         }}
       >
-        {coverDataUrl ? (
-          // eslint-disable-next-line @next/next/no-img-element
-          <img
-            src={coverDataUrl}
-            alt=""
-            width={size.width}
-            height={size.height}
-            style={{
-              position: "absolute",
-              inset: 0,
-              width: "100%",
-              height: "100%",
-              objectFit: "cover",
-            }}
-          />
-        ) : (
-          <div
-            style={{
-              position: "absolute",
-              inset: 0,
-              background: gradient,
-              display: "flex",
-            }}
-          />
-        )}
-
-        {/* Bottom scrim — gradient noir → transparent pour lisibilité du bloc info */}
-        <div
-          style={{
-            position: "absolute",
-            left: 0,
-            right: 0,
-            bottom: 0,
-            height: "55%",
-            background:
-              "linear-gradient(0deg, rgba(0,0,0,0.92) 0%, rgba(0,0,0,0.55) 50%, rgba(0,0,0,0) 100%)",
-            display: "flex",
-          }}
+        <OgCoverBackground
+          coverDataUrl={coverDataUrl}
+          gradient={getMomentGradient(moment.id)}
         />
+        <OgScrim />
+        <OgBrandingPill />
 
-        {/* Branding pill — haut-droite */}
-        <div
-          style={{
-            position: "absolute",
-            top: 36,
-            right: 36,
-            display: "flex",
-            alignItems: "center",
-            gap: 12,
-            background: "rgba(8, 6, 16, 0.55)",
-            padding: "12px 20px",
-            borderRadius: 999,
-            border: "1px solid rgba(255, 255, 255, 0.1)",
-          }}
-        >
-          <div
-            style={{
-              width: 36,
-              height: 36,
-              borderRadius: 9,
-              background: "linear-gradient(135deg, #ec4899, #a855f7)",
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-            }}
-          >
-            <svg width="14" height="16" viewBox="0 0 13 15" fill="none">
-              <polygon points="0,0 0,15 13,7.5" fill="white" />
-            </svg>
-          </div>
-          <div style={{ display: "flex", alignItems: "baseline" }}>
-            <span
-              style={{
-                fontSize: 22,
-                fontWeight: 700,
-                color: "rgba(255, 255, 255, 0.5)",
-                letterSpacing: "-0.5px",
-              }}
-            >
-              {"the "}
-            </span>
-            <span
-              style={{
-                fontSize: 22,
-                fontWeight: 700,
-                color: "#ff6097",
-                letterSpacing: "-0.5px",
-              }}
-            >
-              playground
-            </span>
-          </div>
-        </div>
-
-        {/* Bottom content : date pill + Circle name + title + meta */}
         <div
           style={{
             position: "absolute",
@@ -212,7 +123,7 @@ export default async function OgImage({
               style={{
                 fontSize: 18,
                 fontWeight: 700,
-                color: "#ec4899",
+                color: OG_COLORS.pink,
                 textTransform: "uppercase",
                 letterSpacing: "2.4px",
                 lineHeight: 1,
@@ -225,7 +136,7 @@ export default async function OgImage({
               style={{
                 fontSize: 56,
                 fontWeight: 800,
-                color: "#18181b",
+                color: OG_COLORS.zinc950,
                 letterSpacing: "-1.5px",
                 lineHeight: 1,
               }}
@@ -247,7 +158,7 @@ export default async function OgImage({
                 style={{
                   fontSize: 26,
                   fontWeight: 600,
-                  color: "#ff8eb6",
+                  color: OG_COLORS.pinkSoft,
                   letterSpacing: "0.2px",
                   marginBottom: 10,
                   display: "flex",
@@ -266,7 +177,7 @@ export default async function OgImage({
                 display: "flex",
               }}
             >
-              {truncatedTitle}
+              {truncate(moment.title, TITLE_MAX)}
             </div>
             <div
               style={{
@@ -277,7 +188,7 @@ export default async function OgImage({
                 display: "flex",
               }}
             >
-              {truncatedMeta}
+              {truncate(metaText, META_MAX)}
             </div>
           </div>
         </div>

--- a/src/lib/format-date.ts
+++ b/src/lib/format-date.ts
@@ -137,6 +137,38 @@ export function formatDateRange(
 }
 
 /**
+ * Composantes typographiques utilisées par les og:image (date pill + meta) :
+ * mois & jour pour la pill blanche, weekday + heure pour la ligne meta.
+ * Tout en uppercase, sans le point final que `Intl` ajoute parfois en FR.
+ */
+export function formatOgDateBadge(
+  date: Date,
+  locale: string,
+): { month: string; day: string; weekday: string; time: string } {
+  const intlLocale = toIntlLocale(locale);
+  const stripDot = (s: string) => s.replace(/\.$/, "").toUpperCase();
+  return {
+    month: stripDot(
+      new Intl.DateTimeFormat(intlLocale, {
+        timeZone: TIMEZONE,
+        month: "short",
+      }).format(date),
+    ),
+    day: new Intl.DateTimeFormat(intlLocale, {
+      timeZone: TIMEZONE,
+      day: "numeric",
+    }).format(date),
+    weekday: stripDot(
+      new Intl.DateTimeFormat(intlLocale, {
+        timeZone: TIMEZONE,
+        weekday: "short",
+      }).format(date),
+    ),
+    time: formatLocalizedTime(date, locale),
+  };
+}
+
+/**
  * Affichage meta "Quand" sur la page événement — toujours 2 lignes.
  *
  * - Pas de `endsAt`       → `{ line1: "mardi 22 avril", line2: "15:00", isMultiDay: false }`

--- a/src/lib/og-image-loader.ts
+++ b/src/lib/og-image-loader.ts
@@ -1,13 +1,23 @@
 import sharp from "sharp";
 
+const OG_COVER_SIZE = 1200;
+
 /**
- * Satori (le moteur derrière `next/og`) ne sait pas décoder le WebP.
- * Comme nos covers sont uploadées en WebP, on doit les re-encoder en PNG
- * avant de les passer au composant JSX de l'OG image. On renvoie une data URL
- * inlinable, et null en cas d'échec (le caller retombe alors sur un fallback).
+ * Charge la cover, la re-encode systématiquement en JPEG q80 redimensionné à
+ * 1200×1200 puis la renvoie comme data URL inlinable.
+ *
+ * Pourquoi forcer JPEG + resize :
+ * - Satori (next/og) ne sait pas décoder le WebP — il faut convertir.
+ * - Inliner une cover originale (souvent 1080–4000 px, parfois en PNG)
+ *   gonfle la réponse de plusieurs centaines de Ko et fait travailler Satori
+ *   pour rien. On la cale au format de la canvas (1200×1200).
+ * - La cover est toujours rendue derrière un scrim noir 55% → JPEG q80 est
+ *   visuellement indiscernable du PNG et ~5–10× plus léger.
+ *
+ * Renvoie null en cas d'échec : le caller retombe sur un fallback gradient.
  */
 export async function loadOgCoverAsDataUrl(
-  url: string
+  url: string,
 ): Promise<string | null> {
   try {
     const response = await fetch(url, {
@@ -16,18 +26,13 @@ export async function loadOgCoverAsDataUrl(
     });
     if (!response.ok) return null;
 
-    const contentType = response.headers.get("content-type") ?? "";
     const buffer = Buffer.from(await response.arrayBuffer());
+    const output = await sharp(buffer)
+      .resize(OG_COVER_SIZE, OG_COVER_SIZE, { fit: "cover" })
+      .jpeg({ quality: 80, mozjpeg: true })
+      .toBuffer();
 
-    const needsConversion = contentType.includes("webp");
-    const output = needsConversion
-      ? await sharp(buffer).png().toBuffer()
-      : buffer;
-    const mime = needsConversion
-      ? "image/png"
-      : contentType.split(";")[0] || "image/png";
-
-    return `data:${mime};base64,${output.toString("base64")}`;
+    return `data:image/jpeg;base64,${output.toString("base64")}`;
   } catch {
     return null;
   }

--- a/src/lib/og/components.tsx
+++ b/src/lib/og/components.tsx
@@ -1,0 +1,136 @@
+/**
+ * Composants JSX partagés par les og:image (next/og + Satori).
+ *
+ * Note Satori : tous les nœuds doivent porter `display: flex` (ou autre display
+ * supporté). Les `<div>` "vides" qui peuvent sembler inutiles sont en fait
+ * imposés par le moteur de rendu — ne pas les supprimer.
+ */
+
+const OG_SIZE = 1200;
+
+const BRAND_PINK = "#ec4899";
+const BRAND_PURPLE = "#a855f7";
+const BRAND_PINK_BRIGHT = "#ff6097";
+const BRAND_BG_DARK = "#0c0a14";
+
+export const OG_COLORS = {
+  pink: BRAND_PINK,
+  purple: BRAND_PURPLE,
+  pinkBright: BRAND_PINK_BRIGHT,
+  pinkSoft: "#ff8eb6",
+  bgDark: BRAND_BG_DARK,
+  zinc950: "#18181b",
+  logoGradient: `linear-gradient(135deg, ${BRAND_PINK}, ${BRAND_PURPLE})`,
+  scrim:
+    "linear-gradient(0deg, rgba(0,0,0,0.92) 0%, rgba(0,0,0,0.55) 50%, rgba(0,0,0,0) 100%)",
+} as const;
+
+export function OgCoverBackground({
+  coverDataUrl,
+  gradient,
+}: {
+  coverDataUrl: string | null;
+  gradient: string;
+}) {
+  if (coverDataUrl) {
+    return (
+      // eslint-disable-next-line @next/next/no-img-element
+      <img
+        src={coverDataUrl}
+        alt=""
+        width={OG_SIZE}
+        height={OG_SIZE}
+        style={{
+          position: "absolute",
+          inset: 0,
+          width: "100%",
+          height: "100%",
+          objectFit: "cover",
+        }}
+      />
+    );
+  }
+  return (
+    <div
+      style={{
+        position: "absolute",
+        inset: 0,
+        background: gradient,
+        display: "flex",
+      }}
+    />
+  );
+}
+
+export function OgScrim() {
+  return (
+    <div
+      style={{
+        position: "absolute",
+        left: 0,
+        right: 0,
+        bottom: 0,
+        height: "55%",
+        background: OG_COLORS.scrim,
+        display: "flex",
+      }}
+    />
+  );
+}
+
+export function OgBrandingPill() {
+  return (
+    <div
+      style={{
+        position: "absolute",
+        top: 36,
+        right: 36,
+        display: "flex",
+        alignItems: "center",
+        gap: 12,
+        background: "rgba(8, 6, 16, 0.55)",
+        padding: "12px 20px",
+        borderRadius: 999,
+        border: "1px solid rgba(255, 255, 255, 0.1)",
+      }}
+    >
+      <div
+        style={{
+          width: 36,
+          height: 36,
+          borderRadius: 9,
+          background: OG_COLORS.logoGradient,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <svg width="14" height="16" viewBox="0 0 13 15" fill="none">
+          <polygon points="0,0 0,15 13,7.5" fill="white" />
+        </svg>
+      </div>
+      <div style={{ display: "flex", alignItems: "baseline" }}>
+        <span
+          style={{
+            fontSize: 22,
+            fontWeight: 700,
+            color: "rgba(255, 255, 255, 0.5)",
+            letterSpacing: "-0.5px",
+          }}
+        >
+          {"the "}
+        </span>
+        <span
+          style={{
+            fontSize: 22,
+            fontWeight: 700,
+            color: OG_COLORS.pinkBright,
+            letterSpacing: "-0.5px",
+          }}
+        >
+          playground
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/text.ts
+++ b/src/lib/text.ts
@@ -1,0 +1,11 @@
+const ELLIPSIS = "…";
+
+/**
+ * Tronque une chaîne à `max` caractères en ajoutant un caractère ellipse "…"
+ * (le décompte de `max` inclut l'ellipse). Renvoie la chaîne intacte si elle
+ * est déjà sous la limite.
+ */
+export function truncate(str: string, max: number): string {
+  if (str.length <= max) return str;
+  return str.slice(0, max - ELLIPSIS.length) + ELLIPSIS;
+}


### PR DESCRIPTION
## Summary

- **Refonte des og:image** en format carré 1200×1200 cover-dominante, à la Luma. Sur les canaux où nos liens sont le plus partagés (WhatsApp, iMessage, Slack), le carré rend mieux que l'horizontal 1200×630 split 50/50 — le texte de droite finissait tronqué/illisible en preview mobile.
- **Trois composants OG partagés** extraits dans `src/lib/og/components.tsx` (`OgBrandingPill`, `OgScrim`, `OgCoverBackground` + tokens `OG_COLORS`) — net −100 lignes dédupliquées entre les 2 routes.
- **Bug TZ pré-existant corrigé** : les dates étaient formatées sans timezone explicite → un event à 00:30 Paris affichait la veille sur l'OG (server Vercel = UTC). Désormais routé via `formatOgDateBadge` dans `format-date.ts` (Europe/Paris + en-GB pour EN, format 24h).
- **Perf cover** : `og-image-loader` resize systématiquement à 1200×1200 + JPEG q80 mozjpeg avant base64 inlining. Gain estimé **300-800 ms** + plusieurs centaines de Ko sur le cold path Satori (avant : on inlinait la cover full-resolution en PNG).
- **i18n cohérent** : pluralisation membres via `Explorer.circleCard.members` (ICU déjà câblé) au lieu des ternaires manuels FR/EN. Bénéficiera des futures locales sans modif.

## Designs retenus

Mockups visuels validés dans `spec/mockups/og-image-cover-style.mockup.html` et `spec/mockups/og-image-circle-style.mockup.html` (commités dans le commit `f5b4230` sur main).

**Événement** (V7) : cover plein cadre + scrim noir bas + bloc inline `[date pill] [Circle name + Title + meta]` + branding pill haut-droite. Fallback gradient quand pas de cover.

**Communauté** (option A) : cover plein cadre + scrim (uniquement si cover) + `[Title + meta]` + branding pill. Fallback gradient avec contenu centré.

## Trade-off Twitter / LinkedIn

`twitter:card="summary_large_image"` reste au layout. Twitter rognera très légèrement le 1:1 — choix assumé en faveur des canaux messagerie où le viral organique se fait. LinkedIn affiche le carré sans souci notable.

## Test plan

- [x] `pnpm typecheck` ✅
- [x] `pnpm test:unit` ✅ 1049/1049
- [x] `pnpm build` (CI)
- [ ] Smoke preview sur la PR : ouvrir l'og:image d'un event sur preview Vercel et vérifier rendu (avec cover + sans cover)
- [ ] Smoke preview sur la PR : ouvrir l'og:image d'une Communauté
- [ ] Vérifier `og:image` exposé dans les `<head>` correctement (`view-source:` ou debug Vercel)
- [ ] Tester un partage WhatsApp depuis la preview (envoyer le lien à soi-même, voir l'aperçu)
- [ ] Tester un partage Slack depuis la preview
- [ ] Vérifier qu'un partage Twitter/LinkedIn rend acceptable (rognage léger attendu)

## Périmètre

- `src/app/[locale]/(routes)/m/[slug]/opengraph-image.tsx` — refonte event V7
- `src/app/[locale]/(routes)/circles/[slug]/opengraph-image.tsx` — refonte Circle option A
- `src/lib/og/components.tsx` (nouveau) — composants partagés
- `src/lib/text.ts` (nouveau) — helper `truncate(str, max)`
- `src/lib/format-date.ts` — nouvelle fonction `formatOgDateBadge` (corrige le bug TZ)
- `src/lib/og-image-loader.ts` — resize 1200×1200 + JPEG q80

## Commits

- `222c5ff` feat(og): refonte cover-style 1:1 des og:image (event + Communauté)
- `4f703da` refactor(og): nettoyage post-/simplify

🤖 Generated with [Claude Code](https://claude.com/claude-code)