### PR TITLE
fix(og): cover pure + fix TZ description + members count Communauté

### DIFF
--- a/src/app/[locale]/(routes)/circles/[slug]/opengraph-image.tsx
+++ b/src/app/[locale]/(routes)/circles/[slug]/opengraph-image.tsx
@@ -10,7 +10,6 @@ import {
   OG_COLORS,
   OgBrandingPill,
   OgCoverBackground,
-  OgScrim,
 } from "@/lib/og/components";
 
 export const runtime = "nodejs";
@@ -44,19 +43,14 @@ export default async function OgImage({
     return new Response("Not found", { status: 404 });
   }
 
-  const [memberCount, coverDataUrl, t] = await Promise.all([
-    prismaCircleRepository.countMembers(circle.id),
-    circle.coverImage
-      ? loadOgCoverAsDataUrl(circle.coverImage)
-      : Promise.resolve(null),
-    getTranslations({ locale, namespace: "Explorer.circleCard" }),
-  ]);
+  const coverDataUrl = circle.coverImage
+    ? await loadOgCoverAsDataUrl(circle.coverImage)
+    : null;
 
-  const memberLabel = t("members", { count: memberCount });
-  const metaText = circle.city ? `${memberLabel} · ${circle.city}` : memberLabel;
-
-  return (
-    new ImageResponse(
+  // Cover présente → cover pure + branding seulement. Le nom et la meta sont
+  // déjà repris par og:title + og:description sous l'image — éviter la redondance.
+  if (coverDataUrl) {
+    return new ImageResponse(
       (
         <div
           style={{
@@ -67,52 +61,77 @@ export default async function OgImage({
             background: OG_COLORS.bgDark,
           }}
         >
-          <OgCoverBackground
-            coverDataUrl={coverDataUrl}
-            gradient={getMomentGradient(circle.id)}
-          />
-          {coverDataUrl && <OgScrim />}
+          <OgCoverBackground coverDataUrl={coverDataUrl} />
           <OgBrandingPill />
-
-          <div
-            style={{
-              position: "absolute",
-              left: 56,
-              right: 56,
-              bottom: 56,
-              display: "flex",
-              flexDirection: "column",
-              alignItems: coverDataUrl ? "flex-start" : "center",
-              textAlign: coverDataUrl ? "left" : "center",
-            }}
-          >
-            <div
-              style={{
-                fontSize: 64,
-                fontWeight: 700,
-                color: "white",
-                lineHeight: 1.06,
-                letterSpacing: "-1.7px",
-                display: "flex",
-              }}
-            >
-              {truncate(circle.name, NAME_MAX)}
-            </div>
-            <div
-              style={{
-                fontSize: 26,
-                fontWeight: 500,
-                color: "rgba(255, 255, 255, 0.78)",
-                marginTop: 18,
-                display: "flex",
-              }}
-            >
-              {truncate(metaText, META_MAX)}
-            </div>
-          </div>
         </div>
       ),
       { ...size },
-    )
+    );
+  }
+
+  // Pas de cover → fallback content-rich : titre et meta dans l'image.
+  const [memberCount, t] = await Promise.all([
+    prismaCircleRepository.countMembers(circle.id),
+    getTranslations({ locale, namespace: "Explorer.circleCard" }),
+  ]);
+  const memberLabel = t("members", { count: memberCount });
+  const metaText = circle.city ? `${memberLabel} · ${circle.city}` : memberLabel;
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          position: "relative",
+          background: OG_COLORS.bgDark,
+        }}
+      >
+        <OgCoverBackground
+          coverDataUrl={null}
+          gradient={getMomentGradient(circle.id)}
+        />
+        <OgBrandingPill />
+
+        <div
+          style={{
+            position: "absolute",
+            left: 56,
+            right: 56,
+            bottom: 56,
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            textAlign: "center",
+          }}
+        >
+          <div
+            style={{
+              fontSize: 64,
+              fontWeight: 700,
+              color: "white",
+              lineHeight: 1.06,
+              letterSpacing: "-1.7px",
+              display: "flex",
+            }}
+          >
+            {truncate(circle.name, NAME_MAX)}
+          </div>
+          <div
+            style={{
+              fontSize: 26,
+              fontWeight: 500,
+              color: "rgba(255, 255, 255, 0.78)",
+              marginTop: 18,
+              display: "flex",
+            }}
+          >
+            {truncate(metaText, META_MAX)}
+          </div>
+        </div>
+      </div>
+    ),
+    { ...size },
   );
 }

--- a/src/app/[locale]/(routes)/circles/[slug]/opengraph-image.tsx
+++ b/src/app/[locale]/(routes)/circles/[slug]/opengraph-image.tsx
@@ -10,6 +10,7 @@ import {
   OG_COLORS,
   OgBrandingPill,
   OgCoverBackground,
+  OgPureCoverLayout,
 } from "@/lib/og/components";
 
 export const runtime = "nodejs";
@@ -47,26 +48,10 @@ export default async function OgImage({
     ? await loadOgCoverAsDataUrl(circle.coverImage)
     : null;
 
-  // Cover présente → cover pure + branding seulement. Le nom et la meta sont
-  // déjà repris par og:title + og:description sous l'image — éviter la redondance.
   if (coverDataUrl) {
-    return new ImageResponse(
-      (
-        <div
-          style={{
-            width: "100%",
-            height: "100%",
-            display: "flex",
-            position: "relative",
-            background: OG_COLORS.bgDark,
-          }}
-        >
-          <OgCoverBackground coverDataUrl={coverDataUrl} />
-          <OgBrandingPill />
-        </div>
-      ),
-      { ...size },
-    );
+    return new ImageResponse(<OgPureCoverLayout coverDataUrl={coverDataUrl} />, {
+      ...size,
+    });
   }
 
   // Pas de cover → fallback content-rich : titre et meta dans l'image.

--- a/src/app/[locale]/(routes)/circles/[slug]/page.tsx
+++ b/src/app/[locale]/(routes)/circles/[slug]/page.tsx
@@ -60,6 +60,10 @@ const getCachedCircle = cache(async (slug: string) => {
   }
 });
 
+const getCachedMemberCount = cache((circleId: string) =>
+  prismaCircleRepository.countMembers(circleId),
+);
+
 // ── Helpers ───────────────────────────────────────────────────
 
 // ── Metadata ──────────────────────────────────────────────────
@@ -77,7 +81,7 @@ export async function generateMetadata({
     const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
 
     const [memberCount, t] = await Promise.all([
-      prismaCircleRepository.countMembers(circle.id),
+      getCachedMemberCount(circle.id),
       getTranslations({ locale, namespace: "Explorer.circleCard" }),
     ]);
     const memberLabel = t("members", { count: memberCount });
@@ -154,7 +158,7 @@ export default async function PublicCirclePage({
       { momentRepository: prismaMomentRepository, circleRepository: prismaCircleRepository },
       { skipCircleCheck: true }
     ),
-    prismaCircleRepository.countMembers(circle.id),
+    getCachedMemberCount(circle.id),
     session?.user?.id
       ? prismaCircleRepository.findMembership(circle.id, session.user.id).then((m) => m?.status ?? null)
       : Promise.resolve(null),

--- a/src/app/[locale]/(routes)/circles/[slug]/page.tsx
+++ b/src/app/[locale]/(routes)/circles/[slug]/page.tsx
@@ -69,15 +69,25 @@ export async function generateMetadata({
 }: {
   params: Promise<{ locale: string; slug: string }>;
 }): Promise<Metadata> {
-  const { slug } = await params;
+  const { locale, slug } = await params;
   try {
     const circle = await getCachedCircle(slug);
     if (!circle) return {};
     const isPrivate = circle.visibility !== "PUBLIC";
     const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
+
+    const [memberCount, t] = await Promise.all([
+      prismaCircleRepository.countMembers(circle.id),
+      getTranslations({ locale, namespace: "Explorer.circleCard" }),
+    ]);
+    const memberLabel = t("members", { count: memberCount });
+    const description = circle.description
+      ? `${circle.description} · ${memberLabel}`
+      : memberLabel;
+
     return {
       title: circle.name,
-      description: circle.description,
+      description,
       alternates: {
         canonical: `${appUrl}/circles/${slug}`,
         languages: {
@@ -89,12 +99,12 @@ export async function generateMetadata({
       ...(!isPrivate && {
         openGraph: {
           title: circle.name,
-          description: circle.description ?? undefined,
+          description,
           type: "website",
         },
         twitter: {
           title: circle.name,
-          description: circle.description ?? undefined,
+          description,
         },
       }),
     };

--- a/src/app/[locale]/(routes)/m/[slug]/opengraph-image.tsx
+++ b/src/app/[locale]/(routes)/m/[slug]/opengraph-image.tsx
@@ -14,7 +14,6 @@ import {
   OG_COLORS,
   OgBrandingPill,
   OgCoverBackground,
-  OgScrim,
 } from "@/lib/og/components";
 import type { LocationType } from "@/domain/models/moment";
 
@@ -68,6 +67,30 @@ export default async function OgImage({
       : Promise.resolve(null),
   ]);
 
+  // Cover présente → cover pure + branding seulement. Le titre et la date sont
+  // déjà repris par le client (og:title + og:description) sous l'image dans
+  // WhatsApp / iMessage / Slack — on évite la triple redondance.
+  if (coverDataUrl) {
+    return new ImageResponse(
+      (
+        <div
+          style={{
+            width: "100%",
+            height: "100%",
+            display: "flex",
+            position: "relative",
+            background: OG_COLORS.bgDark,
+          }}
+        >
+          <OgCoverBackground coverDataUrl={coverDataUrl} />
+          <OgBrandingPill />
+        </div>
+      ),
+      { ...size },
+    );
+  }
+
+  // Pas de cover → fallback content-rich : tout dans l'image puisque rien d'autre n'y figure.
   const { month, day, weekday, time } = formatOgDateBadge(moment.startsAt, locale);
   const location = formatLocationLabel(
     moment.locationType,
@@ -89,10 +112,9 @@ export default async function OgImage({
         }}
       >
         <OgCoverBackground
-          coverDataUrl={coverDataUrl}
+          coverDataUrl={null}
           gradient={getMomentGradient(moment.id)}
         />
-        <OgScrim />
         <OgBrandingPill />
 
         <div

--- a/src/app/[locale]/(routes)/m/[slug]/opengraph-image.tsx
+++ b/src/app/[locale]/(routes)/m/[slug]/opengraph-image.tsx
@@ -14,6 +14,7 @@ import {
   OG_COLORS,
   OgBrandingPill,
   OgCoverBackground,
+  OgPureCoverLayout,
 } from "@/lib/og/components";
 import type { LocationType } from "@/domain/models/moment";
 
@@ -60,37 +61,18 @@ export default async function OgImage({
     return new Response("Not found", { status: 404 });
   }
 
-  const [circle, coverDataUrl] = await Promise.all([
-    prismaCircleRepository.findById(moment.circleId),
-    moment.coverImage
-      ? loadOgCoverAsDataUrl(moment.coverImage)
-      : Promise.resolve(null),
-  ]);
+  const coverDataUrl = moment.coverImage
+    ? await loadOgCoverAsDataUrl(moment.coverImage)
+    : null;
 
-  // Cover présente → cover pure + branding seulement. Le titre et la date sont
-  // déjà repris par le client (og:title + og:description) sous l'image dans
-  // WhatsApp / iMessage / Slack — on évite la triple redondance.
   if (coverDataUrl) {
-    return new ImageResponse(
-      (
-        <div
-          style={{
-            width: "100%",
-            height: "100%",
-            display: "flex",
-            position: "relative",
-            background: OG_COLORS.bgDark,
-          }}
-        >
-          <OgCoverBackground coverDataUrl={coverDataUrl} />
-          <OgBrandingPill />
-        </div>
-      ),
-      { ...size },
-    );
+    return new ImageResponse(<OgPureCoverLayout coverDataUrl={coverDataUrl} />, {
+      ...size,
+    });
   }
 
   // Pas de cover → fallback content-rich : tout dans l'image puisque rien d'autre n'y figure.
+  const circle = await prismaCircleRepository.findById(moment.circleId);
   const { month, day, weekday, time } = formatOgDateBadge(moment.startsAt, locale);
   const location = formatLocationLabel(
     moment.locationType,

--- a/src/app/[locale]/(routes)/m/[slug]/page.tsx
+++ b/src/app/[locale]/(routes)/m/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { measureTime } from "@/lib/perf-logger";
 import { isValidSlug } from "@/lib/slug";
 import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
+import { formatLongDate, formatLocalizedTime } from "@/lib/format-date";
 
 // Revalide toutes les 30 secondes — équilibre entre fraîcheur et performance.
 // Les inscriptions en temps réel passent par les Server Actions (revalidatePath),
@@ -52,16 +53,8 @@ export async function generateMetadata({
 
   const circle = await getCircle(moment.circleId);
   const t = await getTranslations({ locale, namespace: "Moment" });
-  const dateLocale = locale === "fr" ? "fr-FR" : "en-US";
-  const date = moment.startsAt.toLocaleDateString(dateLocale, {
-    day: "numeric",
-    month: "long",
-    year: "numeric",
-  });
-  const time = moment.startsAt.toLocaleTimeString(dateLocale, {
-    hour: "2-digit",
-    minute: "2-digit",
-  });
+  const date = formatLongDate(moment.startsAt, locale);
+  const time = formatLocalizedTime(moment.startsAt, locale);
   const location =
     moment.locationType === "ONLINE"
       ? t("form.locationOnline")

--- a/src/lib/og/components.tsx
+++ b/src/lib/og/components.tsx
@@ -21,8 +21,6 @@ export const OG_COLORS = {
   bgDark: BRAND_BG_DARK,
   zinc950: "#18181b",
   logoGradient: `linear-gradient(135deg, ${BRAND_PINK}, ${BRAND_PURPLE})`,
-  scrim:
-    "linear-gradient(0deg, rgba(0,0,0,0.92) 0%, rgba(0,0,0,0.55) 50%, rgba(0,0,0,0) 100%)",
 } as const;
 
 export function OgCoverBackground({
@@ -30,7 +28,7 @@ export function OgCoverBackground({
   gradient,
 }: {
   coverDataUrl: string | null;
-  gradient: string;
+  gradient?: string;
 }) {
   if (coverDataUrl) {
     return (
@@ -56,22 +54,6 @@ export function OgCoverBackground({
         position: "absolute",
         inset: 0,
         background: gradient,
-        display: "flex",
-      }}
-    />
-  );
-}
-
-export function OgScrim() {
-  return (
-    <div
-      style={{
-        position: "absolute",
-        left: 0,
-        right: 0,
-        bottom: 0,
-        height: "55%",
-        background: OG_COLORS.scrim,
         display: "flex",
       }}
     />

--- a/src/lib/og/components.tsx
+++ b/src/lib/og/components.tsx
@@ -60,6 +60,30 @@ export function OgCoverBackground({
   );
 }
 
+/**
+ * Layout og:image en mode "cover pure" : juste la cover plein cadre + la pill
+ * de branding. Utilisé quand une cover est disponible — le titre, la date et
+ * la description ne sont pas rasterisés dans l'image puisque les clients
+ * (WhatsApp, iMessage, Slack…) les affichent déjà sous l'image via og:title
+ * et og:description. Évite la triple redondance.
+ */
+export function OgPureCoverLayout({ coverDataUrl }: { coverDataUrl: string }) {
+  return (
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        position: "relative",
+        background: OG_COLORS.bgDark,
+      }}
+    >
+      <OgCoverBackground coverDataUrl={coverDataUrl} />
+      <OgBrandingPill />
+    </div>
+  );
+}
+
 export function OgBrandingPill() {
   return (
     <div


### PR DESCRIPTION
## Summary

Suite à smoke test sur partage WhatsApp réel après le merge de #457 (capture initiale : Tech Speak'Her) :

1. **Cover pure quand cover dispo** : la cover déjà composée par l'Organisateur (titre intégré, branding propre) faisait **triple redondance** avec l'overlay V7 (titre + date + Circle name rasterisés) ET avec l'og:title/og:description que les clients (WhatsApp, iMessage, Slack…) injectent automatiquement sous l'image. Le scrim n'était par ailleurs pas assez fort pour assurer la lisibilité sur des covers complexes.
2. **Fix bug TZ pré-existant** dans l'og:description event : un event à `18:30` Paris affichait `16:30` (UTC sur Vercel) + format AM/PM en EN.
3. **Ajout du compteur de membres** dans l'og:description Communauté : `${circle.description} · X membres`.

## Comportement après PR

| Cas | Visuel |
|---|---|
| **Event avec cover** | Cover plein cadre + branding pill haut-droite. Aucun overlay (titre/date/Circle/scrim). Le titre + date sont déjà sous l'image dans le bloc og:title/og:description côté client. |
| **Event sans cover** | Fallback inchangé : gradient + Circle eyebrow + date pill + titre + meta + branding. (Pas de redondance puisque la cover ne montre rien.) |
| **Communauté avec cover** | Cover plein cadre + branding pill. |
| **Communauté sans cover** | Gradient + titre centré + meta `X membres · ville` + branding. |

## Périmètre

- `src/app/[locale]/(routes)/m/[slug]/opengraph-image.tsx` — early-return cover pure + fallback content-rich
- `src/app/[locale]/(routes)/circles/[slug]/opengraph-image.tsx` — idem côté Circle
- `src/app/[locale]/(routes)/m/[slug]/page.tsx` — `formatLongDate` + `formatLocalizedTime` (Europe/Paris + en-GB) au lieu de `toLocaleDateString` inline → corrige le bug TZ
- `src/app/[locale]/(routes)/circles/[slug]/page.tsx` — `${circle.description} · X membres` via ICU plural ; nouveau `getCachedMemberCount` (React `cache()`) pour dédupliquer le `countMembers` entre `generateMetadata` et le rendu de la page
- `src/lib/og/components.tsx` — nouveau `OgPureCoverLayout` (factorise le bloc cover + branding partagé) ; `OgScrim` et `OG_COLORS.scrim` retirés (plus consommés)

## Trade-off de design assumé

Quand la cover de l'organisateur est très neutre (genre photo de salle vide), on perd l'info dans l'image. Mais le `og:title` + `og:description` sous l'image (rendus par WhatsApp/iMessage/Slack/etc.) prennent le relais. Le risque est jugé inférieur au coût de la redondance triple sur les covers déjà composées (cas le plus courant).

## Test plan

- [x] `pnpm typecheck` ✅
- [x] `pnpm test:unit` ✅ 1049/1049
- [x] `pnpm build` (CI)
- [ ] Smoke preview : ouvrir l'og:image d'un event avec cover sur preview Vercel → cover pure + branding pill seulement
- [ ] Smoke preview : ouvrir l'og:image d'un event sans cover → fallback content-rich
- [ ] Smoke preview : `view-source:` sur la page event → vérifier `og:description` avec heure correcte (Europe/Paris)
- [ ] Smoke preview : `view-source:` sur la page Circle → `og:description` contient `${desc} · X membres`
- [ ] Tester un partage WhatsApp depuis preview → l'image ne fait plus apparaître le titre 3 fois

## Commits

- `3e466a2` fix(og): cover pure quand cover dispo, fix bug TZ description, ajout members count
- `3de6a4e` refactor(og): nettoyage post-/simplify

🤖 Generated with [Claude Code](https://claude.com/claude-code)