### PR TITLE
fix(meta): mettre le compteur de membres en tête de description (Communauté)

### DIFF
--- a/src/app/[locale]/(routes)/circles/[slug]/page.tsx
+++ b/src/app/[locale]/(routes)/circles/[slug]/page.tsx
@@ -87,8 +87,12 @@ export async function generateMetadata({
     ]);
     const memberLabel = t("members", { count: memberCount });
     const title = collapseWhitespace(circle.name);
+    // Compteur de membres en tête de la description : les clients (WhatsApp,
+    // iMessage…) tronquent la preview à ~80–120 chars — placer le social proof
+    // avant la description du Circle garantit qu'il reste visible quel que soit
+    // le contenu derrière.
     const description = circle.description
-      ? `${collapseWhitespace(circle.description)} · ${memberLabel}`
+      ? `${memberLabel} · ${collapseWhitespace(circle.description)}`
       : memberLabel;
 
     return {


### PR DESCRIPTION
## Summary

Smoke test prod sur Tech Speak'Her après merge #460 : la description incluait bien `· X membres` en fin de chaîne, mais **les clients (WhatsApp, iMessage…) tronquent visuellement la preview à ~80–120 caractères**. Pour les Communautés avec une description longue (Tech Speak'Her ~270 chars), le compteur tombait dans la zone coupée et restait invisible — alors que c'est précisément le social proof qu'on veut mettre en avant.

## Fix

Compteur de membres placé **en tête de `og:description`**, pas en fin. Les clients affichent la preview comme « Titre [gras] / 24 membres · Description… », le compteur reste donc systématiquement visible même quand la description du Circle est tronquée derrière.

## Avant / Après

| Tag | Avant (PR #460) | Après |
|---|---|---|
| `<title>` | `Paris JS — The Playground` | `Paris JS — The Playground` |
| `og:title` | `Paris JS` | `Paris JS` |
| `og:description` | `La communauté JS… · 16 membres` ← compteur tronqué en preview | `16 membres · La communauté JS…` ← compteur toujours visible |

## Test plan

- [x] `pnpm typecheck` ✅
- [x] Test local sur `demo-paris-js` : og:description commence bien par `16 membres ·`
- [ ] Smoke preview Vercel : ouvrir `view-source:` sur `circles/tech-speak-her` → og:description commence par `24 membres ·`
- [ ] Re-tester partage WhatsApp depuis preview Vercel → `24 membres` visible immédiatement après le titre

## Commits

- `bfe5587` fix(meta): mettre le compteur de membres en tête de description (Communauté)

🤖 Generated with [Claude Code](https://claude.com/claude-code)