### PR TITLE
Rendre l’onboarding public plus léger

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1489,6 +1489,11 @@
       "title": "Complete your profile",
       "description": "Tell us a bit about yourself to get started."
     },
+    "inlineOnboarding": {
+      "title": "Just your first name",
+      "description": "It lets us display your registration and comments without interrupting your flow.",
+      "submit": "Continue"
+    },
     "edit": {
       "title": "My profile",
       "description": "Manage your personal information",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1503,7 +1503,7 @@
       "emailHint": "Your email is used to sign in and cannot be changed.",
       "firstName": "First name",
       "firstNamePlaceholder": "Alice",
-      "lastName": "Last name",
+      "lastName": "Last name (optional)",
       "lastNamePlaceholder": "Dupont",
       "bio": "Bio",
       "bioPlaceholder": "Describe yourself in a few words...",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1503,7 +1503,7 @@
       "emailHint": "Votre email est utilisé pour vous connecter et ne peut pas être modifié.",
       "firstName": "Prénom",
       "firstNamePlaceholder": "Alice",
-      "lastName": "Nom",
+      "lastName": "Nom (optionnel)",
       "lastNamePlaceholder": "Dupont",
       "bio": "Bio",
       "bioPlaceholder": "Décrivez-vous en quelques mots...",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1489,6 +1489,11 @@
       "title": "Complétez votre profil",
       "description": "Dites-nous en un peu plus sur vous pour commencer."
     },
+    "inlineOnboarding": {
+      "title": "Juste votre prénom",
+      "description": "Il nous permet d'afficher votre inscription et vos commentaires sans interrompre votre parcours.",
+      "submit": "Continuer"
+    },
     "edit": {
       "title": "Mon profil",
       "description": "Gérez vos informations personnelles",

--- a/src/app/actions/profile.ts
+++ b/src/app/actions/profile.ts
@@ -32,15 +32,11 @@ export async function updateProfileAction(
   }
 
   const firstName = formData.get("firstName") as string;
-  const lastName = formData.get("lastName") as string;
+  const lastName = formData.get("lastName") as string | null;
 
   if (!firstName?.trim()) {
     return { success: false, error: "First name is required", code: "VALIDATION" };
   }
-  if (!lastName?.trim()) {
-    return { success: false, error: "Last name is required", code: "VALIDATION" };
-  }
-
   const bio = formData.get("bio") as string | null;
   const city = formData.get("city") as string | null;
   const website = formData.get("website") as string | null;
@@ -51,13 +47,13 @@ export async function updateProfileAction(
   const userId = session.user.id;
   return toActionResult(async () => {
     const trimmedFirst = firstName.trim();
-    const trimmedLast = lastName.trim();
+    const trimmedLast = lastName?.trim() || null;
     return updateProfile(
       {
         userId,
         firstName: trimmedFirst,
         lastName: trimmedLast,
-        name: `${trimmedFirst} ${trimmedLast}`,
+        name: [trimmedFirst, trimmedLast].filter(Boolean).join(" "),
         bio: bio?.trim() || null,
         city: city?.trim() || null,
         website: website?.trim() || null,

--- a/src/components/circles/join-circle-button.tsx
+++ b/src/components/circles/join-circle-button.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "@/i18n/navigation";
 import posthog from "posthog-js";
 import { Users, Check, Clock } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { InlineOnboardingDialog } from "@/components/profile/inline-onboarding-dialog";
 import { joinCircleDirectlyAction } from "@/app/actions/circle";
 import { handleOnboardingRequired } from "@/lib/onboarding";
 import { useTranslations } from "next-intl";
@@ -19,6 +20,7 @@ export function JoinCircleButton({ circleId, requiresApproval = false }: Props) 
   const router = useRouter();
   const [state, setState] = useState<"idle" | "joined" | "pending">("idle");
   const [isPending, startTransition] = useTransition();
+  const [showOnboarding, setShowOnboarding] = useState(false);
 
   function handleJoin() {
     startTransition(async () => {
@@ -29,7 +31,7 @@ export function JoinCircleButton({ circleId, requiresApproval = false }: Props) 
         router.refresh();
         return;
       }
-      handleOnboardingRequired(result, router);
+      handleOnboardingRequired(result, router, { onRequired: () => setShowOnboarding(true) });
     });
   }
 
@@ -52,15 +54,22 @@ export function JoinCircleButton({ circleId, requiresApproval = false }: Props) 
   }
 
   return (
-    <Button
-      variant="default"
-      size="sm"
-      onClick={handleJoin}
-      disabled={isPending}
-      className="w-full gap-2"
-    >
-      <Users className="size-4" />
-      {requiresApproval ? t("joinRequiresApproval") : t("join")}
-    </Button>
+    <>
+      <InlineOnboardingDialog
+        open={showOnboarding}
+        onOpenChange={setShowOnboarding}
+        onCompleted={handleJoin}
+      />
+      <Button
+        variant="default"
+        size="sm"
+        onClick={handleJoin}
+        disabled={isPending}
+        className="w-full gap-2"
+      >
+        <Users className="size-4" />
+        {requiresApproval ? t("joinRequiresApproval") : t("join")}
+      </Button>
+    </>
   );
 }

--- a/src/components/moments/comment-thread.tsx
+++ b/src/components/moments/comment-thread.tsx
@@ -17,6 +17,7 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
+import { InlineOnboardingDialog } from "@/components/profile/inline-onboarding-dialog";
 import { UserAvatar } from "@/components/user-avatar";
 import { CommentPhotoLightbox } from "@/components/moments/comment-photo-lightbox";
 import { addCommentAction, deleteCommentAction } from "@/app/actions/comment";
@@ -189,6 +190,7 @@ export function CommentThread({
   const [content, setContent] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
+  const [showOnboarding, setShowOnboarding] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const formatRelativeTime = useRelativeTime(t);
@@ -285,13 +287,18 @@ export function CommentThread({
         router.refresh();
         return;
       }
-      if (handleOnboardingRequired(result, router)) return;
+      if (handleOnboardingRequired(result, router, { onRequired: () => setShowOnboarding(true) })) return;
       setError(result.error);
     });
   }
 
   return (
     <div className="border-border bg-card rounded-2xl border p-6">
+      <InlineOnboardingDialog
+        open={showOnboarding}
+        onOpenChange={setShowOnboarding}
+        onCompleted={handleSubmit}
+      />
       <div className="space-y-4">
         {/* Header */}
         <h2 className="text-muted-foreground text-xs font-semibold uppercase tracking-wider">

--- a/src/components/moments/registration-button.tsx
+++ b/src/components/moments/registration-button.tsx
@@ -4,6 +4,7 @@ import { useState, useTransition } from "react";
 import { useTranslations, useLocale } from "next-intl";
 import { useRouter } from "@/i18n/navigation";
 import { Button } from "@/components/ui/button";
+import { InlineOnboardingDialog } from "@/components/profile/inline-onboarding-dialog";
 import { Clock, LogOut } from "lucide-react";
 import {
   AlertDialog,
@@ -76,6 +77,28 @@ export function RegistrationButton({
     existingRegistration?.id ?? null
   );
   const [error, setError] = useState<string | null>(null);
+  const [showOnboarding, setShowOnboarding] = useState(false);
+
+  function handleJoin() {
+    startTransition(async () => {
+      setError(null);
+      const result = await joinMomentAction(momentId);
+      if (result.success) {
+        setLocalStatus(result.data.status);
+        setLocalRegistrationId(result.data.id);
+        posthog.capture("moment_joined", {
+          moment_id: momentId,
+          circle_id: circleId,
+          circle_name: circleName,
+          registration_status: result.data.status,
+        });
+        router.refresh();
+        return;
+      }
+      if (handleOnboardingRequired(result, router, { onRequired: () => setShowOnboarding(true) })) return;
+      setError(result.error);
+    });
+  }
 
   // Not authenticated: link to sign-in (same for free and paid)
   if (!isAuthenticated) {
@@ -227,30 +250,16 @@ export function RegistrationButton({
   // Default: register or join waitlist
   return (
     <div className="space-y-2">
+      <InlineOnboardingDialog
+        open={showOnboarding}
+        onOpenChange={setShowOnboarding}
+        onCompleted={handleJoin}
+      />
       <Button
         className="w-full"
         size="sm"
         disabled={isPending}
-        onClick={() => {
-          startTransition(async () => {
-            setError(null);
-            const result = await joinMomentAction(momentId);
-            if (result.success) {
-              setLocalStatus(result.data.status);
-              setLocalRegistrationId(result.data.id);
-              posthog.capture("moment_joined", {
-                moment_id: momentId,
-                circle_id: circleId,
-                circle_name: circleName,
-                registration_status: result.data.status,
-              });
-              router.refresh();
-              return;
-            }
-            if (handleOnboardingRequired(result, router)) return;
-            setError(result.error);
-          });
-        }}
+        onClick={handleJoin}
       >
         {isPending
           ? tCommon("loading")

--- a/src/components/profile/inline-onboarding-dialog.tsx
+++ b/src/components/profile/inline-onboarding-dialog.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useActionState } from "react";
+import { useTranslations } from "next-intl";
+import { completeOnboardingAction } from "@/app/actions/profile";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+type InlineOnboardingDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onCompleted: () => void;
+};
+
+type FormState = {
+  error?: string;
+};
+
+export function InlineOnboardingDialog({
+  open,
+  onOpenChange,
+  onCompleted,
+}: InlineOnboardingDialogProps) {
+  const t = useTranslations("Profile.inlineOnboarding");
+  const tForm = useTranslations("Profile.form");
+  const tCommon = useTranslations("Common");
+
+  async function handleSubmit(
+    _prev: FormState,
+    formData: FormData,
+  ): Promise<FormState> {
+    const result = await completeOnboardingAction(formData);
+    if (!result.success) return { error: result.error };
+
+    onOpenChange(false);
+    onCompleted();
+    return {};
+  }
+
+  const [state, formAction, isPending] = useActionState(handleSubmit, {});
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <form action={formAction} className="space-y-5">
+          <DialogHeader>
+            <DialogTitle>{t("title")}</DialogTitle>
+            <DialogDescription>{t("description")}</DialogDescription>
+          </DialogHeader>
+
+          {state.error && (
+            <div className="bg-destructive/10 text-destructive rounded-md p-3 text-sm">
+              {state.error}
+            </div>
+          )}
+
+          <div className="space-y-2">
+            <Label htmlFor="inline-firstName">{tForm("firstName")}</Label>
+            <Input
+              id="inline-firstName"
+              name="firstName"
+              placeholder={tForm("firstNamePlaceholder")}
+              required
+              maxLength={50}
+              autoFocus
+            />
+          </div>
+
+          <DialogFooter>
+            <Button type="submit" disabled={isPending} className="w-full sm:w-auto">
+              {isPending ? tCommon("loading") : t("submit")}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/profile/profile-form.tsx
+++ b/src/components/profile/profile-form.tsx
@@ -98,7 +98,6 @@ export function ProfileForm({ user, mode, action, callbackUrl }: ProfileFormProp
             name="lastName"
             placeholder={t("form.lastNamePlaceholder")}
             defaultValue={user.lastName ?? ""}
-            required
             maxLength={50}
             className={INPUT_BG}
           />

--- a/src/domain/ports/repositories/user-repository.ts
+++ b/src/domain/ports/repositories/user-repository.ts
@@ -2,7 +2,7 @@ import type { User, NotificationPreferences, DashboardMode, PublicUser } from "@
 
 export type UpdateProfileInput = {
   firstName: string;
-  lastName: string;
+  lastName: string | null;
   name?: string | null;
   image?: string | null;
   bio?: string | null;

--- a/src/domain/usecases/__tests__/update-profile.test.ts
+++ b/src/domain/usecases/__tests__/update-profile.test.ts
@@ -37,6 +37,32 @@ describe("UpdateProfile", () => {
       expect(result.onboardingCompleted).toBe(true);
     });
 
+    it("should accept a missing lastName", async () => {
+      const existing = makeUser({ id: "user-1" });
+      const updated = makeUser({
+        id: "user-1",
+        firstName: "Alice",
+        lastName: null,
+        onboardingCompleted: true,
+      });
+      const repo = createMockUserRepository({
+        findById: vi.fn().mockResolvedValue(existing),
+        updateProfile: vi.fn().mockResolvedValue(updated),
+      });
+
+      const result = await updateProfile(
+        { userId: "user-1", firstName: "Alice", lastName: null },
+        { userRepository: repo },
+      );
+
+      expect(repo.updateProfile).toHaveBeenCalledWith("user-1", {
+        firstName: "Alice",
+        lastName: null,
+      });
+      expect(result.lastName).toBeNull();
+      expect(result.onboardingCompleted).toBe(true);
+    });
+
     it("should pass optional name if provided", async () => {
       const existing = makeUser({ id: "user-1" });
       const repo = createMockUserRepository({

--- a/src/domain/usecases/update-profile.ts
+++ b/src/domain/usecases/update-profile.ts
@@ -8,7 +8,7 @@ import { UserNotFoundError } from "@/domain/errors";
 type UpdateProfileUseCaseInput = {
   userId: string;
   firstName: string;
-  lastName: string;
+  lastName: string | null;
   name?: string | null;
   image?: string | null;
   bio?: string | null;

--- a/src/lib/__tests__/onboarding.test.ts
+++ b/src/lib/__tests__/onboarding.test.ts
@@ -195,5 +195,18 @@ describe("Onboarding routing guards", () => {
         "/dashboard/profile/setup?callbackUrl=%2Ffr%2Fm%2Fx",
       );
     });
+
+    it("appelle le callback au lieu de rediriger quand onRequired est fourni", () => {
+      const onRequired = vi.fn();
+      const handled = handleOnboardingRequired(
+        { success: false, code: "ONBOARDING_REQUIRED" },
+        { push },
+        { onRequired },
+      );
+
+      expect(handled).toBe(true);
+      expect(onRequired).toHaveBeenCalledTimes(1);
+      expect(push).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/lib/onboarding.ts
+++ b/src/lib/onboarding.ts
@@ -31,8 +31,13 @@ export function buildOnboardingSetupUrl(): string {
 export function handleOnboardingRequired(
   result: { success: true } | { success: false; code: string },
   router: { push: (url: string) => void },
+  options?: { onRequired?: () => void },
 ): boolean {
   if (result.success || result.code !== "ONBOARDING_REQUIRED") return false;
+  if (options?.onRequired) {
+    options.onRequired();
+    return true;
+  }
   router.push(buildOnboardingSetupUrl());
   return true;
 }


### PR DESCRIPTION
## Summary
- Make lastName optional across profile validation, form, and update flow
- Add an inline first-name onboarding dialog for public actions
- Retry moment registration, circle join, or comment submission after onboarding completion

## Tests
- pnpm test:unit src/lib/__tests__/onboarding.test.ts src/domain/usecases/__tests__/update-profile.test.ts
- pnpm typecheck

Closes #462
Closes #463