### PR TITLE
feat(admin-notif): date/lieu à la création + notif sur modification d'event publié

### DIFF
--- a/src/app/[locale]/(routes)/lab/emails/page.tsx
+++ b/src/app/[locale]/(routes)/lab/emails/page.tsx
@@ -13,6 +13,7 @@ import { NewMomentNotificationEmail } from "@/infrastructure/services/email/temp
 import { BroadcastMomentEmail } from "@/infrastructure/services/email/templates/broadcast-moment";
 import { CircleInvitationEmail } from "@/infrastructure/services/email/templates/circle-invitation";
 import { AdminEntityCreatedEmail } from "@/infrastructure/services/email/templates/admin-entity-created";
+import { AdminMomentUpdatedEmail } from "@/infrastructure/services/email/templates/admin-moment-updated";
 import { AdminNewUserEmail } from "@/infrastructure/services/email/templates/admin-new-user";
 import { MagicLinkEmail } from "@/infrastructure/services/email/templates/magic-link";
 import { RegistrationReminderEmail } from "@/infrastructure/services/email/templates/registration-reminder";
@@ -343,7 +344,7 @@ async function buildTemplates(): Promise<{ id: string; label: string; html: stri
     },
     {
       id: "admin-entity-created",
-      label: "Admin — Nouvelle entité",
+      label: "Admin — Nouvelle entité (Communauté)",
       element: AdminEntityCreatedEmail({
         to: "admin@the-playground.fr",
         entityType: "circle",
@@ -355,6 +356,57 @@ async function buildTemplates(): Promise<{ id: string; label: string; html: stri
           subject: "Nouvelle Communauté créée : Paris Creative Tech",
           heading: "Nouvelle Communauté",
           message: "Bob Dupont vient de créer la Communauté Paris Creative Tech.",
+          ctaLabel: "Voir dans l'admin",
+          footer: FOOTER,
+        },
+        baseUrl: BASE_URL,
+      }),
+    },
+    {
+      id: "admin-entity-created-moment",
+      label: "Admin — Nouvel événement",
+      element: AdminEntityCreatedEmail({
+        to: "admin@the-playground.fr",
+        entityType: "moment",
+        entityName: "Soirée JS & Pizza",
+        creatorName: "Bob Dupont",
+        creatorEmail: "bob@example.com",
+        circleName: "Paris Creative Tech",
+        momentDate: "vendredi 21 mars 2026, 19:00",
+        locationText: "Le Cargo, 18 rue de la Paix, Paris",
+        entityUrl: `${BASE_URL}/dashboard/circles/paris-creative-tech/moments/soiree-js-pizza`,
+        strings: {
+          subject: "Nouvel événement créé : Soirée JS & Pizza",
+          heading: "Nouvel événement",
+          message: "Bob Dupont vient de créer un nouvel événement.",
+          ctaLabel: "Voir dans l'admin",
+          footer: FOOTER,
+          dateLabel: "Date",
+          locationLabel: "Lieu",
+        },
+        baseUrl: BASE_URL,
+      }),
+    },
+    {
+      id: "admin-moment-updated",
+      label: "Admin — Événement modifié",
+      element: AdminMomentUpdatedEmail({
+        to: "admin@the-playground.fr",
+        momentTitle: "Soirée JS & Pizza",
+        circleName: "Paris Creative Tech",
+        hostName: "Bob Dupont",
+        hostEmail: "bob@example.com",
+        momentUrl: `${BASE_URL}/dashboard/circles/paris-creative-tech/moments/soiree-js-pizza`,
+        momentDate: "vendredi 21 mars 2026, 19:00",
+        locationText: "Le Cargo, 18 rue de la Paix, Paris",
+        changedFields: ["Date", "Lieu", "Capacité"],
+        strings: {
+          subject: "[Admin] Événement modifié — Soirée JS & Pizza",
+          heading: "Événement modifié",
+          message: "Bob Dupont vient de modifier un événement publié.",
+          changesLabel: "Champs modifiés",
+          dateLabel: "Date",
+          locationLabel: "Lieu",
           ctaLabel: "Voir dans l'admin",
           footer: FOOTER,
         },

--- a/src/app/actions/moment.ts
+++ b/src/app/actions/moment.ts
@@ -295,11 +295,10 @@ export async function updateMomentAction(
         ).catch((err) => Sentry.captureException(err));
       }
 
-      // Notifier les admins si un événement publié a été modifié sur un champ significatif.
-      // On ne notifie pas pour les passages DRAFT → PUBLISHED (couverts par la notif de création)
-      // ni quand un admin agit lui-même sur l'événement d'un autre.
-      if (existingMoment.status === "PUBLISHED" && !isAdminUser(session)) {
-        const titleChanged = Boolean(title && title.trim() !== existingMoment.title);
+      // Les passages DRAFT → PUBLISHED sont couverts par la notif de création.
+      // Le filtre par email côté recipients exclut l'auteur s'il est admin.
+      if (existingMoment.status === "PUBLISHED") {
+        const titleChanged = title !== null && title.trim() !== existingMoment.title;
         const capacityChanged = capacity !== undefined && capacity !== existingMoment.capacity;
         const priceChanged = price !== undefined && price !== existingMoment.price;
 
@@ -658,19 +657,18 @@ async function sendAdminMomentUpdatedNotification(
   if (!circle) return;
 
   const ctx = buildMomentEmailContext(moment, DEFAULT_RECIPIENT_LOCALE);
-  const hostName =
-    [host?.firstName, host?.lastName].filter(Boolean).join(" ") ||
-    host?.email ||
-    "Organisateur";
+  const hostEmail = host?.email ?? "";
+  const hostName = host
+    ? getDisplayName(host.firstName, host.lastName, hostEmail)
+    : "Organisateur";
 
   await notifyAdminMomentUpdated({
     momentTitle: moment.title,
     momentSlug: moment.slug,
     circleName: circle.name,
     circleSlug: circle.slug,
-    hostId,
     hostName,
-    hostEmail: host?.email ?? "",
+    hostEmail,
     momentDate: ctx.momentDate,
     locationText: ctx.locationText,
     changedFields,

--- a/src/app/actions/moment.ts
+++ b/src/app/actions/moment.ts
@@ -31,6 +31,7 @@ import { revalidatePath } from "next/cache";
 import { invalidateDashboardCache } from "@/lib/dashboard-cache";
 import { notifyNewMoment } from "./notify-new-moment";
 import { notifyAdminEntityCreated } from "./notify-admin-entity-created";
+import { notifyAdminMomentUpdated } from "./notify-admin-moment-updated";
 import { isAdminUser, resolveCircleRepository } from "@/lib/admin-host-mode";
 import { getDisplayName } from "@/lib/display-name";
 import {
@@ -124,6 +125,7 @@ export async function createMomentAction(
       if (!circle) return;
 
       const creator = await prismaUserRepository.findById(userId);
+      const ctx = buildMomentEmailContext(result.moment, DEFAULT_RECIPIENT_LOCALE);
       notifyAdminEntityCreated({
         entityType: "moment",
         entityName: result.moment.title,
@@ -133,6 +135,8 @@ export async function createMomentAction(
         creatorEmail: creator?.email ?? session.user.email ?? "",
         circleName: circle.name,
         circleSlug: circle.slug,
+        momentDate: ctx.momentDate,
+        locationText: ctx.locationText,
       }).catch(console.error);
     }).catch((err) => {
       console.error(err);
@@ -289,6 +293,30 @@ export async function updateMomentAction(
           Boolean(locationChanged),
           resolver
         ).catch((err) => Sentry.captureException(err));
+      }
+
+      // Notifier les admins si un événement publié a été modifié sur un champ significatif.
+      // On ne notifie pas pour les passages DRAFT → PUBLISHED (couverts par la notif de création)
+      // ni quand un admin agit lui-même sur l'événement d'un autre.
+      if (existingMoment.status === "PUBLISHED" && !isAdminUser(session)) {
+        const titleChanged = Boolean(title && title.trim() !== existingMoment.title);
+        const capacityChanged = capacity !== undefined && capacity !== existingMoment.capacity;
+        const priceChanged = price !== undefined && price !== existingMoment.price;
+
+        const changedFields: string[] = [];
+        if (titleChanged) changedFields.push("Titre");
+        if (dateChanged) changedFields.push("Date");
+        if (locationChanged) changedFields.push("Lieu");
+        if (capacityChanged) changedFields.push("Capacité");
+        if (priceChanged) changedFields.push("Prix");
+
+        if (changedFields.length > 0) {
+          sendAdminMomentUpdatedNotification(
+            result.moment,
+            userId,
+            changedFields,
+          ).catch((err) => Sentry.captureException(err));
+        }
       }
     }
 
@@ -616,6 +644,37 @@ function sendMomentPublishedNotifications(
       console.error(err);
       Sentry.captureException(err);
     });
+}
+
+async function sendAdminMomentUpdatedNotification(
+  moment: Moment,
+  hostId: string,
+  changedFields: string[],
+): Promise<void> {
+  const [circle, host] = await Promise.all([
+    prismaCircleRepository.findById(moment.circleId),
+    prismaUserRepository.findById(hostId),
+  ]);
+  if (!circle) return;
+
+  const ctx = buildMomentEmailContext(moment, DEFAULT_RECIPIENT_LOCALE);
+  const hostName =
+    [host?.firstName, host?.lastName].filter(Boolean).join(" ") ||
+    host?.email ||
+    "Organisateur";
+
+  await notifyAdminMomentUpdated({
+    momentTitle: moment.title,
+    momentSlug: moment.slug,
+    circleName: circle.name,
+    circleSlug: circle.slug,
+    hostId,
+    hostName,
+    hostEmail: host?.email ?? "",
+    momentDate: ctx.momentDate,
+    locationText: ctx.locationText,
+    changedFields,
+  });
 }
 
 export async function getMomentParticipantsPageAction(

--- a/src/app/actions/notify-admin-entity-created.ts
+++ b/src/app/actions/notify-admin-entity-created.ts
@@ -15,6 +15,9 @@ export type AdminEntityCreatedParams = {
   creatorEmail: string;
   circleName?: string; // Pour les moments
   circleSlug?: string; // Pour les moments
+  // Pour les moments uniquement
+  momentDate?: string;
+  locationText?: string;
 };
 
 export async function notifyAdminEntityCreated(
@@ -43,6 +46,8 @@ export async function notifyAdminEntityCreated(
     message: `${params.creatorName} vient de créer ${isCircle ? "une nouvelle Communauté" : "un nouvel événement"}.`,
     ctaLabel: `Voir ${isCircle ? "la Communauté" : "l'événement"} dans l'admin`,
     footer: "Vous recevez cet email car vous êtes administrateur de The Playground.",
+    dateLabel: "Date",
+    locationLabel: "Lieu",
   };
 
   if (isAdminEmailEnabled()) {
@@ -56,6 +61,8 @@ export async function notifyAdminEntityCreated(
           creatorEmail: params.creatorEmail,
           circleName: params.circleName,
           entityUrl,
+          momentDate: params.momentDate,
+          locationText: params.locationText,
           strings,
         })
       )
@@ -78,5 +85,7 @@ export async function notifyAdminEntityCreated(
     creatorEmail: params.creatorEmail,
     circleName: params.circleName,
     entityUrl,
+    momentDate: params.momentDate,
+    locationText: params.locationText,
   });
 }

--- a/src/app/actions/notify-admin-moment-updated.ts
+++ b/src/app/actions/notify-admin-moment-updated.ts
@@ -6,6 +6,7 @@ import {
   notifySlackMomentUpdated,
   isAdminEmailEnabled,
 } from "@/infrastructure/services/slack/slack-notification-service";
+import { getAppUrl } from "@/lib/app-url";
 
 const emailService = createResendEmailService();
 
@@ -14,7 +15,6 @@ export type AdminMomentUpdatedParams = {
   momentSlug: string;
   circleName: string;
   circleSlug: string;
-  hostId: string;
   hostName: string;
   hostEmail: string;
   momentDate: string;
@@ -28,13 +28,10 @@ export async function notifyAdminMomentUpdated(
   if (params.changedFields.length === 0) return;
 
   const adminEmails = await prismaUserRepository.findAdminEmails();
-
-  // Exclure l'auteur de la modification s'il est lui-même admin
   const recipients = adminEmails.filter((email) => email !== params.hostEmail);
   if (recipients.length === 0) return;
 
-  const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
-  const momentUrl = `${appUrl}/dashboard/circles/${params.circleSlug}/moments/${params.momentSlug}`;
+  const momentUrl = `${getAppUrl()}/dashboard/circles/${params.circleSlug}/moments/${params.momentSlug}`;
 
   const strings = {
     subject: `[Admin] Événement modifié — ${params.momentTitle}`,

--- a/src/app/actions/notify-admin-moment-updated.ts
+++ b/src/app/actions/notify-admin-moment-updated.ts
@@ -1,0 +1,88 @@
+"use server";
+
+import { prismaUserRepository } from "@/infrastructure/repositories";
+import { createResendEmailService } from "@/infrastructure/services";
+import {
+  notifySlackMomentUpdated,
+  isAdminEmailEnabled,
+} from "@/infrastructure/services/slack/slack-notification-service";
+
+const emailService = createResendEmailService();
+
+export type AdminMomentUpdatedParams = {
+  momentTitle: string;
+  momentSlug: string;
+  circleName: string;
+  circleSlug: string;
+  hostId: string;
+  hostName: string;
+  hostEmail: string;
+  momentDate: string;
+  locationText: string;
+  changedFields: string[];
+};
+
+export async function notifyAdminMomentUpdated(
+  params: AdminMomentUpdatedParams,
+): Promise<void> {
+  if (params.changedFields.length === 0) return;
+
+  const adminEmails = await prismaUserRepository.findAdminEmails();
+
+  // Exclure l'auteur de la modification s'il est lui-même admin
+  const recipients = adminEmails.filter((email) => email !== params.hostEmail);
+  if (recipients.length === 0) return;
+
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
+  const momentUrl = `${appUrl}/dashboard/circles/${params.circleSlug}/moments/${params.momentSlug}`;
+
+  const strings = {
+    subject: `[Admin] Événement modifié — ${params.momentTitle}`,
+    heading: "Événement modifié sur The Playground",
+    message: `${params.hostName} vient de modifier un événement publié.`,
+    changesLabel: "Champs modifiés",
+    dateLabel: "Date",
+    locationLabel: "Lieu",
+    ctaLabel: "Voir l'événement dans l'admin",
+    footer: "Vous recevez cet email car vous êtes administrateur de The Playground.",
+  };
+
+  if (isAdminEmailEnabled()) {
+    const results = await Promise.allSettled(
+      recipients.map((to) =>
+        emailService.sendAdminMomentUpdated({
+          to,
+          momentTitle: params.momentTitle,
+          circleName: params.circleName,
+          hostName: params.hostName,
+          hostEmail: params.hostEmail,
+          momentUrl,
+          momentDate: params.momentDate,
+          locationText: params.locationText,
+          changedFields: params.changedFields,
+          strings,
+        }),
+      ),
+    );
+
+    results.forEach((result, i) => {
+      if (result.status === "rejected") {
+        console.error(
+          `[notifyAdminMomentUpdated] Échec envoi email admin ${recipients[i]}:`,
+          result.reason,
+        );
+      }
+    });
+  }
+
+  await notifySlackMomentUpdated({
+    momentTitle: params.momentTitle,
+    circleName: params.circleName,
+    hostName: params.hostName,
+    hostEmail: params.hostEmail,
+    momentUrl,
+    momentDate: params.momentDate,
+    locationText: params.locationText,
+    changedFields: params.changedFields,
+  });
+}

--- a/src/domain/ports/services/email-service.ts
+++ b/src/domain/ports/services/email-service.ts
@@ -272,10 +272,38 @@ export type AdminEntityCreatedEmailData = {
   creatorEmail: string;
   circleName?: string; // Pour les moments : nom de la Communauté
   entityUrl: string;
+  // Pour les moments uniquement : date pré-formatée + lieu lisible
+  momentDate?: string;
+  locationText?: string;
   strings: {
     subject: string;
     heading: string;
     message: string;
+    ctaLabel: string;
+    footer: string;
+    dateLabel?: string;
+    locationLabel?: string;
+  };
+};
+
+export type AdminMomentUpdatedEmailData = {
+  to: string;
+  momentTitle: string;
+  circleName: string;
+  hostName: string;
+  hostEmail: string;
+  momentUrl: string;
+  momentDate: string;
+  locationText: string;
+  // Liste lisible des champs modifiés (ex: ["Date", "Lieu", "Capacité"])
+  changedFields: string[];
+  strings: {
+    subject: string;
+    heading: string;
+    message: string;
+    changesLabel: string;
+    dateLabel: string;
+    locationLabel: string;
     ctaLabel: string;
     footer: string;
   };
@@ -480,6 +508,7 @@ export interface EmailService {
   sendHostMomentCreated(data: HostMomentCreatedEmailData): Promise<void>;
   sendBroadcastMoments(data: BroadcastMomentsBatchEmailData): Promise<void>;
   sendAdminEntityCreated(data: AdminEntityCreatedEmailData): Promise<void>;
+  sendAdminMomentUpdated(data: AdminMomentUpdatedEmailData): Promise<void>;
   sendCircleInvitation(data: CircleInvitationEmailData): Promise<void>;
   sendCircleInvitations(data: CircleInvitationsBatchEmailData): Promise<void>;
   sendAdminNewUser(data: AdminNewUserEmailData): Promise<void>;

--- a/src/domain/usecases/__tests__/helpers/mock-email-service.ts
+++ b/src/domain/usecases/__tests__/helpers/mock-email-service.ts
@@ -18,6 +18,7 @@ export function createMockEmailService(
     sendHostMomentCreated: vi.fn().mockResolvedValue(undefined),
     sendBroadcastMoments: vi.fn().mockResolvedValue(undefined),
     sendAdminEntityCreated: vi.fn().mockResolvedValue(undefined),
+    sendAdminMomentUpdated: vi.fn().mockResolvedValue(undefined),
     sendCircleInvitation: vi.fn().mockResolvedValue(undefined),
     sendCircleInvitations: vi.fn().mockResolvedValue(undefined),
     sendAdminNewUser: vi.fn().mockResolvedValue(undefined),

--- a/src/infrastructure/services/email/resend-email-service.ts
+++ b/src/infrastructure/services/email/resend-email-service.ts
@@ -15,6 +15,7 @@ import type {
   HostMomentCreatedEmailData,
   BroadcastMomentsBatchEmailData,
   AdminEntityCreatedEmailData,
+  AdminMomentUpdatedEmailData,
   CircleInvitationEmailData,
   CircleInvitationsBatchEmailData,
   AdminNewUserEmailData,
@@ -38,6 +39,7 @@ import { MomentCancelledEmail } from "./templates/moment-cancelled";
 import { HostMomentCreatedEmail } from "./templates/host-moment-created";
 import { BroadcastMomentEmail } from "./templates/broadcast-moment";
 import { AdminEntityCreatedEmail } from "./templates/admin-entity-created";
+import { AdminMomentUpdatedEmail } from "./templates/admin-moment-updated";
 import { CircleInvitationEmail } from "./templates/circle-invitation";
 import { AdminNewUserEmail } from "./templates/admin-new-user";
 import { HostNewCircleMemberEmail } from "./templates/host-new-circle-member";
@@ -296,6 +298,15 @@ export function createResendEmailService(): EmailService {
         to: data.to,
         subject: data.strings.subject,
         react: AdminEntityCreatedEmail({ ...data, baseUrl }),
+      });
+    },
+
+    async sendAdminMomentUpdated(data: AdminMomentUpdatedEmailData): Promise<void> {
+      await send({
+        from,
+        to: data.to,
+        subject: data.strings.subject,
+        react: AdminMomentUpdatedEmail({ ...data, baseUrl }),
       });
     },
 

--- a/src/infrastructure/services/email/templates/admin-entity-created.tsx
+++ b/src/infrastructure/services/email/templates/admin-entity-created.tsx
@@ -45,13 +45,13 @@ export function AdminEntityCreatedEmail({
         )}
         {isMoment && momentDate && (
           <>
-            <Text style={infoLabel}>{strings.dateLabel ?? "Date"}</Text>
+            <Text style={infoLabel}>{strings.dateLabel}</Text>
             <Text style={infoValue}>{momentDate}</Text>
           </>
         )}
         {isMoment && locationText && (
           <>
-            <Text style={infoLabel}>{strings.locationLabel ?? "Lieu"}</Text>
+            <Text style={infoLabel}>{strings.locationLabel}</Text>
             <Text style={infoValue}>{locationText}</Text>
           </>
         )}

--- a/src/infrastructure/services/email/templates/admin-entity-created.tsx
+++ b/src/infrastructure/services/email/templates/admin-entity-created.tsx
@@ -21,8 +21,11 @@ export function AdminEntityCreatedEmail({
   creatorEmail,
   circleName,
   entityUrl,
+  momentDate,
+  locationText,
   strings,
 }: Props) {
+  const isMoment = entityType === "moment";
   return (
     <EmailLayout preview={strings.subject} footer={strings.footer}>
       <Text style={heading}>{strings.heading}</Text>
@@ -31,13 +34,25 @@ export function AdminEntityCreatedEmail({
 
       <Section style={infoCard}>
         <Text style={infoLabel}>
-          {entityType === "circle" ? "Communauté" : "Événement"}
+          {isMoment ? "Événement" : "Communauté"}
         </Text>
         <Text style={infoValue}>{entityName}</Text>
         {circleName && (
           <>
             <Text style={infoLabel}>Communauté</Text>
             <Text style={infoValue}>{circleName}</Text>
+          </>
+        )}
+        {isMoment && momentDate && (
+          <>
+            <Text style={infoLabel}>{strings.dateLabel ?? "Date"}</Text>
+            <Text style={infoValue}>{momentDate}</Text>
+          </>
+        )}
+        {isMoment && locationText && (
+          <>
+            <Text style={infoLabel}>{strings.locationLabel ?? "Lieu"}</Text>
+            <Text style={infoValue}>{locationText}</Text>
           </>
         )}
         <Text style={infoLabel}>Créé par</Text>

--- a/src/infrastructure/services/email/templates/admin-moment-updated.tsx
+++ b/src/infrastructure/services/email/templates/admin-moment-updated.tsx
@@ -1,0 +1,69 @@
+import { Button, Section, Text } from "@react-email/components";
+import * as React from "react";
+import { EmailLayout } from "./components/email-layout";
+import type { AdminMomentUpdatedEmailData } from "@/domain/ports/services/email-service";
+import {
+  ctaButton,
+  headingLg as heading,
+  infoCard,
+  infoLabel,
+  infoValue,
+} from "./components/email-styles";
+
+type Props = AdminMomentUpdatedEmailData & {
+  baseUrl: string;
+};
+
+export function AdminMomentUpdatedEmail({
+  momentTitle,
+  circleName,
+  hostName,
+  hostEmail,
+  momentUrl,
+  momentDate,
+  locationText,
+  changedFields,
+  strings,
+}: Props) {
+  return (
+    <EmailLayout preview={strings.subject} footer={strings.footer}>
+      <Text style={heading}>{strings.heading}</Text>
+
+      <Text style={message}>{strings.message}</Text>
+
+      <Section style={infoCard}>
+        <Text style={infoLabel}>Événement</Text>
+        <Text style={infoValue}>{momentTitle}</Text>
+        <Text style={infoLabel}>Communauté</Text>
+        <Text style={infoValue}>{circleName}</Text>
+        <Text style={infoLabel}>{strings.dateLabel}</Text>
+        <Text style={infoValue}>{momentDate}</Text>
+        <Text style={infoLabel}>{strings.locationLabel}</Text>
+        <Text style={infoValue}>{locationText}</Text>
+        <Text style={infoLabel}>Modifié par</Text>
+        <Text style={infoValue}>
+          {hostName} — {hostEmail}
+        </Text>
+        <Text style={infoLabel}>{strings.changesLabel}</Text>
+        <Text style={infoValue}>{changedFields.join(", ")}</Text>
+      </Section>
+
+      <Section style={ctaSection}>
+        <Button style={ctaButton} href={momentUrl}>
+          {strings.ctaLabel}
+        </Button>
+      </Section>
+    </EmailLayout>
+  );
+}
+
+const message: React.CSSProperties = {
+  fontSize: "14px",
+  color: "#52525b",
+  margin: "0 0 20px 0",
+  lineHeight: "22px",
+};
+
+const ctaSection: React.CSSProperties = {
+  textAlign: "center" as const,
+};

--- a/src/infrastructure/services/slack/slack-notification-service.ts
+++ b/src/infrastructure/services/slack/slack-notification-service.ts
@@ -45,6 +45,8 @@ export async function notifySlackNewEntity(params: {
   creatorEmail: string;
   circleName?: string;
   entityUrl: string;
+  momentDate?: string;
+  locationText?: string;
 }): Promise<void> {
   const isCircle = params.entityType === "circle";
   const icon = isCircle ? "🟣" : "📅";
@@ -52,6 +54,8 @@ export async function notifySlackNewEntity(params: {
 
   const bodyParts = [`*${params.entityName}*`, `Par ${params.creatorName} (${params.creatorEmail})`];
   if (params.circleName) bodyParts.push(`Communaute : ${params.circleName}`);
+  if (params.momentDate) bodyParts.push(`Date : ${params.momentDate}`);
+  if (params.locationText) bodyParts.push(`Lieu : ${params.locationText}`);
 
   await sendSlack({
     text: `${icon} ${label} — ${params.entityName}`,
@@ -59,6 +63,35 @@ export async function notifySlackNewEntity(params: {
       { type: "header", text: { type: "plain_text", text: `${icon} ${label}`, emoji: true } },
       { type: "section", text: { type: "mrkdwn", text: bodyParts.join("\n") } },
       { type: "actions", elements: [{ type: "button", text: { type: "plain_text", text: "Voir dans le dashboard" }, url: params.entityUrl }] },
+    ],
+  });
+}
+
+export async function notifySlackMomentUpdated(params: {
+  momentTitle: string;
+  circleName: string;
+  hostName: string;
+  hostEmail: string;
+  momentUrl: string;
+  momentDate: string;
+  locationText: string;
+  changedFields: string[];
+}): Promise<void> {
+  const bodyParts = [
+    `*${params.momentTitle}*`,
+    `Par ${params.hostName} (${params.hostEmail})`,
+    `Communaute : ${params.circleName}`,
+    `Date : ${params.momentDate}`,
+    `Lieu : ${params.locationText}`,
+  ];
+
+  await sendSlack({
+    text: `✏️ Evenement modifie — ${params.momentTitle}`,
+    blocks: [
+      { type: "header", text: { type: "plain_text", text: "✏️ Evenement modifie", emoji: true } },
+      { type: "section", text: { type: "mrkdwn", text: bodyParts.join("\n") } },
+      { type: "section", text: { type: "mrkdwn", text: `*Champs modifies*\n${params.changedFields.map((f) => `• ${f}`).join("\n")}` } },
+      { type: "actions", elements: [{ type: "button", text: { type: "plain_text", text: "Voir dans le dashboard" }, url: params.momentUrl }] },
     ],
   });
 }


### PR DESCRIPTION
## Summary
- Notifs admin (email + Slack) à la **création d'un événement** incluent désormais la **date** et le **lieu**.
- Nouvelle notif admin (email + Slack) **« événement modifié »**, déclenchée quand un événement `PUBLISHED` est mis à jour sur un champ significatif (Titre, Date, Lieu, Capacité, Prix).
- Pas de notif distincte au passage DRAFT → PUBLISHED (couvert par la notif de création).
- Le filtre par email côté recipients exclut l'auteur s'il est admin → garantit l'audit trail vers les autres admins.

## Test plan
- [ ] Vérifier que `pnpm typecheck` passe (vert localement)
- [ ] Aperçu des nouveaux emails dans `/lab/emails` :
  - `admin-entity-created-moment` (notif création avec date/lieu)
  - `admin-moment-updated` (notif modification avec liste des champs)
- [ ] Sur preview : créer un event publié, vérifier que l'email/Slack admin contiennent date + lieu
- [ ] Modifier le titre/date/lieu d'un event publié, vérifier que la notif "modifié" est envoyée avec les bons champs listés
- [ ] Modifier la description seule (champ non significatif) : pas de notif admin
- [ ] Modifier un DRAFT : pas de notif admin (statut !== PUBLISHED)