### PR TITLE
chore(github): add issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-fix.yml
+++ b/.github/ISSUE_TEMPLATE/01-fix.yml
@@ -1,0 +1,47 @@
+name: Correction de bug
+description: Signaler un bug ou un comportement incorrect.
+title: ""
+labels:
+  - type:fix
+body:
+  - type: textarea
+    id: probleme
+    attributes:
+      label: Problème
+      description: Décris le bug, son impact utilisateur ou technique, et les surfaces concernées.
+      placeholder: Le comportement observé, l'impact et les surfaces concernées.
+    validations:
+      required: true
+  - type: textarea
+    id: observations
+    attributes:
+      label: Reproduction / observations
+      description: Ajoute les étapes, captures, liens, logs ou contexte utile pour reproduire ou diagnostiquer.
+      placeholder: Étapes, captures, liens, logs ou contexte utile.
+    validations:
+      required: false
+  - type: textarea
+    id: piste
+    attributes:
+      label: Piste
+      description: Indique la cause probable, les fichiers à auditer, ou l'approche de correction envisagée.
+      placeholder: Cause probable, fichiers à auditer, ou approche envisagée.
+    validations:
+      required: false
+  - type: textarea
+    id: spec
+    attributes:
+      label: Spec
+      description: Ajoute une spec existante ou note les décisions attendues. Mets `—` si rien à ajouter.
+      placeholder: "—"
+    validations:
+      required: false
+  - type: textarea
+    id: validation
+    attributes:
+      label: Tests / Validation
+      description: Liste les vérifications attendues pour considérer le bug corrigé.
+      value: |
+        - [ ]
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/02-feature.yml
+++ b/.github/ISSUE_TEMPLATE/02-feature.yml
@@ -1,0 +1,64 @@
+name: Nouvelle fonctionnalité
+description: Proposer une nouvelle fonctionnalité produit ou plateforme.
+title: ""
+labels:
+  - type:feature
+body:
+  - type: textarea
+    id: contexte
+    attributes:
+      label: Contexte
+      description: Explique la situation actuelle, les utilisateurs concernés, et les limites observées.
+      placeholder: Situation actuelle, utilisateurs concernés, limites observées.
+    validations:
+      required: true
+  - type: textarea
+    id: probleme
+    attributes:
+      label: Problème
+      description: Formule le besoin ou le problème utilisateur à résoudre.
+      placeholder: Besoin utilisateur ou problème à résoudre.
+    validations:
+      required: true
+  - type: textarea
+    id: idee
+    attributes:
+      label: Idée
+      description: Décris le comportement cible et les grands choix de conception.
+      placeholder: Comportement cible et grands choix de conception.
+    validations:
+      required: true
+  - type: textarea
+    id: perimetre
+    attributes:
+      label: Périmètre V1
+      description: Liste les éléments inclus dans une première version livrable.
+      value: |
+        - [ ]
+    validations:
+      required: false
+  - type: textarea
+    id: hors_scope
+    attributes:
+      label: Hors scope
+      description: Note explicitement ce qui ne doit pas être traité dans cette issue.
+      placeholder: Ce qui ne doit pas être traité dans cette issue.
+    validations:
+      required: false
+  - type: textarea
+    id: risques
+    attributes:
+      label: Risques / Points d'attention
+      description: Ajoute les risques techniques, produit, données, sécurité ou UX.
+      placeholder: Risques techniques, produit, données, sécurité ou UX.
+    validations:
+      required: false
+  - type: textarea
+    id: validation
+    attributes:
+      label: Tests / Validation
+      description: Liste les scénarios à tester pour valider la fonctionnalité.
+      value: |
+        - [ ]
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/03-evolution.yml
+++ b/.github/ISSUE_TEMPLATE/03-evolution.yml
@@ -1,0 +1,64 @@
+name: Évolution
+description: Faire évoluer une fonctionnalité existante.
+title: ""
+labels:
+  - type:evol
+body:
+  - type: textarea
+    id: contexte
+    attributes:
+      label: Contexte
+      description: Décris le comportement actuel et les surfaces concernées.
+      placeholder: Comportement actuel et surfaces concernées.
+    validations:
+      required: true
+  - type: textarea
+    id: objectif
+    attributes:
+      label: Objectif
+      description: Décris le résultat attendu pour l'utilisateur ou l'équipe.
+      placeholder: Résultat attendu pour l'utilisateur ou l'équipe.
+    validations:
+      required: true
+  - type: textarea
+    id: idee
+    attributes:
+      label: Idée
+      description: Décris l'évolution envisagée et les principaux choix d'UX ou d'implémentation.
+      placeholder: Évolution envisagée et principaux choix d'UX ou d'implémentation.
+    validations:
+      required: false
+  - type: textarea
+    id: a_cadrer
+    attributes:
+      label: À cadrer
+      description: Liste les décisions ou inconnues à clarifier avant implémentation.
+      placeholder: Décisions à prendre, arbitrages ou inconnues à clarifier.
+    validations:
+      required: false
+  - type: textarea
+    id: benefice
+    attributes:
+      label: Bénéfice attendu
+      description: Explique pourquoi cette évolution vaut l'effort.
+      placeholder: Impact attendu pour les utilisateurs, l'équipe ou la plateforme.
+    validations:
+      required: false
+  - type: textarea
+    id: perimetre
+    attributes:
+      label: Périmètre
+      description: Liste les écrans, workflows, composants ou comportements concernés.
+      value: |
+        - [ ]
+    validations:
+      required: false
+  - type: textarea
+    id: validation
+    attributes:
+      label: Tests / Validation
+      description: Liste les vérifications attendues.
+      value: |
+        - [ ]
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/04-idea.yml
+++ b/.github/ISSUE_TEMPLATE/04-idea.yml
@@ -1,0 +1,39 @@
+name: Idée à qualifier
+description: Capturer une idée, une opportunité ou un spike avant cadrage.
+title: ""
+labels:
+  - type:idea
+body:
+  - type: textarea
+    id: probleme
+    attributes:
+      label: Problème ou opportunité
+      description: Décris l'idée, le signal observé, ou l'opportunité à explorer.
+      placeholder: Idée, signal observé, ou opportunité à explorer.
+    validations:
+      required: true
+  - type: textarea
+    id: piste
+    attributes:
+      label: Piste
+      description: Ajoute les hypothèses, benchmarks, options ou recherches à mener.
+      placeholder: Hypothèses, benchmarks, options ou recherches à mener.
+    validations:
+      required: false
+  - type: textarea
+    id: questions
+    attributes:
+      label: Questions ouvertes
+      description: Liste les décisions ou inconnues à clarifier avant implémentation.
+      value: |
+        1.
+    validations:
+      required: false
+  - type: textarea
+    id: spec
+    attributes:
+      label: Spec
+      description: Ajoute une spec existante, `à créer`, ou `—`.
+      placeholder: "—"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/05-chore.yml
+++ b/.github/ISSUE_TEMPLATE/05-chore.yml
@@ -1,0 +1,39 @@
+name: Maintenance / documentation / infra
+description: Suivre une tâche de maintenance, documentation, CI, infra ou dette technique.
+title: ""
+labels:
+  - type:chore
+body:
+  - type: textarea
+    id: probleme
+    attributes:
+      label: Problème
+      description: Décris la dette, le manque, le risque ou la tâche à traiter.
+      placeholder: Dette, manque, risque ou tâche à traiter.
+    validations:
+      required: true
+  - type: textarea
+    id: piste
+    attributes:
+      label: Piste
+      description: Indique l'approche envisagée, les fichiers concernés ou la commande à ajouter.
+      placeholder: Approche envisagée, fichiers concernés ou commande à ajouter.
+    validations:
+      required: false
+  - type: textarea
+    id: spec
+    attributes:
+      label: Spec
+      description: Ajoute une spec existante ou mets `—` si rien à ajouter.
+      placeholder: "—"
+    validations:
+      required: false
+  - type: textarea
+    id: validation
+    attributes:
+      label: Tests / Validation
+      description: Liste les vérifications attendues.
+      value: |
+        - [ ]
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Faille de sécurité
+    url: https://github.com/DragosDreptate/the-playground/security/advisories/new
+    about: Signaler une vulnérabilité en privé via GitHub Security Advisories.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+<!--
+Titre attendu : Conventional Commit, par exemple `feat(scope): description`, `fix(scope): description`, `chore(scope): description`.
+Si la PR ferme une issue, ajouter `closes #123` dans le résumé.
+-->
+
+## Summary
+
+-
+
+## Test plan
+
+- [ ]
+
+## Issue
+
+<!-- Si la PR ferme une issue : `closes #123`. Sinon, supprimer cette section. -->


### PR DESCRIPTION
## Summary

- add structured GitHub issue forms for fixes, features, evolutions, ideas, and chores
- disable blank issues to guide contributors through the project conventions
- add a pull request template aligned with the existing Summary / Test plan format

## Test plan

- [x] Parse all `.github/ISSUE_TEMPLATE/*.yml` files with Ruby YAML
- [x] Verify referenced labels exist on GitHub
- [x] Verify templates contain no Codex, Claude, assistant, generated, or tool references

## Issue

closes #

Forged with help from Codex.