### PR TITLE
fix(db): retry les hiccups Neon control plane

### DIFF
--- a/src/infrastructure/db/__tests__/retry-policy.test.ts
+++ b/src/infrastructure/db/__tests__/retry-policy.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { Prisma } from "@prisma/client";
+import { isTransientError } from "../retry-policy";
+
+describe("isTransientError", () => {
+  describe("given a Neon control plane error", () => {
+    it.each([
+      "Control plane request failed",
+      "Control plane request timed out",
+      "DriverAdapterError: Control plane request failed",
+    ])("should treat %s as transient", (message) => {
+      expect(isTransientError(new Error(message))).toBe(true);
+    });
+  });
+
+  describe("given a connection-level error", () => {
+    it.each([
+      "Connection terminated unexpectedly",
+      "ECONNRESET",
+      "ETIMEDOUT",
+      "socket hang up",
+      "too many connections",
+    ])("should treat %s as transient", (message) => {
+      expect(isTransientError(new Error(message))).toBe(true);
+    });
+  });
+
+  describe("given a known Prisma connection error code", () => {
+    it.each(["P1008", "P1011", "P1015", "P1017", "P2024"])(
+      "should treat %s as transient",
+      (code) => {
+        const error = new Prisma.PrismaClientKnownRequestError("boom", {
+          code,
+          clientVersion: "test",
+        });
+        expect(isTransientError(error)).toBe(true);
+      },
+    );
+  });
+
+  describe("given a non-transient error", () => {
+    it("should not retry a unique constraint violation (P2002)", () => {
+      const error = new Prisma.PrismaClientKnownRequestError(
+        "Unique constraint failed",
+        { code: "P2002", clientVersion: "test" },
+      );
+      expect(isTransientError(error)).toBe(false);
+    });
+
+    it("should not retry an unrelated error message", () => {
+      expect(isTransientError(new Error("Validation failed"))).toBe(false);
+    });
+
+    it("should not retry a non-Error value", () => {
+      expect(isTransientError("oops")).toBe(false);
+      expect(isTransientError(null)).toBe(false);
+      expect(isTransientError(undefined)).toBe(false);
+    });
+  });
+});

--- a/src/infrastructure/db/prisma.ts
+++ b/src/infrastructure/db/prisma.ts
@@ -1,61 +1,14 @@
 import { PrismaClient, Prisma } from "@prisma/client";
 import { PrismaNeon } from "@prisma/adapter-neon";
+import {
+  BASE_DELAY_MS,
+  MAX_RETRIES,
+  READ_OPERATIONS,
+  isTransientError,
+  sleep,
+} from "./retry-policy";
 
 export { Prisma };
-
-// ---------------------------------------------------------------------------
-// Retry — erreurs de connexion transitoires Neon
-// ---------------------------------------------------------------------------
-
-const MAX_RETRIES = 3;
-const BASE_DELAY_MS = 100;
-
-const TRANSIENT_PATTERNS = [
-  "Connection terminated unexpectedly",
-  "Connection terminated due to connection timeout",
-  "Connection refused",
-  "connection timed out",
-  "too many connections",
-  "socket hang up",
-  "ECONNRESET",
-  "ECONNREFUSED",
-  "ETIMEDOUT",
-  "ENOTFOUND",
-  "timeout exceeded when trying to connect",
-];
-
-// Prisma error codes for connection issues
-const TRANSIENT_PRISMA_CODES = new Set([
-  "P1008", // Operations timed out
-  "P1011", // Error opening a TLS connection
-  "P1015", // Can't reach database server
-  "P1017", // Server has closed the connection
-  "P2024", // Timed out fetching a new connection from the pool
-]);
-
-// Opérations de lecture — safe to retry (idempotentes par nature)
-const READ_OPERATIONS = new Set([
-  "findUnique",
-  "findUniqueOrThrow",
-  "findFirst",
-  "findFirstOrThrow",
-  "findMany",
-  "count",
-  "aggregate",
-  "groupBy",
-]);
-
-function isTransientError(error: unknown): boolean {
-  if (error instanceof Prisma.PrismaClientKnownRequestError) {
-    return TRANSIENT_PRISMA_CODES.has(error.code);
-  }
-  const message = error instanceof Error ? error.message : String(error);
-  return TRANSIENT_PATTERNS.some((p) => message.includes(p));
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
 
 // ---------------------------------------------------------------------------
 // Driver WebSocket Pool (PrismaNeon / @neondatabase/serverless)

--- a/src/infrastructure/db/retry-policy.ts
+++ b/src/infrastructure/db/retry-policy.ts
@@ -1,0 +1,52 @@
+import { Prisma } from "@prisma/client";
+
+export const MAX_RETRIES = 3;
+export const BASE_DELAY_MS = 100;
+
+const TRANSIENT_PATTERNS = [
+  "Connection terminated unexpectedly",
+  "Connection terminated due to connection timeout",
+  "Connection refused",
+  "connection timed out",
+  "too many connections",
+  "socket hang up",
+  "ECONNRESET",
+  "ECONNREFUSED",
+  "ETIMEDOUT",
+  "ENOTFOUND",
+  "timeout exceeded when trying to connect",
+  // Neon control plane hiccup (cold start, rolling deploy, transient saturation).
+  // Substring matches "Control plane request failed" and any future variant.
+  "Control plane",
+];
+
+const TRANSIENT_PRISMA_CODES = new Set([
+  "P1008", // Operations timed out
+  "P1011", // Error opening a TLS connection
+  "P1015", // Can't reach database server
+  "P1017", // Server has closed the connection
+  "P2024", // Timed out fetching a new connection from the pool
+]);
+
+export const READ_OPERATIONS = new Set([
+  "findUnique",
+  "findUniqueOrThrow",
+  "findFirst",
+  "findFirstOrThrow",
+  "findMany",
+  "count",
+  "aggregate",
+  "groupBy",
+]);
+
+export function isTransientError(error: unknown): boolean {
+  if (error instanceof Prisma.PrismaClientKnownRequestError) {
+    return TRANSIENT_PRISMA_CODES.has(error.code);
+  }
+  const message = error instanceof Error ? error.message : String(error);
+  return TRANSIENT_PATTERNS.some((p) => message.includes(p));
+}
+
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
## Summary

- Ajoute le pattern `"Control plane"` (substring) aux erreurs transitoires retryées par l'extension Prisma, pour absorber les `DriverAdapterError: Control plane request failed` levés par `@prisma/adapter-neon` lors d'un cold start ou d'un rolling deploy Neon.
- Extrait la politique de retry (constantes + `isTransientError` + `sleep`) dans `retry-policy.ts` pour la rendre testable sans instancier le client Prisma.
- Ajoute 16 tests unitaires couvrant les patterns control plane, les erreurs de connexion, les codes Prisma transitoires, et les non-régressions (P2002, message non lié, valeurs non-Error).

## Contexte

Sentry a remonté 2 nouvelles issues (`THE-PLAYGROUND-1C` et `THE-PLAYGROUND-1D`) sur les routes cron `transition-past-moments` et `send-reminders` à partir du 9 mai, avec un pic à 11 occurrences/24h. Le diagnostic pointe vers le rolling deploy Neon du 8 mai (changement FPW + déplacement compute → storage) qui amplifie un problème transient préexistant (déjà 2 occurrences sur `recalculate-scores` les 14 derniers jours).

Le `isTransientError` actuel ne matchait ni `DriverAdapterError` ni le message `"Control plane request failed"` → aucune retry, l'erreur remontait immédiatement. Avec ce fix, les reads (`findMany`, `findUnique`, etc.) seront retryés jusqu'à 3 fois (backoff 100/200/400ms = max 700ms).

Le wrapper retry au niveau route (Option B discutée) a été délibérément exclu du scope :
- impact métier réel quasi nul (cosmétique sur transition-past-moments, idempotence inter-run sur les rappels)
- risque de double envoi d'email sur `send-reminders` / `send-onboarding-welcome` si on retry au niveau handler
- le pic est probablement transient et devrait se résorber avec la fin du rollout Neon

## Test plan

- [x] `pnpm typecheck` passe
- [x] `pnpm vitest run src/infrastructure/db/__tests__/retry-policy.test.ts` → 16/16 verts
- [ ] CI vert sur la PR
- [ ] Surveillance des issues Sentry `THE-PLAYGROUND-1C` et `THE-PLAYGROUND-1D` post-merge :
  - elles devraient se résorber pour `send-reminders` (read en première op → retry actif)
  - elles persisteront pour `transition-past-moments` (updateMany, pas de retry sur write) jusqu'à la fin du rollout Neon. Point de contrôle au 17 mai, on revient sur Option B si nécessaire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)