### PR TITLE
chore(pre-release): màj page Aide + stats À propos

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1666,7 +1666,8 @@
         "photosLabel": "Photos in comments:",
         "photos1": "You can <strong>add up to 3 photos</strong> to each comment (JPG, PNG, WebP)",
         "photos2": "Large photos are <strong>automatically compressed</strong> for fast upload, even from a phone",
-        "photos3": "Click a photo to enlarge it"
+        "photos3": "Click a photo to enlarge it",
+        "contactNote": "For a private question, use the \"Contact the organizer\" link available under the organizers section on the event or community page. Your message is sent directly to the organizer by email, and they can reply to you in return."
       },
       "mySpace": {
         "title": "My Dashboard",
@@ -1761,7 +1762,8 @@
       },
       "contact": {
         "title": "Contact your members",
-        "intro": "From the event dashboard, the <strong>Invite my community</strong> button lets you send an email to all community members to invite them to the event. You can personalize the message. The same broadcast can only be resent after 24 hours."
+        "intro": "From the event dashboard, the <strong>Invite my community</strong> button lets you send an email to all community members to invite them to the event. You can personalize the message. The same broadcast can only be resent after 24 hours.",
+        "inboundNote": "Members can also send you a private message via the \"Contact the organizer\" link shown on the event or community page. You receive this message by email and can reply directly."
       },
       "editCancel": {
         "title": "Edit or cancel an event",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1666,7 +1666,8 @@
         "photosLabel": "Photos dans les commentaires :",
         "photos1": "Vous pouvez <strong>ajouter jusqu'à 3 photos</strong> à chaque commentaire (JPG, PNG, WebP)",
         "photos2": "Les photos volumineuses sont <strong>automatiquement compressées</strong> pour un envoi rapide, même depuis un téléphone",
-        "photos3": "Cliquez sur une photo pour l'agrandir"
+        "photos3": "Cliquez sur une photo pour l'agrandir",
+        "contactNote": "Pour une question privée, utilisez le lien « Contacter l'organisateur » disponible sous la section organisateurs sur la page de l'événement ou de la communauté. Votre message est envoyé directement à l'organisateur par email, et il peut vous répondre en retour."
       },
       "mySpace": {
         "title": "Mon espace",
@@ -1761,7 +1762,8 @@
       },
       "contact": {
         "title": "Contacter vos participants",
-        "intro": "Depuis le tableau de bord de l'événement, le bouton <strong>Inviter ma communauté</strong> vous permet d'envoyer un email à l'ensemble des membres de votre communauté pour les inviter à l'événement. Vous pouvez personnaliser le message. Un même envoi ne peut être relancé qu'après 24 heures."
+        "intro": "Depuis le tableau de bord de l'événement, le bouton <strong>Inviter ma communauté</strong> vous permet d'envoyer un email à l'ensemble des membres de votre communauté pour les inviter à l'événement. Vous pouvez personnaliser le message. Un même envoi ne peut être relancé qu'après 24 heures.",
+        "inboundNote": "Les participants peuvent également vous envoyer un message privé via le lien « Contacter l'organisateur » affiché sur la page de l'événement ou de la communauté. Vous recevez ce message par email et pouvez répondre directement."
       },
       "editCancel": {
         "title": "Modifier ou annuler un événement",

--- a/src/app/[locale]/(routes)/(static)/about/page.tsx
+++ b/src/app/[locale]/(routes)/(static)/about/page.tsx
@@ -375,10 +375,10 @@ export default async function AboutPage() {
         </h2>
         <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
           {[
-            { value: "1 900+", label: isFr ? "commits" : "commits" },
-            { value: "390+", label: isFr ? "pull requests" : "pull requests" },
-            { value: "80", label: isFr ? "cas d'usage" : "use cases" },
-            { value: "1 010+", label: isFr ? "tests" : "tests" },
+            { value: "2 000+", label: isFr ? "commits" : "commits" },
+            { value: "410+", label: isFr ? "pull requests" : "pull requests" },
+            { value: "81", label: isFr ? "cas d'usage" : "use cases" },
+            { value: "1 110+", label: isFr ? "tests" : "tests" },
           ].map(({ value, label }) => (
             <div key={label} className="text-center">
               <p className="text-2xl font-extrabold tracking-tight bg-gradient-to-r from-pink-500 to-violet-500 bg-clip-text text-transparent">

--- a/src/app/[locale]/(routes)/(static)/help/page.tsx
+++ b/src/app/[locale]/(routes)/(static)/help/page.tsx
@@ -322,6 +322,9 @@ export default async function HelpPage() {
                 <li>{t.rich("participant.comments.photos2", rich)}</li>
                 <li>{t("participant.comments.photos3")}</li>
               </ul>
+              <p className="text-sm leading-relaxed text-muted-foreground">
+                {t("participant.comments.contactNote")}
+              </p>
             </div>
 
             <hr className="border-border" />
@@ -511,6 +514,9 @@ export default async function HelpPage() {
               <SectionH3 id="contactParticipants">{t("organizer.contact.title")}</SectionH3>
               <p className="text-sm leading-relaxed text-muted-foreground">
                 {t.rich("organizer.contact.intro", rich)}
+              </p>
+              <p className="text-sm leading-relaxed text-muted-foreground">
+                {t("organizer.contact.inboundNote")}
               </p>
             </div>
 


### PR DESCRIPTION
## Summary
- Ajout du contact Organisateur sur la page Aide (côté Participant et côté Organisateur), FR + EN
- Mise à jour des stats À propos avant la release v2.12.0

## Test plan
- [ ] La page Aide expose bien la feature contact Organisateur (FR + EN)
- [ ] Les chiffres affichés sur /about sont à jour

🤖 Generated with [Claude Code](https://claude.com/claude-code)