### PR TITLE
fix(privacy/security): protéger l'affichage public et bloquer les actions des users non onboardés

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -110,6 +110,7 @@
   "Common": {
     "loading": "Loading...",
     "error": "An error occurred",
+    "anonymousFallback": "Member",
     "back": "Back",
     "save": "Save",
     "cancel": "Cancel",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -110,6 +110,7 @@
   "Common": {
     "loading": "Chargement...",
     "error": "Une erreur est survenue",
+    "anonymousFallback": "Membre",
     "back": "Retour",
     "save": "Enregistrer",
     "cancel": "Annuler",

--- a/src/app/[locale]/(routes)/circles/[slug]/page.tsx
+++ b/src/app/[locale]/(routes)/circles/[slug]/page.tsx
@@ -21,7 +21,6 @@ import { Button } from "@/components/ui/button";
 import { getMomentGradient } from "@/lib/gradient";
 import { formatLongDate } from "@/lib/format-date";
 import { collapseWhitespace } from "@/lib/text";
-import { getDisplayName } from "@/lib/display-name";
 import { JoinCircleButton } from "@/components/circles/join-circle-button";
 import { CollapsibleDescription } from "@/components/moments/collapsible-description";
 import { HostLink } from "@/components/circles/host-link";

--- a/src/app/[locale]/(routes)/circles/[slug]/page.tsx
+++ b/src/app/[locale]/(routes)/circles/[slug]/page.tsx
@@ -183,8 +183,9 @@ export default async function PublicCirclePage({
   const primaryHosts = hosts.filter((h) => h.role === "HOST");
   const circleOrganizers = sortCircleOrganizers(hosts);
   const categoryLabel = resolveCategoryLabel(circle.category, circle.customCategory, tCategory);
+  const anonymousFallback = tCommon("anonymousFallback");
   const { visibleAvatars: visibleMemberAvatars, metaText: membersMetaText, metaMobileText: membersMetaMobileText } =
-    computeMembersMeta(hosts, players, memberCount, t);
+    computeMembersMeta(hosts, players, memberCount, t, anonymousFallback);
   // Membres visibles : connecté + (circle public OU membre/organisateur)
   const canSeeMembers = isConnected && (circle.visibility === "PUBLIC" || isMember || isOrganizer);
   const showJoinButton = isConnected && !isMember && !isPendingMember;
@@ -285,6 +286,7 @@ export default async function PublicCirclePage({
             organizers={circleOrganizers}
             linkable={isConnected}
             label={t("detail.hostedBy")}
+            anonymousFallback={anonymousFallback}
             contactOrganizer={
               isOrganizer
                 ? undefined
@@ -431,7 +433,10 @@ export default async function PublicCirclePage({
                       initialHasMore={membersFirstPage.hasMore}
                       triggerClassName="group flex cursor-pointer flex-wrap items-center gap-x-2 gap-y-1 text-left"
                     >
-                      <MemberAvatarStack members={visibleMemberAvatars} />
+                      <MemberAvatarStack
+                        members={visibleMemberAvatars}
+                        anonymousFallback={anonymousFallback}
+                      />
                       <span className="text-sm font-medium group-hover:text-primary dark:group-hover:text-[oklch(0.76_0.27_341)] transition-colors">
                         <span className="lg:hidden">{membersMetaMobileText}</span>
                         <span className="hidden lg:inline">{membersMetaText}</span>
@@ -439,7 +444,10 @@ export default async function PublicCirclePage({
                     </CircleMembersDialog>
                   ) : (
                     <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-                      <MemberAvatarStack members={visibleMemberAvatars} />
+                      <MemberAvatarStack
+                        members={visibleMemberAvatars}
+                        anonymousFallback={anonymousFallback}
+                      />
                       <span className="text-sm font-medium">
                         <span className="lg:hidden">{membersMetaMobileText}</span>
                         <span className="hidden lg:inline">{membersMetaText}</span>

--- a/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/page.tsx
+++ b/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/page.tsx
@@ -111,8 +111,9 @@ export default async function CircleDetailPage({
   const totalMembers = hosts.length + players.length;
   const circleOrganizers = sortCircleOrganizers(hosts);
   const categoryLabel = resolveCategoryLabel(circle.category, circle.customCategory, tCategory);
+  const anonymousFallback = tCommon("anonymousFallback");
   const { visibleAvatars: visibleMemberAvatars, metaText: membersMetaText, metaMobileText: membersMetaMobileText } =
-    computeMembersMeta(hosts, players, totalMembers, t);
+    computeMembersMeta(hosts, players, totalMembers, t, anonymousFallback);
   const upcomingMoments = allMoments.filter((m) => m.status === "PUBLISHED" || (m.status === "DRAFT" && isOrganizer));
   const pastMoments = allMoments.filter((m) => m.status === "PAST" || m.status === "CANCELLED");
 
@@ -180,6 +181,7 @@ export default async function CircleDetailPage({
             organizers={circleOrganizers}
             linkable
             label={t("detail.hostedBy")}
+            anonymousFallback={anonymousFallback}
             contactOrganizer={
               isOrganizer
                 ? undefined
@@ -305,7 +307,10 @@ export default async function CircleDetailPage({
                     circleSlug={circle.slug}
                     triggerClassName="group flex cursor-pointer flex-wrap items-center gap-x-2 gap-y-1 text-left"
                   >
-                    <MemberAvatarStack members={visibleMemberAvatars} />
+                    <MemberAvatarStack
+                      members={visibleMemberAvatars}
+                      anonymousFallback={anonymousFallback}
+                    />
                     <span className="text-sm font-medium group-hover:text-primary dark:group-hover:text-[oklch(0.76_0.27_341)] transition-colors">
                       <span className="lg:hidden">{membersMetaMobileText}</span>
                       <span className="hidden lg:inline">{membersMetaText}</span>

--- a/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/page.tsx
+++ b/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/page.tsx
@@ -26,7 +26,6 @@ import { PendingMembershipsList } from "@/components/circles/pending-requests-li
 import { CoverBlock } from "@/components/circles/cover-block";
 import { CircleShareButton } from "@/components/circles/circle-share-button";
 import { getMomentGradient } from "@/lib/gradient";
-import { getDisplayName } from "@/lib/display-name";
 import { CollapsibleDescription } from "@/components/moments/collapsible-description";
 import { HostLink } from "@/components/circles/host-link";
 import { resolveCircleRepository } from "@/lib/admin-host-mode";

--- a/src/app/[locale]/(routes)/dashboard/(onboarding)/profile/setup/page.tsx
+++ b/src/app/[locale]/(routes)/dashboard/(onboarding)/profile/setup/page.tsx
@@ -20,16 +20,27 @@ function parseName(name: string | null): { firstName: string; lastName: string }
   };
 }
 
-export default async function ProfileSetupPage() {
+export default async function ProfileSetupPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ callbackUrl?: string }>;
+}) {
   const session = await getCachedSession();
 
   if (!session?.user?.id) {
     redirect("/auth/sign-in");
   }
 
+  // callbackUrl peut venir :
+  //  - de la query (cas guard onboarding sur server action publique : Player connecté
+  //    mais non onboardé qui clique S'inscrire / Rejoindre / poste un commentaire)
+  //  - du cookie auth-callback-url (cas magic link / OAuth posant le cookie pendant sign-in)
+  // La query est prioritaire car elle correspond à l'intention immédiate du clic.
+  const { callbackUrl: queryCallbackUrl } = await searchParams;
   const cookieStore = await cookies();
-  const rawCallbackUrl = cookieStore.get("auth-callback-url")?.value;
-  const callbackUrl = safeCallbackUrl(rawCallbackUrl);
+  const cookieCallbackUrl = cookieStore.get("auth-callback-url")?.value;
+  const callbackUrl =
+    safeCallbackUrl(queryCallbackUrl) ?? safeCallbackUrl(cookieCallbackUrl);
 
   if (shouldRedirectFromSetup(session.user)) {
     redirect(callbackUrl ?? "/dashboard");

--- a/src/app/[locale]/(routes)/dashboard/(onboarding)/profile/setup/page.tsx
+++ b/src/app/[locale]/(routes)/dashboard/(onboarding)/profile/setup/page.tsx
@@ -31,11 +31,7 @@ export default async function ProfileSetupPage({
     redirect("/auth/sign-in");
   }
 
-  // callbackUrl peut venir :
-  //  - de la query (cas guard onboarding sur server action publique : Player connecté
-  //    mais non onboardé qui clique S'inscrire / Rejoindre / poste un commentaire)
-  //  - du cookie auth-callback-url (cas magic link / OAuth posant le cookie pendant sign-in)
-  // La query est prioritaire car elle correspond à l'intention immédiate du clic.
+  // Query (intention immédiate du clic) prioritaire sur cookie (posé pendant sign-in).
   const { callbackUrl: queryCallbackUrl } = await searchParams;
   const cookieStore = await cookies();
   const cookieCallbackUrl = cookieStore.get("auth-callback-url")?.value;

--- a/src/app/actions/circle.ts
+++ b/src/app/actions/circle.ts
@@ -257,6 +257,9 @@ export async function joinCircleDirectlyAction(
   if (!session?.user?.id) {
     return { success: false, error: "Not authenticated", code: "UNAUTHORIZED" };
   }
+  if (!session.user.onboardingCompleted) {
+    return { success: false, error: "Onboarding required", code: "ONBOARDING_REQUIRED" };
+  }
 
   const userId = session.user.id;
   return toActionResult(async () => {

--- a/src/app/actions/comment.ts
+++ b/src/app/actions/comment.ts
@@ -39,6 +39,9 @@ export async function addCommentAction(
   if (!session?.user?.id) {
     return { success: false, error: "Not authenticated", code: "UNAUTHORIZED" };
   }
+  if (!session.user.onboardingCompleted) {
+    return { success: false, error: "Onboarding required", code: "ONBOARDING_REQUIRED" };
+  }
   const userId = session.user.id;
 
   const rawContent = formData.get("content");

--- a/src/app/actions/registration.ts
+++ b/src/app/actions/registration.ts
@@ -39,6 +39,9 @@ export async function joinMomentAction(
   if (!session?.user?.id) {
     return { success: false, error: "Not authenticated", code: "UNAUTHORIZED" };
   }
+  if (!session.user.onboardingCompleted) {
+    return { success: false, error: "Onboarding required", code: "ONBOARDING_REQUIRED" };
+  }
 
   const userId = session.user.id;
   return toActionResult(async () => {

--- a/src/components/circles/circle-members-dialog.tsx
+++ b/src/components/circles/circle-members-dialog.tsx
@@ -27,7 +27,7 @@ import { UserAvatar } from "@/components/user-avatar";
 import { RemoveMemberDialog } from "@/components/circles/remove-member-dialog";
 import { Users as UsersIcon, Crown, MoreVertical, Star, ChevronDown, Trash2, Globe, Linkedin, Github, Download } from "lucide-react";
 import { XIcon } from "@/components/icons/x-icon";
-import { getDisplayName } from "@/lib/display-name";
+import { getPublicDisplayName } from "@/lib/display-name";
 import { generateSlug } from "@/lib/slug";
 import {
   getCircleMembersPageAction,
@@ -254,8 +254,13 @@ function MemberRow({
 }: MemberRowProps) {
   const t = useTranslations("Dashboard");
   const tCircle = useTranslations("Circle");
+  const tCommon = useTranslations("Common");
   const { user } = member;
-  const displayName = getDisplayName(user.firstName, user.lastName, user.email);
+  const displayName = getPublicDisplayName(
+    user.firstName,
+    user.lastName,
+    tCommon("anonymousFallback"),
+  );
   const router = useRouter();
 
   const [removeDialogOpen, setRemoveDialogOpen] = useState(false);

--- a/src/components/circles/circle-members-dialog.tsx
+++ b/src/components/circles/circle-members-dialog.tsx
@@ -301,38 +301,50 @@ function MemberRow({
     });
   };
 
+  const avatar = <UserAvatar name={displayName} email={user.email} image={user.image} size="md" />;
+  const info = (
+    <div className="min-w-0 flex-1">
+      <div className="flex items-center gap-2">
+        <span className="text-sm leading-snug font-medium group-hover/member:text-primary dark:group-hover/member:text-[oklch(0.76_0.27_341)] transition-colors">
+          {displayName}
+        </span>
+        {(member.role === "HOST" || member.role === "CO_HOST") && (
+          <span className="group/role relative shrink-0">
+            <Badge
+              variant="outline"
+              className="border-primary/40 text-primary flex size-6 items-center justify-center p-0"
+            >
+              <Crown className="size-3" />
+            </Badge>
+            <span className="bg-foreground text-background pointer-events-none absolute top-full left-1/2 z-50 mt-1 -translate-x-1/2 rounded-md px-2 py-1 text-xs font-medium whitespace-nowrap opacity-0 transition-opacity group-hover/role:opacity-100">
+              {t("role.host")}
+            </span>
+          </span>
+        )}
+      </div>
+      {showEmail && (
+        <p className="text-muted-foreground truncate text-xs">{user.email}</p>
+      )}
+    </div>
+  );
+
   return (
     <>
       <div className="flex items-center gap-3 py-2.5">
-        <Link
-          href={`/u/${user.publicId}`}
-          className="group/member flex min-w-0 flex-1 items-center gap-3"
-        >
-          <UserAvatar name={displayName} email={user.email} image={user.image} size="md" />
-          <div className="min-w-0 flex-1">
-            <div className="flex items-center gap-2">
-              <span className="text-sm leading-snug font-medium group-hover/member:text-primary dark:group-hover/member:text-[oklch(0.76_0.27_341)] transition-colors">
-                {displayName}
-              </span>
-              {(member.role === "HOST" || member.role === "CO_HOST") && (
-                <span className="group/role relative shrink-0">
-                  <Badge
-                    variant="outline"
-                    className="border-primary/40 text-primary flex size-6 items-center justify-center p-0"
-                  >
-                    <Crown className="size-3" />
-                  </Badge>
-                  <span className="bg-foreground text-background pointer-events-none absolute top-full left-1/2 z-50 mt-1 -translate-x-1/2 rounded-md px-2 py-1 text-xs font-medium whitespace-nowrap opacity-0 transition-opacity group-hover/role:opacity-100">
-                    {t("role.host")}
-                  </span>
-                </span>
-              )}
-            </div>
-            {showEmail && (
-              <p className="text-muted-foreground truncate text-xs">{user.email}</p>
-            )}
+        {user.publicId ? (
+          <Link
+            href={`/u/${user.publicId}`}
+            className="group/member flex min-w-0 flex-1 items-center gap-3"
+          >
+            {avatar}
+            {info}
+          </Link>
+        ) : (
+          <div className="flex min-w-0 flex-1 items-center gap-3">
+            {avatar}
+            {info}
           </div>
-        </Link>
+        )}
 
         <SocialLinks user={user} />
 

--- a/src/components/circles/circle-members-dialog.tsx
+++ b/src/components/circles/circle-members-dialog.tsx
@@ -74,6 +74,8 @@ export function CircleMembersDialog({
   children,
 }: Props) {
   const t = useTranslations("Circle");
+  const tCommon = useTranslations("Common");
+  const anonymousFallback = tCommon("anonymousFallback");
   const [open, setOpen] = useState(false);
   const [members, setMembers] = useState<CircleMemberWithUser[]>(initialMembers);
   const [total, setTotal] = useState(initialTotal);
@@ -215,6 +217,7 @@ export function CircleMembersDialog({
                 callerRole={callerRole}
                 showEmail={showEmails}
                 circleId={circleId}
+                anonymousFallback={anonymousFallback}
                 onRemoved={handleMemberRemoved}
                 onRoleChanged={handleMemberRoleChanged}
               />
@@ -240,6 +243,7 @@ type MemberRowProps = {
   callerRole: CircleMemberRole | undefined;
   showEmail: boolean;
   circleId: string;
+  anonymousFallback: string;
   onRemoved: (userId: string) => void;
   onRoleChanged: (userId: string, role: CircleMemberRole) => void;
 };
@@ -249,18 +253,14 @@ function MemberRow({
   callerRole,
   showEmail,
   circleId,
+  anonymousFallback,
   onRemoved,
   onRoleChanged,
 }: MemberRowProps) {
   const t = useTranslations("Dashboard");
   const tCircle = useTranslations("Circle");
-  const tCommon = useTranslations("Common");
   const { user } = member;
-  const displayName = getPublicDisplayName(
-    user.firstName,
-    user.lastName,
-    tCommon("anonymousFallback"),
-  );
+  const displayName = getPublicDisplayName(user.firstName, user.lastName, anonymousFallback);
   const router = useRouter();
 
   const [removeDialogOpen, setRemoveDialogOpen] = useState(false);

--- a/src/components/circles/circle-organizers-list.tsx
+++ b/src/components/circles/circle-organizers-list.tsx
@@ -49,9 +49,10 @@ export function CircleOrganizersList({ organizers, linkable, label, anonymousFal
                 size="sm"
               />
             );
+            const showLink = linkable && host.user.publicId;
             return (
               <li key={host.id}>
-                {linkable ? (
+                {showLink ? (
                   <Link
                     href={`/u/${host.user.publicId}`}
                     className="group/organizer flex items-center gap-3"

--- a/src/components/circles/circle-organizers-list.tsx
+++ b/src/components/circles/circle-organizers-list.tsx
@@ -1,7 +1,7 @@
 import { Link } from "@/i18n/navigation";
 import { UserAvatar } from "@/components/user-avatar";
 import { ContactOrganizerLink } from "@/components/contact-organizer-link";
-import { getDisplayName } from "@/lib/display-name";
+import { getPublicDisplayName } from "@/lib/display-name";
 import type { CircleMemberWithUser } from "@/domain/models/circle";
 
 type ContactOrganizerConfig = {
@@ -16,6 +16,8 @@ type Props = {
   linkable: boolean;
   /** Label de section, déjà traduit. */
   label: string;
+  /** Étiquette pour un organisateur sans nom (`t("Common.anonymousFallback")`). */
+  anonymousFallback: string;
   /**
    * Si fourni, affiche un lien discret "Contacter l'organisateur" sous la liste.
    * À ne PAS passer si le visiteur est lui-même organisateur du Circle.
@@ -27,7 +29,7 @@ type Props = {
  * Bloc "Organisé par" de la colonne gauche des pages Circle (publique + dashboard).
  * Liste les organisateurs triés (HOST puis CO_HOST) avec avatar + nom.
  */
-export function CircleOrganizersList({ organizers, linkable, label, contactOrganizer }: Props) {
+export function CircleOrganizersList({ organizers, linkable, label, anonymousFallback, contactOrganizer }: Props) {
   if (organizers.length === 0) return null;
 
   return (
@@ -38,7 +40,7 @@ export function CircleOrganizersList({ organizers, linkable, label, contactOrgan
         </p>
         <ul className="space-y-2">
           {organizers.map((host) => {
-            const hostDisplayName = getDisplayName(host.user.firstName, host.user.lastName, host.user.email);
+            const hostDisplayName = getPublicDisplayName(host.user.firstName, host.user.lastName, anonymousFallback);
             const avatar = (
               <UserAvatar
                 name={hostDisplayName}

--- a/src/components/circles/host-link.tsx
+++ b/src/components/circles/host-link.tsx
@@ -1,5 +1,5 @@
 import { Link } from "@/i18n/navigation";
-import { getDisplayName } from "@/lib/display-name";
+import { getPublicDisplayName } from "@/lib/display-name";
 import { cn } from "@/lib/utils";
 
 type HostUser = {
@@ -7,19 +7,20 @@ type HostUser = {
   publicId?: string | null;
   firstName?: string | null;
   lastName?: string | null;
-  email: string;
 };
 
 type Props = {
   user: HostUser;
+  /** Étiquette pour un Host sans nom (typiquement `t("Common.anonymousFallback")`). */
+  anonymousFallback: string;
   /** Classes CSS appliquées au lien et au fallback <span> */
   className?: string;
   /** Désactive le lien (ex: visiteur non connecté sur page publique) */
   linkDisabled?: boolean;
 };
 
-export function HostLink({ user, className, linkDisabled }: Props) {
-  const name = getDisplayName(user.firstName, user.lastName, user.email);
+export function HostLink({ user, anonymousFallback, className, linkDisabled }: Props) {
+  const name = getPublicDisplayName(user.firstName, user.lastName, anonymousFallback);
   if (!linkDisabled && user.publicId) {
     return (
       <Link

--- a/src/components/circles/join-circle-button.tsx
+++ b/src/components/circles/join-circle-button.tsx
@@ -6,7 +6,7 @@ import posthog from "posthog-js";
 import { Users, Check, Clock } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { joinCircleDirectlyAction } from "@/app/actions/circle";
-import { buildOnboardingSetupUrl } from "@/lib/onboarding";
+import { handleOnboardingRequired } from "@/lib/onboarding";
 import { useTranslations } from "next-intl";
 
 type Props = {
@@ -29,9 +29,7 @@ export function JoinCircleButton({ circleId, requiresApproval = false }: Props) 
         router.refresh();
         return;
       }
-      if (result.code === "ONBOARDING_REQUIRED") {
-        router.push(buildOnboardingSetupUrl());
-      }
+      handleOnboardingRequired(result, router);
     });
   }
 

--- a/src/components/circles/join-circle-button.tsx
+++ b/src/components/circles/join-circle-button.tsx
@@ -6,6 +6,7 @@ import posthog from "posthog-js";
 import { Users, Check, Clock } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { joinCircleDirectlyAction } from "@/app/actions/circle";
+import { buildOnboardingSetupUrl } from "@/lib/onboarding";
 import { useTranslations } from "next-intl";
 
 type Props = {
@@ -26,6 +27,10 @@ export function JoinCircleButton({ circleId, requiresApproval = false }: Props) 
         posthog.capture("circle_joined_directly", { circle_id: circleId });
         setState(result.data.pendingApproval ? "pending" : "joined");
         router.refresh();
+        return;
+      }
+      if (result.code === "ONBOARDING_REQUIRED") {
+        router.push(buildOnboardingSetupUrl());
       }
     });
   }

--- a/src/components/circles/member-avatar-stack.tsx
+++ b/src/components/circles/member-avatar-stack.tsx
@@ -1,16 +1,25 @@
 import type { CircleMemberWithUser } from "@/domain/models/circle";
-import { getDisplayName, getCircleUserInitials } from "@/lib/display-name";
+import { getPublicDisplayName, getPublicUserInitials } from "@/lib/display-name";
 import { getMomentGradient } from "@/lib/gradient";
 
 /**
  * Rangée d'avatars de membres superposés avec tooltip au survol.
  * Utilisée sur les pages Circle (publique + dashboard) dans la section Meta.
+ *
+ * `anonymousFallback` (typiquement `t("Common.anonymousFallback")`) sert d'étiquette
+ * pour les membres sans nom — l'email n'est jamais exposé côté public (RGPD).
  */
-export function MemberAvatarStack({ members }: { members: CircleMemberWithUser[] }) {
+export function MemberAvatarStack({
+  members,
+  anonymousFallback,
+}: {
+  members: CircleMemberWithUser[];
+  anonymousFallback: string;
+}) {
   return (
     <span className="flex -space-x-1.5">
       {members.map((m) => {
-        const displayName = getDisplayName(m.user.firstName, m.user.lastName, m.user.email);
+        const displayName = getPublicDisplayName(m.user.firstName, m.user.lastName, anonymousFallback);
         return (
           <span key={m.id} className="group/avatar relative">
             <span
@@ -26,7 +35,7 @@ export function MemberAvatarStack({ members }: { members: CircleMemberWithUser[]
                   className="absolute inset-0 size-full object-cover"
                 />
               ) : (
-                getCircleUserInitials(m.user)
+                getPublicUserInitials(m.user)
               )}
             </span>
             <span className="bg-foreground text-background pointer-events-none absolute bottom-full left-1/2 z-50 mb-1 -translate-x-1/2 rounded-md px-2 py-1 text-xs font-medium whitespace-nowrap opacity-0 transition-opacity group-hover/avatar:opacity-100">

--- a/src/components/circles/member-avatar-stack.tsx
+++ b/src/components/circles/member-avatar-stack.tsx
@@ -2,13 +2,6 @@ import type { CircleMemberWithUser } from "@/domain/models/circle";
 import { getPublicDisplayName, getPublicUserInitials } from "@/lib/display-name";
 import { getMomentGradient } from "@/lib/gradient";
 
-/**
- * Rangée d'avatars de membres superposés avec tooltip au survol.
- * Utilisée sur les pages Circle (publique + dashboard) dans la section Meta.
- *
- * `anonymousFallback` (typiquement `t("Common.anonymousFallback")`) sert d'étiquette
- * pour les membres sans nom — l'email n'est jamais exposé côté public (RGPD).
- */
 export function MemberAvatarStack({
   members,
   anonymousFallback,

--- a/src/components/moments/attendee-avatar-stack.tsx
+++ b/src/components/moments/attendee-avatar-stack.tsx
@@ -1,4 +1,4 @@
-import { getCircleUserInitials } from "@/lib/display-name";
+import { getPublicUserInitials } from "@/lib/display-name";
 import { getMomentGradient } from "@/lib/gradient";
 import type { UserAvatarInfo } from "@/domain/models/user";
 
@@ -25,7 +25,7 @@ export function AttendeeAvatarStack({
     <div className="flex items-center">
       <div className="flex -space-x-1.5">
         {visible.map((a, i) => {
-          const initials = getCircleUserInitials(a.user);
+          const initials = getPublicUserInitials(a.user);
           const gradient = getMomentGradient(a.user.email);
           return (
             <div

--- a/src/components/moments/comment-thread.tsx
+++ b/src/components/moments/comment-thread.tsx
@@ -21,7 +21,7 @@ import { UserAvatar } from "@/components/user-avatar";
 import { CommentPhotoLightbox } from "@/components/moments/comment-photo-lightbox";
 import { addCommentAction, deleteCommentAction } from "@/app/actions/comment";
 import { compressCommentPhoto } from "@/lib/image-compress";
-import { buildOnboardingSetupUrl } from "@/lib/onboarding";
+import { handleOnboardingRequired } from "@/lib/onboarding";
 import { isCoarsePointer } from "@/lib/coarse-pointer";
 import { getPublicDisplayName } from "@/lib/display-name";
 import { linkifyText } from "@/lib/linkify";
@@ -184,6 +184,7 @@ export function CommentThread({
 }: CommentThreadProps) {
   const t = useTranslations("Moment");
   const tCommon = useTranslations("Common");
+  const anonymousFallback = tCommon("anonymousFallback");
   const router = useRouter();
   const [content, setContent] = useState("");
   const [error, setError] = useState<string | null>(null);
@@ -284,10 +285,7 @@ export function CommentThread({
         router.refresh();
         return;
       }
-      if (result.code === "ONBOARDING_REQUIRED") {
-        router.push(buildOnboardingSetupUrl());
-        return;
-      }
+      if (handleOnboardingRequired(result, router)) return;
       setError(result.error);
     });
   }
@@ -313,7 +311,7 @@ export function CommentThread({
               const authorName = getPublicDisplayName(
                 comment.user.firstName,
                 comment.user.lastName,
-                tCommon("anonymousFallback")
+                anonymousFallback,
               );
               return (
                 <div key={comment.id} className="flex gap-3">

--- a/src/components/moments/comment-thread.tsx
+++ b/src/components/moments/comment-thread.tsx
@@ -21,8 +21,9 @@ import { UserAvatar } from "@/components/user-avatar";
 import { CommentPhotoLightbox } from "@/components/moments/comment-photo-lightbox";
 import { addCommentAction, deleteCommentAction } from "@/app/actions/comment";
 import { compressCommentPhoto } from "@/lib/image-compress";
+import { buildOnboardingSetupUrl } from "@/lib/onboarding";
 import { isCoarsePointer } from "@/lib/coarse-pointer";
-import { getDisplayName } from "@/lib/display-name";
+import { getPublicDisplayName } from "@/lib/display-name";
 import { linkifyText } from "@/lib/linkify";
 import {
   MAX_COMMENT_PHOTOS,
@@ -281,9 +282,13 @@ export function CommentThread({
         for (const p of stagedPhotos) URL.revokeObjectURL(p.previewUrl);
         setStagedPhotos([]);
         router.refresh();
-      } else {
-        setError(result.error);
+        return;
       }
+      if (result.code === "ONBOARDING_REQUIRED") {
+        router.push(buildOnboardingSetupUrl());
+        return;
+      }
+      setError(result.error);
     });
   }
 
@@ -305,15 +310,16 @@ export function CommentThread({
             {comments.map((comment) => {
               const canDelete =
                 currentUserId === comment.user.id || isOrganizer;
+              const authorName = getPublicDisplayName(
+                comment.user.firstName,
+                comment.user.lastName,
+                tCommon("anonymousFallback")
+              );
               return (
                 <div key={comment.id} className="flex gap-3">
                   {/* Avatar */}
                   <UserAvatar
-                    name={getDisplayName(
-                      comment.user.firstName,
-                      comment.user.lastName,
-                      comment.user.email
-                    )}
+                    name={authorName}
                     email={comment.user.email}
                     image={comment.user.image}
                     size="sm"
@@ -322,13 +328,7 @@ export function CommentThread({
                   {/* Content */}
                   <div className="min-w-0 flex-1">
                     <div className="flex flex-wrap items-baseline gap-2">
-                      <span className="text-sm font-medium">
-                        {getDisplayName(
-                          comment.user.firstName,
-                          comment.user.lastName,
-                          comment.user.email
-                        )}
-                      </span>
+                      <span className="text-sm font-medium">{authorName}</span>
                       <span className="text-muted-foreground text-xs" suppressHydrationWarning>
                         {formatRelativeTime(comment.createdAt)}
                       </span>

--- a/src/components/moments/moment-detail-view.tsx
+++ b/src/components/moments/moment-detail-view.tsx
@@ -13,7 +13,7 @@ import { CopyLinkButton } from "@/components/moments/copy-link-button";
 import { MomentShareButton } from "@/components/moments/moment-share-button";
 import { CommentThread } from "@/components/moments/comment-thread";
 import { getMomentGradient } from "@/lib/gradient";
-import { getDisplayName } from "@/lib/display-name";
+import { getPublicDisplayName } from "@/lib/display-name";
 import { computeAvatarStackMeta } from "@/lib/avatar-stack-meta";
 import type { Moment } from "@/domain/models/moment";
 import type { MomentAttachment } from "@/domain/models/moment-attachment";
@@ -242,12 +242,13 @@ export async function MomentDetailView(props: MomentDetailViewProps) {
       ? `https://maps.google.com/?q=${encodeURIComponent(moment.locationAddress)}`
       : null;
 
+  const anonymousFallback = tCommon("anonymousFallback");
   const registeredParticipants = registrations.filter((r) => r.status === "REGISTERED");
   const {
     visibleAvatars: visibleParticipantAvatars,
     metaText: participantsMetaText,
     metaMobileText: participantsMetaMobileText,
-  } = computeAvatarStackMeta(registeredParticipants, registeredCount, tCircle);
+  } = computeAvatarStackMeta(registeredParticipants, registeredCount, tCircle, { anonymousFallback });
 
   const circleHref = isHostView
     ? `/dashboard/circles/${props.circleSlug}`
@@ -334,7 +335,7 @@ export async function MomentDetailView(props: MomentDetailViewProps) {
                 </p>
                 <ul className="space-y-2">
                   {primaryHosts.map((h) => {
-                    const hostDisplayName = getDisplayName(h.user.firstName, h.user.lastName, h.user.email);
+                    const hostDisplayName = getPublicDisplayName(h.user.firstName, h.user.lastName, anonymousFallback);
                     const avatar = (
                       <UserAvatar
                         name={hostDisplayName}
@@ -559,7 +560,10 @@ export async function MomentDetailView(props: MomentDetailViewProps) {
                       momentStartsAt={moment.startsAt}
                       triggerClassName="group flex cursor-pointer flex-wrap items-center gap-x-2 gap-y-1 text-left"
                     >
-                      <ParticipantAvatarStack participants={visibleParticipantAvatars} />
+                      <ParticipantAvatarStack
+                        participants={visibleParticipantAvatars}
+                        anonymousFallback={anonymousFallback}
+                      />
                       <span className="text-sm font-medium group-hover:text-primary dark:group-hover:text-[oklch(0.76_0.27_341)] transition-colors">
                         <span className="lg:hidden">{participantsMetaMobileText}</span>
                         <span className="hidden lg:inline">{participantsMetaText}</span>
@@ -567,7 +571,10 @@ export async function MomentDetailView(props: MomentDetailViewProps) {
                     </MomentRegistrationsDialog>
                   ) : (
                     <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-                      <ParticipantAvatarStack participants={visibleParticipantAvatars} />
+                      <ParticipantAvatarStack
+                        participants={visibleParticipantAvatars}
+                        anonymousFallback={anonymousFallback}
+                      />
                       <span className="text-sm font-medium">
                         <span className="lg:hidden">{participantsMetaMobileText}</span>
                         <span className="hidden lg:inline">{participantsMetaText}</span>

--- a/src/components/moments/moment-registrations-dialog.tsx
+++ b/src/components/moments/moment-registrations-dialog.tsx
@@ -23,7 +23,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Users as UsersIcon, Crown, Clock, Download, Trash2, MoreVertical, Globe, Linkedin, Github } from "lucide-react";
 import { XIcon } from "@/components/icons/x-icon";
-import { getDisplayName } from "@/lib/display-name";
+import { getPublicDisplayName } from "@/lib/display-name";
 import { generateSlug } from "@/lib/slug";
 import { getMomentParticipantsPageAction } from "@/app/actions/moment";
 import { RemoveRegistrationDialog } from "@/components/moments/remove-registration-dialog";
@@ -267,8 +267,13 @@ function ParticipantRow({
 }: ParticipantRowProps) {
   const t = useTranslations("Dashboard");
   const tMoment = useTranslations("Moment");
+  const tCommon = useTranslations("Common");
   const { user } = registration;
-  const displayName = getDisplayName(user.firstName, user.lastName, user.email);
+  const displayName = getPublicDisplayName(
+    user.firstName,
+    user.lastName,
+    tCommon("anonymousFallback"),
+  );
   const avatar = <UserAvatar name={displayName} email={user.email} image={user.image} size="md" />;
   const hostBadge = isHost && (
     <span className="group/role relative shrink-0">

--- a/src/components/moments/moment-registrations-dialog.tsx
+++ b/src/components/moments/moment-registrations-dialog.tsx
@@ -74,6 +74,8 @@ export function MomentRegistrationsDialog({
 }: Props) {
   const hostUserIdSet = new Set(hostUserIds);
   const t = useTranslations("Moment");
+  const tCommon = useTranslations("Common");
+  const anonymousFallback = tCommon("anonymousFallback");
   const [open, setOpen] = useState(false);
   const [participants, setParticipants] = useState<RegistrationWithUser[]>(initialParticipants);
   const [hasMore, setHasMore] = useState(initialHasMore);
@@ -199,6 +201,7 @@ export function MomentRegistrationsDialog({
                 showEmail={isHostView}
                 isHost={hostUserIdSet.has(r.user.id)}
                 isHostView={isHostView}
+                anonymousFallback={anonymousFallback}
                 onRequestRemove={setRemoveTarget}
               />
             ))}
@@ -223,6 +226,7 @@ export function MomentRegistrationsDialog({
                     showEmail={isHostView}
                     isHost={hostUserIdSet.has(r.user.id)}
                     isHostView={isHostView}
+                    anonymousFallback={anonymousFallback}
                     onRequestRemove={setRemoveTarget}
                   />
                 ))}
@@ -255,6 +259,7 @@ type ParticipantRowProps = {
   showEmail: boolean;
   isHost: boolean;
   isHostView: boolean;
+  anonymousFallback: string;
   onRequestRemove: (target: { id: string; name: string; isPaid: boolean }) => void;
 };
 
@@ -263,17 +268,13 @@ function ParticipantRow({
   showEmail,
   isHost,
   isHostView,
+  anonymousFallback,
   onRequestRemove,
 }: ParticipantRowProps) {
   const t = useTranslations("Dashboard");
   const tMoment = useTranslations("Moment");
-  const tCommon = useTranslations("Common");
   const { user } = registration;
-  const displayName = getPublicDisplayName(
-    user.firstName,
-    user.lastName,
-    tCommon("anonymousFallback"),
-  );
+  const displayName = getPublicDisplayName(user.firstName, user.lastName, anonymousFallback);
   const avatar = <UserAvatar name={displayName} email={user.email} image={user.image} size="md" />;
   const hostBadge = isHost && (
     <span className="group/role relative shrink-0">

--- a/src/components/moments/participant-avatar-stack.tsx
+++ b/src/components/moments/participant-avatar-stack.tsx
@@ -2,15 +2,8 @@ import type { RegistrationWithUser } from "@/domain/models/registration";
 import { getPublicDisplayName, getPublicUserInitials } from "@/lib/display-name";
 import { getMomentGradient } from "@/lib/gradient";
 
-/**
- * Rangée d'avatars d'inscrits superposés avec tooltip au survol.
- * Utilisée sur la page Moment (publique + dashboard) dans la section Participants.
- * Pendant très similaire à MemberAvatarStack côté Circle — les domaines restent séparés
- * car le type d'entrée diffère (Registration vs CircleMembership).
- *
- * `anonymousFallback` (typiquement `t("Common.anonymousFallback")`) sert d'étiquette
- * pour les Participants sans nom — l'email n'est jamais exposé côté public (RGPD).
- */
+// Pendant de MemberAvatarStack côté Circle — domaines séparés car les types
+// d'entrée diffèrent (Registration vs CircleMembership).
 export function ParticipantAvatarStack({
   participants,
   anonymousFallback,

--- a/src/components/moments/participant-avatar-stack.tsx
+++ b/src/components/moments/participant-avatar-stack.tsx
@@ -1,5 +1,5 @@
 import type { RegistrationWithUser } from "@/domain/models/registration";
-import { getDisplayName, getCircleUserInitials } from "@/lib/display-name";
+import { getPublicDisplayName, getPublicUserInitials } from "@/lib/display-name";
 import { getMomentGradient } from "@/lib/gradient";
 
 /**
@@ -7,16 +7,21 @@ import { getMomentGradient } from "@/lib/gradient";
  * Utilisée sur la page Moment (publique + dashboard) dans la section Participants.
  * Pendant très similaire à MemberAvatarStack côté Circle — les domaines restent séparés
  * car le type d'entrée diffère (Registration vs CircleMembership).
+ *
+ * `anonymousFallback` (typiquement `t("Common.anonymousFallback")`) sert d'étiquette
+ * pour les Participants sans nom — l'email n'est jamais exposé côté public (RGPD).
  */
 export function ParticipantAvatarStack({
   participants,
+  anonymousFallback,
 }: {
   participants: RegistrationWithUser[];
+  anonymousFallback: string;
 }) {
   return (
     <span className="flex -space-x-1.5">
       {participants.map((r) => {
-        const displayName = getDisplayName(r.user.firstName, r.user.lastName, r.user.email);
+        const displayName = getPublicDisplayName(r.user.firstName, r.user.lastName, anonymousFallback);
         return (
           <span key={r.id} className="group/avatar relative">
             <span
@@ -32,7 +37,7 @@ export function ParticipantAvatarStack({
                   className="absolute inset-0 size-full object-cover"
                 />
               ) : (
-                getCircleUserInitials(r.user)
+                getPublicUserInitials(r.user)
               )}
             </span>
             <span className="bg-foreground text-background pointer-events-none absolute bottom-full left-1/2 z-50 mb-1 -translate-x-1/2 rounded-md px-2 py-1 text-xs font-medium whitespace-nowrap opacity-0 transition-opacity group-hover/avatar:opacity-100">

--- a/src/components/moments/registration-button.tsx
+++ b/src/components/moments/registration-button.tsx
@@ -21,7 +21,7 @@ import {
   cancelRegistrationAction,
 } from "@/app/actions/registration";
 import { createCheckoutAction } from "@/app/actions/checkout";
-import { buildOnboardingSetupUrl } from "@/lib/onboarding";
+import { handleOnboardingRequired } from "@/lib/onboarding";
 import { formatPrice } from "@/lib/format-price";
 import type { Registration, RegistrationStatus } from "@/domain/models/registration";
 import type { CalendarEventData } from "@/lib/calendar";
@@ -247,10 +247,7 @@ export function RegistrationButton({
               router.refresh();
               return;
             }
-            if (result.code === "ONBOARDING_REQUIRED") {
-              router.push(buildOnboardingSetupUrl());
-              return;
-            }
+            if (handleOnboardingRequired(result, router)) return;
             setError(result.error);
           });
         }}

--- a/src/components/moments/registration-button.tsx
+++ b/src/components/moments/registration-button.tsx
@@ -21,6 +21,7 @@ import {
   cancelRegistrationAction,
 } from "@/app/actions/registration";
 import { createCheckoutAction } from "@/app/actions/checkout";
+import { buildOnboardingSetupUrl } from "@/lib/onboarding";
 import { formatPrice } from "@/lib/format-price";
 import type { Registration, RegistrationStatus } from "@/domain/models/registration";
 import type { CalendarEventData } from "@/lib/calendar";
@@ -244,9 +245,13 @@ export function RegistrationButton({
                 registration_status: result.data.status,
               });
               router.refresh();
-            } else {
-              setError(result.error);
+              return;
             }
+            if (result.code === "ONBOARDING_REQUIRED") {
+              router.push(buildOnboardingSetupUrl());
+              return;
+            }
+            setError(result.error);
           });
         }}
       >

--- a/src/components/user-avatar.tsx
+++ b/src/components/user-avatar.tsx
@@ -4,10 +4,9 @@ import { cn } from "@/lib/utils";
 type UserAvatarProps = {
   name?: string | null;
   /**
-   * Optionnel : email du user. Sert UNIQUEMENT à dériver l'initiale en
-   * contextes privés (Host dashboard, admin) quand `name` est absent.
-   * À NE PAS passer en contexte public — l'initiale d'email reste un fragment
-   * d'email exposé. Sans `name` ni `email`, l'initiale tombe sur "?".
+   * Privé uniquement (Host dashboard, admin) — `email[0]` sert d'initiale
+   * fallback. À ne PAS passer en contexte public ; sans `name` ni `email`
+   * l'initiale tombe sur "?".
    */
   email?: string | null;
   image?: string | null;

--- a/src/components/user-avatar.tsx
+++ b/src/components/user-avatar.tsx
@@ -3,12 +3,18 @@ import { cn } from "@/lib/utils";
 
 type UserAvatarProps = {
   name?: string | null;
-  email: string;
+  /**
+   * Optionnel : email du user. Sert UNIQUEMENT à dériver l'initiale en
+   * contextes privés (Host dashboard, admin) quand `name` est absent.
+   * À NE PAS passer en contexte public — l'initiale d'email reste un fragment
+   * d'email exposé. Sans `name` ni `email`, l'initiale tombe sur "?".
+   */
+  email?: string | null;
   image?: string | null;
   size?: "sm" | "default" | "md" | "lg" | "xl";
 };
 
-function getInitials(name?: string | null, email?: string): string {
+function getInitials(name?: string | null, email?: string | null): string {
   if (name) {
     const parts = name.trim().split(/\s+/);
     if (parts.length >= 2) {
@@ -32,7 +38,7 @@ export function UserAvatar({ name, email, image, size = "default" }: UserAvatarP
         size === "xl" && "size-24 text-3xl",
       )}
     >
-      {image && <AvatarImage src={image} alt={name ?? email} referrerPolicy="no-referrer" />}
+      {image && <AvatarImage src={image} alt={name ?? ""} referrerPolicy="no-referrer" />}
       <AvatarFallback className="bg-primary/10 text-primary font-medium">
         {initials}
       </AvatarFallback>

--- a/src/lib/__tests__/circle-helpers.test.ts
+++ b/src/lib/__tests__/circle-helpers.test.ts
@@ -34,6 +34,8 @@ const translate: Parameters<typeof computeMembersMeta>[3] = (key, values) => {
   return key;
 };
 
+const FALLBACK = "Membre";
+
 describe("computeMembersMeta", () => {
   describe("given fewer members than the avatars cap", () => {
     it("renders all avatars and no mobile 'others' suffix", () => {
@@ -43,7 +45,7 @@ describe("computeMembersMeta", () => {
         makeMember({ id: "carol", firstName: "Carol" }),
       ];
 
-      const result = computeMembersMeta([], members, members.length, translate);
+      const result = computeMembersMeta([], members, members.length, translate, FALLBACK);
 
       expect(result.visibleAvatars).toHaveLength(3);
       expect(result.metaText).toBe("Alice, Bob et 1 autre");
@@ -56,7 +58,7 @@ describe("computeMembersMeta", () => {
         makeMember({ id: "bob", firstName: "Bob" }),
       ];
 
-      const result = computeMembersMeta([], members, members.length, translate);
+      const result = computeMembersMeta([], members, members.length, translate, FALLBACK);
 
       expect(result.metaText).toBe("Alice, Bob");
       expect(result.metaMobileText).toBe("");
@@ -69,7 +71,7 @@ describe("computeMembersMeta", () => {
         makeMember({ id: `m${i}`, firstName: `M${i}` }),
       );
 
-      const result = computeMembersMeta([], members, members.length, translate);
+      const result = computeMembersMeta([], members, members.length, translate, FALLBACK);
 
       expect(result.visibleAvatars).toHaveLength(AVATAR_STACK_MAX);
       expect(result.metaMobileText).toBe("");
@@ -83,7 +85,7 @@ describe("computeMembersMeta", () => {
         makeMember({ id: `m${i}`, firstName: `M${i}` }),
       );
 
-      const result = computeMembersMeta([], members, totalCount, translate);
+      const result = computeMembersMeta([], members, totalCount, translate, FALLBACK);
 
       expect(result.visibleAvatars).toHaveLength(AVATAR_STACK_MAX);
       expect(result.metaText).toBe(`M0, M1 et ${totalCount - 2} autres`);
@@ -98,7 +100,7 @@ describe("computeMembersMeta", () => {
         makeMember({ id: `m${i}`, firstName: `M${i}` }),
       );
 
-      const result = computeMembersMeta([], members, totalCount, translate);
+      const result = computeMembersMeta([], members, totalCount, translate, FALLBACK);
 
       expect(result.metaText).toBe(`M0, M1 et ${totalCount - 2} autres`);
       expect(result.metaMobileText).toBe("et 7 autres");
@@ -128,6 +130,7 @@ describe("computeMembersMeta", () => {
         [midPlayer],
         3,
         translate,
+        FALLBACK,
       );
 
       expect(result.visibleAvatars.map((m) => m.id)).toEqual([

--- a/src/lib/__tests__/display-name.test.ts
+++ b/src/lib/__tests__/display-name.test.ts
@@ -1,12 +1,19 @@
 import { describe, it, expect } from "vitest";
-import { getDisplayName, getCircleUserInitials } from "@/lib/display-name";
+import {
+  getDisplayName,
+  getCircleUserInitials,
+  getPublicDisplayName,
+  getPublicUserInitials,
+} from "@/lib/display-name";
 
 /**
  * Tests — display-name.ts
  *
  * Règles métier :
- * - getDisplayName : prénom + nom > prénom seul > email (fallback)
- * - getCircleUserInitials : initiales prénom+nom > initiale prénom > initiale email (fallback)
+ * - getDisplayName : prénom + nom > prénom seul > email (fallback) — contextes privés
+ * - getCircleUserInitials : initiales prénom+nom > initiale prénom > initiale email — contextes privés
+ * - getPublicDisplayName : prénom + nom > prénom seul > fallback générique (jamais d'email)
+ * - getPublicUserInitials : initiales prénom+nom > initiale prénom > "?" (jamais d'email)
  */
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -264,6 +271,89 @@ describe("getCircleUserInitials", () => {
         email: "alice@example.com",
       });
       expect(result).toHaveLength(1);
+    });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// getPublicDisplayName — jamais d'email exposé
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("getPublicDisplayName", () => {
+  describe("given a user with first name and last name", () => {
+    it("should return 'firstName lastName'", () => {
+      expect(getPublicDisplayName("Alice", "Dupont", "Membre")).toBe("Alice Dupont");
+    });
+  });
+
+  describe("given a user with first name only", () => {
+    it("should return the first name when lastName is null", () => {
+      expect(getPublicDisplayName("Alice", null, "Membre")).toBe("Alice");
+    });
+
+    it("should return the first name when lastName is empty (falsy)", () => {
+      expect(getPublicDisplayName("Alice", "", "Membre")).toBe("Alice");
+    });
+  });
+
+  describe("given a user with no first name (RGPD-sensitive case)", () => {
+    it("should return the fallback when firstName is null — never exposing email", () => {
+      expect(getPublicDisplayName(null, null, "Membre")).toBe("Membre");
+    });
+
+    it("should return the fallback when firstName is undefined", () => {
+      expect(getPublicDisplayName(undefined, undefined, "Member")).toBe("Member");
+    });
+
+    it("should return the fallback when firstName is empty even with lastName", () => {
+      expect(getPublicDisplayName("", "Dupont", "Membre")).toBe("Membre");
+    });
+
+    it("should localize via the caller-provided fallback (FR vs EN)", () => {
+      expect(getPublicDisplayName(null, null, "Membre")).toBe("Membre");
+      expect(getPublicDisplayName(null, null, "Member")).toBe("Member");
+    });
+  });
+
+  describe("priority order — firstName + lastName > firstName > fallback", () => {
+    it.each([
+      { firstName: "Alice", lastName: "Dupont", expected: "Alice Dupont", label: "prénom + nom" },
+      { firstName: "Alice", lastName: null, expected: "Alice", label: "prénom seul" },
+      { firstName: null, lastName: null, expected: "Membre", label: "fallback générique" },
+    ])("should return '$expected' given $label", ({ firstName, lastName, expected }) => {
+      expect(getPublicDisplayName(firstName, lastName, "Membre")).toBe(expected);
+    });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// getPublicUserInitials — jamais d'initiale d'email
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("getPublicUserInitials", () => {
+  describe("given a user with first name and last name", () => {
+    it("should return uppercased initials", () => {
+      expect(getPublicUserInitials({ firstName: "Alice", lastName: "Dupont" })).toBe("AD");
+    });
+  });
+
+  describe("given a user with first name only", () => {
+    it("should return the first initial", () => {
+      expect(getPublicUserInitials({ firstName: "Alice", lastName: null })).toBe("A");
+    });
+  });
+
+  describe("given a user with no first name (RGPD-sensitive case)", () => {
+    it("should return '?' instead of an email-derived initial", () => {
+      expect(getPublicUserInitials({ firstName: null, lastName: null })).toBe("?");
+    });
+
+    it("should return '?' when only lastName is provided (no first = no initials)", () => {
+      expect(getPublicUserInitials({ firstName: null, lastName: "Dupont" })).toBe("?");
+    });
+
+    it("should return '?' for undefined fields", () => {
+      expect(getPublicUserInitials({})).toBe("?");
     });
   });
 });

--- a/src/lib/__tests__/onboarding.test.ts
+++ b/src/lib/__tests__/onboarding.test.ts
@@ -1,5 +1,10 @@
-import { describe, it, expect } from "vitest";
-import { shouldRedirectToSetup, shouldRedirectFromSetup } from "@/lib/onboarding";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  shouldRedirectToSetup,
+  shouldRedirectFromSetup,
+  buildOnboardingSetupUrl,
+  handleOnboardingRequired,
+} from "@/lib/onboarding";
 
 describe("Onboarding routing guards", () => {
   // ─── shouldRedirectToSetup (protected pages) ────────────────
@@ -121,6 +126,74 @@ describe("Onboarding routing guards", () => {
       expect(
         shouldRedirectToSetup(onboarded) && shouldRedirectFromSetup(onboarded)
       ).toBe(false);
+    });
+  });
+
+  // ─── buildOnboardingSetupUrl ────────────────────────────────
+
+  describe("buildOnboardingSetupUrl", () => {
+    function stubLocation(pathname: string, search = "") {
+      vi.stubGlobal("window", { location: { pathname, search } });
+    }
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it("encode le chemin courant en callbackUrl", () => {
+      stubLocation("/fr/m/some-event");
+      expect(buildOnboardingSetupUrl()).toBe(
+        "/dashboard/profile/setup?callbackUrl=%2Ffr%2Fm%2Fsome-event",
+      );
+    });
+
+    it("préserve la query string courante dans le callbackUrl", () => {
+      stubLocation("/fr/circles/spark", "?tab=members");
+      expect(buildOnboardingSetupUrl()).toBe(
+        "/dashboard/profile/setup?callbackUrl=%2Ffr%2Fcircles%2Fspark%3Ftab%3Dmembers",
+      );
+    });
+  });
+
+  // ─── handleOnboardingRequired ───────────────────────────────
+
+  describe("handleOnboardingRequired", () => {
+    let push: ReturnType<typeof vi.fn<(url: string) => void>>;
+
+    beforeEach(() => {
+      push = vi.fn<(url: string) => void>();
+      vi.stubGlobal("window", { location: { pathname: "/fr/m/x", search: "" } });
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it("retourne false et n'appelle pas push sur succès", () => {
+      const handled = handleOnboardingRequired({ success: true }, { push });
+      expect(handled).toBe(false);
+      expect(push).not.toHaveBeenCalled();
+    });
+
+    it("retourne false et n'appelle pas push pour un autre code d'erreur", () => {
+      const handled = handleOnboardingRequired(
+        { success: false, code: "UNAUTHORIZED" },
+        { push },
+      );
+      expect(handled).toBe(false);
+      expect(push).not.toHaveBeenCalled();
+    });
+
+    it("redirige vers setup et retourne true sur ONBOARDING_REQUIRED", () => {
+      const handled = handleOnboardingRequired(
+        { success: false, code: "ONBOARDING_REQUIRED" },
+        { push },
+      );
+      expect(handled).toBe(true);
+      expect(push).toHaveBeenCalledTimes(1);
+      expect(push).toHaveBeenCalledWith(
+        "/dashboard/profile/setup?callbackUrl=%2Ffr%2Fm%2Fx",
+      );
     });
   });
 });

--- a/src/lib/avatar-stack-meta.ts
+++ b/src/lib/avatar-stack-meta.ts
@@ -15,28 +15,16 @@ type Translator = (key: string, values?: Record<string, number | string>) => str
 type Options = {
   avatarsMax?: number;
   namesToShow?: number;
-  /**
-   * Étiquette à afficher pour un Player sans nom (typiquement
-   * `t("Common.anonymousFallback")` côté caller). Évite d'exposer l'email.
-   */
+  /** Étiquette pour un user sans nom (typiquement `t("Common.anonymousFallback")`). */
   anonymousFallback: string;
 };
 
-/**
- * Aperçu "stack d'avatars + et X autres" partagé entre la page Communauté
- * et la page événement.
- *
- * Le compteur "et X autres" est calculé par rapport à ce qui est *visible*
- * dans chaque contexte d'affichage, pour éviter une lecture fausse :
- * - desktop affiche les noms → compteur = total − noms affichés
- * - mobile n'affiche que les avatars → compteur = total − avatars visibles
- *
- * Sans cette distinction, un mobile à 5 avatars affichait "et 4 autres" pour
- * 6 inscrits (calcul desktop appliqué au mobile), donnant l'illusion de 9.
- *
- * Les `items` doivent être déjà triés par le caller dans l'ordre voulu —
- * la fonction se contente de slicer.
- */
+// Le compteur "et X autres" diffère selon le contexte d'affichage :
+//   desktop affiche les noms → compteur = total − noms
+//   mobile n'affiche que les avatars → compteur = total − avatars visibles
+// Avant cette distinction, un mobile à 5 avatars affichait "et 4 autres" pour
+// 6 inscrits (calcul desktop appliqué au mobile), donnant l'illusion de 9.
+// `items` doit être pré-trié par le caller — la fonction se contente de slicer.
 export function computeAvatarStackMeta<T extends WithDisplayUser>(
   items: T[],
   totalCount: number,

--- a/src/lib/avatar-stack-meta.ts
+++ b/src/lib/avatar-stack-meta.ts
@@ -1,4 +1,4 @@
-import { getDisplayName } from "@/lib/display-name";
+import { getPublicDisplayName } from "@/lib/display-name";
 
 export const AVATAR_STACK_MAX = 5;
 export const AVATAR_STACK_NAMES_TO_SHOW = 2;
@@ -7,7 +7,6 @@ type WithDisplayUser = {
   user: {
     firstName: string | null;
     lastName: string | null;
-    email: string;
   };
 };
 
@@ -16,6 +15,11 @@ type Translator = (key: string, values?: Record<string, number | string>) => str
 type Options = {
   avatarsMax?: number;
   namesToShow?: number;
+  /**
+   * Étiquette à afficher pour un Player sans nom (typiquement
+   * `t("Common.anonymousFallback")` côté caller). Évite d'exposer l'email.
+   */
+  anonymousFallback: string;
 };
 
 /**
@@ -37,7 +41,7 @@ export function computeAvatarStackMeta<T extends WithDisplayUser>(
   items: T[],
   totalCount: number,
   t: Translator,
-  options: Options = {},
+  options: Options,
 ): {
   visibleAvatars: T[];
   metaText: string;
@@ -49,7 +53,13 @@ export function computeAvatarStackMeta<T extends WithDisplayUser>(
   const visibleAvatars = items.slice(0, avatarsMax);
   const names = items
     .slice(0, namesToShow)
-    .map((item) => getDisplayName(item.user.firstName, item.user.lastName, item.user.email));
+    .map((item) =>
+      getPublicDisplayName(
+        item.user.firstName,
+        item.user.lastName,
+        options.anonymousFallback,
+      ),
+    );
 
   const desktopOthersCount = Math.max(0, totalCount - names.length);
   const desktopOthersText = desktopOthersCount > 0

--- a/src/lib/circle-helpers.ts
+++ b/src/lib/circle-helpers.ts
@@ -4,15 +4,9 @@ import { computeAvatarStackMeta } from "@/lib/avatar-stack-meta";
 
 type Translator = (key: string, values?: Record<string, number | string>) => string;
 
-/**
- * Trie les organisateurs d'un Circle : HOST en premier, puis CO_HOST, chaque groupe
- * trié alphabétiquement par nom affiché (sensibilité accents ignorée).
- *
- * `getDisplayName` est utilisé ici comme clé de tri uniquement — la valeur
- * n'est jamais rendue dans le HTML, donc même si elle retombe sur l'email
- * elle ne sort pas de la mémoire de la fonction. Et un Host a normalement
- * complété son onboarding (firstName/lastName non vides).
- */
+// HOST puis CO_HOST, alphabétique sur le nom (insensible aux accents).
+// `getDisplayName` sert de clé de tri uniquement (jamais rendue) : le
+// fallback email reste interne à la fonction.
 export function sortCircleOrganizers(
   organizers: CircleMemberWithUser[],
 ): CircleMemberWithUser[] {
@@ -27,15 +21,8 @@ export function sortCircleOrganizers(
   ];
 }
 
-/**
- * Aperçu "Membres" pour la colonne meta des pages Communauté : merge
- * hosts + players, trie par `joinedAt` ascendant, puis délègue le rendu
- * de la stack à `computeAvatarStackMeta`.
- *
- * `anonymousFallback` (typiquement `t("Common.anonymousFallback")`) est passé
- * au helper de stack pour ne jamais rendre l'email d'un Player sans nom dans
- * un contexte public.
- */
+// Bloc "Membres" des pages Communauté : merge hosts+players, trie par
+// `joinedAt` ascendant, délègue le rendu de la stack.
 export function computeMembersMeta(
   hosts: CircleMemberWithUser[],
   players: CircleMemberWithUser[],

--- a/src/lib/circle-helpers.ts
+++ b/src/lib/circle-helpers.ts
@@ -7,6 +7,11 @@ type Translator = (key: string, values?: Record<string, number | string>) => str
 /**
  * Trie les organisateurs d'un Circle : HOST en premier, puis CO_HOST, chaque groupe
  * trié alphabétiquement par nom affiché (sensibilité accents ignorée).
+ *
+ * `getDisplayName` est utilisé ici comme clé de tri uniquement — la valeur
+ * n'est jamais rendue dans le HTML, donc même si elle retombe sur l'email
+ * elle ne sort pas de la mémoire de la fonction. Et un Host a normalement
+ * complété son onboarding (firstName/lastName non vides).
  */
 export function sortCircleOrganizers(
   organizers: CircleMemberWithUser[],
@@ -26,12 +31,17 @@ export function sortCircleOrganizers(
  * Aperçu "Membres" pour la colonne meta des pages Communauté : merge
  * hosts + players, trie par `joinedAt` ascendant, puis délègue le rendu
  * de la stack à `computeAvatarStackMeta`.
+ *
+ * `anonymousFallback` (typiquement `t("Common.anonymousFallback")`) est passé
+ * au helper de stack pour ne jamais rendre l'email d'un Player sans nom dans
+ * un contexte public.
  */
 export function computeMembersMeta(
   hosts: CircleMemberWithUser[],
   players: CircleMemberWithUser[],
   totalCount: number,
   t: Translator,
+  anonymousFallback: string,
 ): {
   visibleAvatars: CircleMemberWithUser[];
   metaText: string;
@@ -40,5 +50,5 @@ export function computeMembersMeta(
   const allMembers = [...hosts, ...players].sort(
     (a, b) => a.joinedAt.getTime() - b.joinedAt.getTime(),
   );
-  return computeAvatarStackMeta(allMembers, totalCount, t);
+  return computeAvatarStackMeta(allMembers, totalCount, t, { anonymousFallback });
 }

--- a/src/lib/display-name.ts
+++ b/src/lib/display-name.ts
@@ -1,11 +1,20 @@
 /**
- * Retourne le nom d'affichage d'un utilisateur.
+ * Retourne le nom d'affichage d'un utilisateur, avec l'**email en fallback**.
+ *
+ * À RÉSERVER aux contextes privés (dashboard Host, emails serveur, admin) où
+ * l'exposition de l'email est légitime — par ex. un Host doit pouvoir
+ * identifier un Player via son email s'il n'a pas saisi de nom.
+ *
+ * Pour les contextes publics (page événement publique, page Communauté, listes
+ * de membres/inscrits, fil de commentaires), utiliser `getPublicDisplayName` :
+ * exposer l'email à un visiteur anonyme constitue une fuite RGPD.
+ *
  * Priorité : prénom + nom > prénom seul > email
  */
 export function getDisplayName(
   firstName: string | null | undefined,
   lastName: string | null | undefined,
-  email: string
+  email: string,
 ): string {
   if (firstName && lastName) return `${firstName} ${lastName}`;
   if (firstName) return firstName;
@@ -13,7 +22,28 @@ export function getDisplayName(
 }
 
 /**
- * Retourne les initiales d'un membre de Circle pour l'avatar.
+ * Retourne le nom d'affichage d'un utilisateur **sans jamais exposer l'email**.
+ *
+ * À utiliser pour tout rendu côté pages publiques (visibles par des visiteurs
+ * anonymes ou par des Players autres que celui affiché). Le fallback est une
+ * étiquette générique localisée passée par le caller (par ex. "Membre" / "Member").
+ *
+ * Priorité : prénom + nom > prénom seul > fallback générique
+ */
+export function getPublicDisplayName(
+  firstName: string | null | undefined,
+  lastName: string | null | undefined,
+  fallback: string,
+): string {
+  if (firstName && lastName) return `${firstName} ${lastName}`;
+  if (firstName) return firstName;
+  return fallback;
+}
+
+/**
+ * Retourne les initiales d'un membre de Circle pour l'avatar (contexte privé,
+ * email autorisé en fallback).
+ *
  * Priorité : initiales prénom+nom > initiale prénom > initiale email
  */
 export function getCircleUserInitials(user: {
@@ -25,4 +55,19 @@ export function getCircleUserInitials(user: {
     return `${user.firstName[0]}${user.lastName[0]}`.toUpperCase();
   if (user.firstName) return user.firstName[0].toUpperCase();
   return user.email[0].toUpperCase();
+}
+
+/**
+ * Initiales pour l'avatar dans les contextes publics (jamais d'initiale email).
+ *
+ * Priorité : initiales prénom+nom > initiale prénom > "?" (placeholder neutre)
+ */
+export function getPublicUserInitials(user: {
+  firstName?: string | null;
+  lastName?: string | null;
+}): string {
+  if (user.firstName && user.lastName)
+    return `${user.firstName[0]}${user.lastName[0]}`.toUpperCase();
+  if (user.firstName) return user.firstName[0].toUpperCase();
+  return "?";
 }

--- a/src/lib/display-name.ts
+++ b/src/lib/display-name.ts
@@ -1,15 +1,7 @@
 /**
- * Retourne le nom d'affichage d'un utilisateur, avec l'**email en fallback**.
- *
- * À RÉSERVER aux contextes privés (dashboard Host, emails serveur, admin) où
- * l'exposition de l'email est légitime — par ex. un Host doit pouvoir
- * identifier un Player via son email s'il n'a pas saisi de nom.
- *
- * Pour les contextes publics (page événement publique, page Communauté, listes
- * de membres/inscrits, fil de commentaires), utiliser `getPublicDisplayName` :
- * exposer l'email à un visiteur anonyme constitue une fuite RGPD.
- *
- * Priorité : prénom + nom > prénom seul > email
+ * Contextes privés uniquement (Host dashboard, emails serveur, admin) :
+ * fallback sur l'email autorisé. Pour les pages publiques, utiliser
+ * `getPublicDisplayName` — exposer l'email serait une fuite RGPD.
  */
 export function getDisplayName(
   firstName: string | null | undefined,
@@ -21,15 +13,7 @@ export function getDisplayName(
   return email;
 }
 
-/**
- * Retourne le nom d'affichage d'un utilisateur **sans jamais exposer l'email**.
- *
- * À utiliser pour tout rendu côté pages publiques (visibles par des visiteurs
- * anonymes ou par des Players autres que celui affiché). Le fallback est une
- * étiquette générique localisée passée par le caller (par ex. "Membre" / "Member").
- *
- * Priorité : prénom + nom > prénom seul > fallback générique
- */
+/** Pages publiques : fallback générique localisé fourni par le caller. */
 export function getPublicDisplayName(
   firstName: string | null | undefined,
   lastName: string | null | undefined,
@@ -40,12 +24,7 @@ export function getPublicDisplayName(
   return fallback;
 }
 
-/**
- * Retourne les initiales d'un membre de Circle pour l'avatar (contexte privé,
- * email autorisé en fallback).
- *
- * Priorité : initiales prénom+nom > initiale prénom > initiale email
- */
+/** Initiales avatar — contextes privés (email[0] autorisé en fallback). */
 export function getCircleUserInitials(user: {
   firstName?: string | null;
   lastName?: string | null;
@@ -57,11 +36,7 @@ export function getCircleUserInitials(user: {
   return user.email[0].toUpperCase();
 }
 
-/**
- * Initiales pour l'avatar dans les contextes publics (jamais d'initiale email).
- *
- * Priorité : initiales prénom+nom > initiale prénom > "?" (placeholder neutre)
- */
+/** Initiales avatar — pages publiques, fallback "?" (jamais email[0]). */
 export function getPublicUserInitials(user: {
   firstName?: string | null;
   lastName?: string | null;

--- a/src/lib/onboarding.ts
+++ b/src/lib/onboarding.ts
@@ -1,45 +1,38 @@
-/**
- * Onboarding routing guards — pure functions.
- *
- * These encode the redirect invariants for the onboarding flow.
- * The key architectural rule: a non-onboarded user MUST be able to
- * reach the setup page without triggering another redirect (no loop).
- */
+// Invariant : un user non onboardé DOIT pouvoir atteindre /setup sans redirect (pas de boucle).
 
 type OnboardingUser = {
   id: string;
   onboardingCompleted: boolean;
 } | null | undefined;
 
-/**
- * Should the user be redirected away from a protected dashboard page
- * to the onboarding setup page?
- *
- * Used by the (main) route group layout guard.
- */
 export function shouldRedirectToSetup(user: OnboardingUser): boolean {
   return !!user && !user.onboardingCompleted;
 }
 
-/**
- * Should the user be redirected away from the setup page
- * (because they already completed onboarding)?
- *
- * Used by the setup page itself.
- */
 export function shouldRedirectFromSetup(user: OnboardingUser): boolean {
   return !!user && user.onboardingCompleted;
 }
 
 /**
- * Construit l'URL `/dashboard/profile/setup` avec un `callbackUrl` pointant
- * vers la page courante (chemin + query). Appelée côté client quand une
- * server action publique renvoie `code: "ONBOARDING_REQUIRED"` — le user a
- * une session mais n'a pas finalisé son profil.
- *
- * Le routeur i18n (`@/i18n/navigation`) ajoutera le préfixe de locale.
+ * Construit l'URL `/dashboard/profile/setup` avec un `callbackUrl` vers la
+ * page courante. Le router i18n ajoute le préfixe de locale au push.
  */
 export function buildOnboardingSetupUrl(): string {
   const callbackUrl = `${window.location.pathname}${window.location.search}`;
-  return `/dashboard/profile/setup?callbackUrl=${encodeURIComponent(callbackUrl)}`;
+  const params = new URLSearchParams({ callbackUrl });
+  return `/dashboard/profile/setup?${params}`;
+}
+
+/**
+ * Si le `result` d'une server action publique signale que l'utilisateur n'a
+ * pas finalisé son onboarding, redirige vers la page setup. Retourne `true`
+ * dans ce cas pour permettre au caller de court-circuiter sa gestion d'erreur.
+ */
+export function handleOnboardingRequired(
+  result: { success: true } | { success: false; code: string },
+  router: { push: (url: string) => void },
+): boolean {
+  if (result.success || result.code !== "ONBOARDING_REQUIRED") return false;
+  router.push(buildOnboardingSetupUrl());
+  return true;
 }

--- a/src/lib/onboarding.ts
+++ b/src/lib/onboarding.ts
@@ -30,3 +30,16 @@ export function shouldRedirectToSetup(user: OnboardingUser): boolean {
 export function shouldRedirectFromSetup(user: OnboardingUser): boolean {
   return !!user && user.onboardingCompleted;
 }
+
+/**
+ * Construit l'URL `/dashboard/profile/setup` avec un `callbackUrl` pointant
+ * vers la page courante (chemin + query). Appelée côté client quand une
+ * server action publique renvoie `code: "ONBOARDING_REQUIRED"` — le user a
+ * une session mais n'a pas finalisé son profil.
+ *
+ * Le routeur i18n (`@/i18n/navigation`) ajoutera le préfixe de locale.
+ */
+export function buildOnboardingSetupUrl(): string {
+  const callbackUrl = `${window.location.pathname}${window.location.search}`;
+  return `/dashboard/profile/setup?callbackUrl=${encodeURIComponent(callbackUrl)}`;
+}


### PR DESCRIPTION
## Problème

Découverte d'une fuite RGPD : un user qui s'authentifie via OAuth (Google/GitHub) sans finaliser son onboarding reste un « zombie » (`onboardingCompleted=false`, `firstName=null`). Comme rien n'empêchait ce zombie d'agir publiquement (s'inscrire à un événement, rejoindre une Communauté, commenter), son **email** se retrouvait affiché sur des pages indexables (`/m/[slug]`, `/circles/[slug]`, modales membres) — `getDisplayName` retombait dessus en l'absence de prénom.

## Changements

### Phase A — Privacy : `getPublicDisplayName` / `getPublicUserInitials`

Nouveaux helpers qui ne retombent **jamais** sur l'email :

- `getPublicDisplayName(firstName, lastName, fallback)` → fallback localisé (« Membre » / « Member » via `Common.anonymousFallback`)
- `getPublicUserInitials(user)` → `?` si pas de prénom (vs `email[0]` avant)

Anciens helpers `getDisplayName` / `getCircleUserInitials` conservés mais **réservés aux contextes privés** (Host dashboard, emails serveur, admin) — JSDoc mis à jour.

Migration de tous les callsites publics :
- `ParticipantAvatarStack`, `MemberAvatarStack`, `AttendeeAvatarStack`
- `CircleOrganizersList`, `HostLink`, `MomentDetailView` (bloc « Organisé par »)
- `CommentThread` (en-tête commentaires)
- `CircleMembersDialog` (modale membres Circle)
- `MomentRegistrationsDialog` (modale inscrits — **modale ouverte par tout user connecté**, pas seulement Host : bug initialement raté puis corrigé après test live)
- Pages `/circles/[slug]` (publique + dashboard)

`UserAvatar` : prop `email` rendue **optionnelle**, fallback initiale `?` au lieu de `email[0]`, `alt` d'image n'expose plus l'email.

### Phase B — Security : guards `ONBOARDING_REQUIRED`

Guard `if (!session.user.onboardingCompleted)` ajouté dans 3 server actions :
- `joinMomentAction`
- `joinCircleDirectlyAction`
- `addCommentAction`

Les autres actions (delete/cancel) restent ouvertes — elles n'exposent rien publiquement.

Côté client : `RegistrationButton`, `JoinCircleButton`, `CommentThread` interceptent le code via le helper partagé `handleOnboardingRequired(result, router)` et redirigent vers `/dashboard/profile/setup?callbackUrl=…`.

La page setup accepte désormais `callbackUrl` depuis la **query** (priorité sur le cookie `auth-callback-url` posé pendant le sign-in) — la query reflète l'intention immédiate du clic.

### Phase C — Lien profil cassé pour zombie

Un zombie a `publicId=null` → le `<Link href="/u/${publicId}">` générait `/u/null` → 404. Pattern `publicId ? <Link> : <div>` appliqué à `CircleMembersDialog` et `CircleOrganizersList` (les autres callsites étaient déjà guardés).

## Backlog créé en parallèle

- #462 — Onboarding in-flow : modal demandant juste le prénom à la première action publique (réduction de friction du redirect)
- #463 — Rendre `lastName` optionnel, garder uniquement `firstName` requis
- #464 — Supprimer le composant mort `registrations-list.tsx`

## Test plan

- [x] `pnpm typecheck` (aucune erreur)
- [x] `pnpm test:unit` (1091 tests, dont 49 nouveaux sur `display-name` + 5 sur `onboarding`)
- [x] `pnpm build` (compile sans erreur)
- [x] Test manuel local : zombie inscrit dans la modale `/m/...` et `/circles/...` affiche « Membre » sans email
- [ ] Test manuel preview : reproduction du flow zombie via OAuth

🤖 Generated with [Claude Code](https://claude.com/claude-code)