### PR TITLE
feat(nav): mobile nav icons + dashboard greeting copy

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -291,7 +291,7 @@
     "hostTools": "Host tools",
     "greeting": "Hello, {name}",
     "greetingAnonymous": "Hello",
-    "greetingSubtitle": "Here's what's happening in your communities.",
+    "greetingSubtitle": "Your events and communities, at a glance.",
     "memberCount": "{count} members",
     "filterAll": "All",
     "filterHostOnly": "Organizer"

--- a/messages/en.json
+++ b/messages/en.json
@@ -1010,7 +1010,13 @@
   "UserMenu": {
     "dashboard": "Dashboard",
     "profile": "Profile",
-    "signOut": "Sign out"
+    "signOut": "Sign out",
+    "preferences": {
+      "language": "Language",
+      "theme": "Theme",
+      "light": "Light mode",
+      "dark": "Dark mode"
+    }
   },
   "Email": {
     "coHostPromoted": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -291,7 +291,7 @@
     "hostTools": "Outils organisateur",
     "greeting": "Bonjour, {name}",
     "greetingAnonymous": "Bonjour",
-    "greetingSubtitle": "Voici ce qui se passe dans vos communautés.",
+    "greetingSubtitle": "Vos événements et vos communautés, en un coup d'œil.",
     "memberCount": "{count} membres",
     "filterAll": "Tous",
     "filterHostOnly": "Organisateur"

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1010,7 +1010,13 @@
   "UserMenu": {
     "dashboard": "Mon espace",
     "profile": "Profil",
-    "signOut": "Se déconnecter"
+    "signOut": "Se déconnecter",
+    "preferences": {
+      "language": "Langue",
+      "theme": "Thème",
+      "light": "Mode clair",
+      "dark": "Mode sombre"
+    }
   },
   "Email": {
     "coHostPromoted": {

--- a/src/components/locale-toggle.tsx
+++ b/src/components/locale-toggle.tsx
@@ -1,8 +1,6 @@
 "use client";
 
-import { useLocale } from "next-intl";
-import { usePathname, useRouter } from "@/i18n/navigation";
-import { routing } from "@/i18n/routing";
+import { Globe } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -10,8 +8,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { Globe } from "lucide-react";
-import { useTransition } from "react";
+import { useLocaleSwitcher } from "@/lib/use-locale-switcher";
 
 const localeLabels: Record<string, { short: string; full: string }> = {
   fr: { short: "FR", full: "Français" },
@@ -19,16 +16,7 @@ const localeLabels: Record<string, { short: string; full: string }> = {
 };
 
 export function LocaleToggle() {
-  const locale = useLocale();
-  const router = useRouter();
-  const pathname = usePathname();
-  const [isPending, startTransition] = useTransition();
-
-  function switchLocale(nextLocale: string) {
-    startTransition(() => {
-      router.replace(pathname, { locale: nextLocale });
-    });
-  }
+  const { locale, locales, switchLocale, isPending } = useLocaleSwitcher();
 
   return (
     <DropdownMenu>
@@ -39,7 +27,7 @@ export function LocaleToggle() {
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
-        {routing.locales.map((l) => (
+        {locales.map((l) => (
           <DropdownMenuItem
             key={l}
             onClick={() => switchLocale(l)}

--- a/src/components/mobile-nav.tsx
+++ b/src/components/mobile-nav.tsx
@@ -2,18 +2,8 @@
 
 import { useTranslations } from "next-intl";
 import { Link, usePathname } from "@/i18n/navigation";
-import { usePathname as useFullPathname } from "next/navigation";
-import { Menu, Compass, LayoutDashboard, LogIn } from "lucide-react";
-import { Button } from "@/components/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { ThemeToggle } from "@/components/theme-toggle";
-import { LocaleToggle } from "@/components/locale-toggle";
+import { Compass, LayoutDashboard, type LucideIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
 
 type MobileNavProps = {
   isAuthenticated: boolean;
@@ -23,48 +13,58 @@ type MobileNavProps = {
 export function MobileNav({ isAuthenticated, dashboardHref = "/dashboard" }: MobileNavProps) {
   const tExplorer = useTranslations("Explorer");
   const tDashboard = useTranslations("Dashboard");
-  const tAuth = useTranslations("Auth");
   const pathname = usePathname();
-  const fullPathname = useFullPathname();
 
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button variant="ghost" size="sm" className="md:hidden">
-          <Menu className="size-5" />
-          <span className="sr-only">Menu</span>
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-48">
-        {isAuthenticated ? (
-          <>
-            <DropdownMenuItem asChild>
-              <Link href="/explorer" className={`cursor-pointer ${pathname.startsWith("/explorer") ? "text-foreground font-medium" : ""}`}>
-                <Compass className="mr-2 size-4" />
-                {tExplorer("navLink")}
-              </Link>
-            </DropdownMenuItem>
-            <DropdownMenuItem asChild>
-              <Link href={dashboardHref} className={`cursor-pointer ${pathname.startsWith("/dashboard") ? "text-foreground font-medium" : ""}`}>
-                <LayoutDashboard className="mr-2 size-4" />
-                {tDashboard("title")}
-              </Link>
-            </DropdownMenuItem>
-          </>
-        ) : (
-          <DropdownMenuItem asChild>
-            <Link href={`/auth/sign-in?callbackUrl=${encodeURIComponent(fullPathname)}`} className="cursor-pointer">
-              <LogIn className="mr-2 size-4" />
-              {tAuth("signIn.title")}
-            </Link>
-          </DropdownMenuItem>
-        )}
-        <DropdownMenuSeparator />
-        <div className="flex items-center justify-between px-2 py-1.5">
-          <LocaleToggle />
-          <ThemeToggle />
-        </div>
-      </DropdownMenuContent>
-    </DropdownMenu>
+    <nav className="flex flex-1 items-center justify-center gap-1 md:hidden">
+      <MobileNavItem
+        href="/explorer"
+        icon={Compass}
+        label={tExplorer("navLink")}
+        active={pathname.startsWith("/explorer")}
+      />
+      {isAuthenticated && (
+        <MobileNavItem
+          href={dashboardHref}
+          icon={LayoutDashboard}
+          label={tDashboard("title")}
+          active={pathname.startsWith("/dashboard")}
+        />
+      )}
+    </nav>
+  );
+}
+
+function MobileNavItem({
+  href,
+  icon: Icon,
+  label,
+  active,
+}: {
+  href: string;
+  icon: LucideIcon;
+  label: string;
+  active: boolean;
+}) {
+  return (
+    <Link
+      href={href}
+      aria-label={label}
+      aria-current={active ? "page" : undefined}
+      className={cn(
+        "relative flex size-11 items-center justify-center rounded-md transition-colors",
+        active
+          ? "text-foreground"
+          : "text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+      )}
+    >
+      <Icon className="size-5" />
+      {active && (
+        <span
+          aria-hidden
+          className="bg-primary absolute bottom-1.5 size-1 rounded-full"
+        />
+      )}
+    </Link>
   );
 }

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -10,7 +10,7 @@ import { ThemeToggle } from "@/components/theme-toggle";
 import { LocaleToggle } from "@/components/locale-toggle";
 import { UserMenu } from "@/components/user-menu";
 import { MobileNav } from "@/components/mobile-nav";
-import { Compass, LayoutDashboard } from "lucide-react";
+import { Compass, LayoutDashboard, LogIn } from "lucide-react";
 
 export function SiteHeader() {
   const { data: session } = useSession();
@@ -31,6 +31,8 @@ export function SiteHeader() {
     );
   }, []);
 
+  const signInHref = `/auth/sign-in?callbackUrl=${encodeURIComponent(fullPathname)}`;
+
   return (
     <header className="sticky top-0 z-50 border-b border-border/40 bg-background/80 backdrop-blur-sm">
       <div className="mx-auto flex h-14 max-w-5xl items-center px-4">
@@ -41,10 +43,10 @@ export function SiteHeader() {
               <polygon points="0,0 0,12 10,6" fill="white" />
             </svg>
           </div>
-          <span className="text-[15px] font-extrabold tracking-[-0.4px]">the&thinsp;<span className="text-primary">playground</span></span>
+          <span className="hidden text-[15px] font-extrabold tracking-[-0.4px] md:inline">the&thinsp;<span className="text-primary">playground</span></span>
         </Link>
 
-        {/* Nav — center (desktop only) */}
+        {/* Nav — center (desktop) */}
         <nav className="hidden flex-1 items-center justify-center gap-6 md:flex">
           <Link
             href="/explorer"
@@ -64,8 +66,8 @@ export function SiteHeader() {
           )}
         </nav>
 
-        {/* Spacer for mobile (pushes actions to the right) */}
-        <div className="flex-1 md:hidden" />
+        {/* Nav — center (mobile) */}
+        <MobileNav isAuthenticated={!!user} dashboardHref={dashboardHref} />
 
         {/* Actions — right */}
         <div className="flex shrink-0 items-center gap-2">
@@ -76,11 +78,17 @@ export function SiteHeader() {
           {user ? (
             <UserMenu user={user} />
           ) : (
-            <Button variant="ghost" size="sm" asChild className="hidden md:inline-flex">
-              <Link href={`/auth/sign-in?callbackUrl=${encodeURIComponent(fullPathname)}`}>{t("signIn.title")}</Link>
-            </Button>
+            <>
+              <Button variant="ghost" size="sm" asChild className="hidden md:inline-flex">
+                <Link href={signInHref}>{t("signIn.title")}</Link>
+              </Button>
+              <Button variant="ghost" size="icon" asChild className="md:hidden">
+                <Link href={signInHref} aria-label={t("signIn.title")}>
+                  <LogIn className="size-5" />
+                </Link>
+              </Button>
+            </>
           )}
-          <MobileNav isAuthenticated={!!user} dashboardHref={dashboardHref} />
         </div>
       </div>
     </header>

--- a/src/components/user-menu.tsx
+++ b/src/components/user-menu.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useTransition } from "react";
+import { useEffect, useState } from "react";
 import {
   ChevronDown,
   Compass,
@@ -13,14 +13,14 @@ import {
   User,
   type LucideIcon,
 } from "lucide-react";
-import { useLocale, useTranslations } from "next-intl";
+import { useTranslations } from "next-intl";
 import { useTheme } from "next-themes";
 import { signOut } from "next-auth/react";
-import { Link, usePathname, useRouter } from "@/i18n/navigation";
-import { routing } from "@/i18n/routing";
+import { Link } from "@/i18n/navigation";
 import {
   DropdownMenu,
   DropdownMenuContent,
+  DropdownMenuGroup,
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
@@ -28,6 +28,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { UserAvatar } from "@/components/user-avatar";
 import { cn } from "@/lib/utils";
+import { useLocaleSwitcher } from "@/lib/use-locale-switcher";
 
 type UserMenuProps = {
   user: {
@@ -85,10 +86,10 @@ export function UserMenu({ user }: UserMenuProps) {
             </Link>
           </DropdownMenuItem>
         )}
-        <div className="md:hidden">
-          <DropdownMenuSeparator />
+        <DropdownMenuSeparator className="md:hidden" />
+        <DropdownMenuGroup className="md:hidden">
           <PreferencesBlock />
-        </div>
+        </DropdownMenuGroup>
         <DropdownMenuSeparator />
         <DropdownMenuItem
           className="cursor-pointer"
@@ -109,10 +110,10 @@ function PreferencesBlock() {
   return (
     <>
       <PreferenceRow icon={Globe} label={t("language")}>
-        <LocaleSegmented />
+        <LocaleSegmented ariaLabel={t("language")} />
       </PreferenceRow>
       <PreferenceRow icon={Sun} label={t("theme")}>
-        <ThemeSegmented lightLabel={t("light")} darkLabel={t("dark")} />
+        <ThemeSegmented ariaLabel={t("theme")} />
       </PreferenceRow>
     </>
   );
@@ -138,25 +139,16 @@ function PreferenceRow({
   );
 }
 
-function LocaleSegmented() {
-  const locale = useLocale();
-  const router = useRouter();
-  const pathname = usePathname();
-  const [isPending, startTransition] = useTransition();
-
+function LocaleSegmented({ ariaLabel }: { ariaLabel: string }) {
+  const { locale, locales, switchLocale, isPending } = useLocaleSwitcher();
   return (
-    <SegmentedGroup ariaLabel="Locale">
-      {routing.locales.map((l) => (
+    <SegmentedGroup ariaLabel={ariaLabel}>
+      {locales.map((l) => (
         <SegmentedButton
           key={l}
           active={l === locale}
           disabled={isPending}
-          onClick={() => {
-            if (l === locale) return;
-            startTransition(() => {
-              router.replace(pathname, { locale: l });
-            });
-          }}
+          onClick={() => switchLocale(l)}
         >
           {l.toUpperCase()}
         </SegmentedButton>
@@ -165,7 +157,8 @@ function LocaleSegmented() {
   );
 }
 
-function ThemeSegmented({ lightLabel, darkLabel }: { lightLabel: string; darkLabel: string }) {
+function ThemeSegmented({ ariaLabel }: { ariaLabel: string }) {
+  const t = useTranslations("UserMenu.preferences");
   const { theme, setTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
 
@@ -176,17 +169,17 @@ function ThemeSegmented({ lightLabel, darkLabel }: { lightLabel: string; darkLab
   const current = mounted ? theme : undefined;
 
   return (
-    <SegmentedGroup ariaLabel="Theme">
+    <SegmentedGroup ariaLabel={ariaLabel}>
       <SegmentedButton
         active={current === "light"}
-        ariaLabel={lightLabel}
+        ariaLabel={t("light")}
         onClick={() => setTheme("light")}
       >
         <Sun className="size-3.5" />
       </SegmentedButton>
       <SegmentedButton
         active={current === "dark"}
-        ariaLabel={darkLabel}
+        ariaLabel={t("dark")}
         onClick={() => setTheme("dark")}
       >
         <Moon className="size-3.5" />

--- a/src/components/user-menu.tsx
+++ b/src/components/user-menu.tsx
@@ -1,9 +1,23 @@
 "use client";
 
-import { LayoutDashboard, LogOut, User, Shield } from "lucide-react";
-import { useTranslations } from "next-intl";
-import { Link } from "@/i18n/navigation";
+import { useEffect, useState, useTransition } from "react";
+import {
+  ChevronDown,
+  Compass,
+  Globe,
+  LayoutDashboard,
+  LogOut,
+  Moon,
+  Shield,
+  Sun,
+  User,
+  type LucideIcon,
+} from "lucide-react";
+import { useLocale, useTranslations } from "next-intl";
+import { useTheme } from "next-themes";
 import { signOut } from "next-auth/react";
+import { Link, usePathname, useRouter } from "@/i18n/navigation";
+import { routing } from "@/i18n/routing";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -13,7 +27,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { UserAvatar } from "@/components/user-avatar";
-import { ChevronDown } from "lucide-react";
+import { cn } from "@/lib/utils";
 
 type UserMenuProps = {
   user: {
@@ -26,6 +40,7 @@ type UserMenuProps = {
 
 export function UserMenu({ user }: UserMenuProps) {
   const t = useTranslations("UserMenu");
+  const tExplorer = useTranslations("Explorer");
   const email = user.email ?? "";
 
   return (
@@ -34,7 +49,7 @@ export function UserMenu({ user }: UserMenuProps) {
         <UserAvatar name={user.name} email={email} image={user.image} size="sm" />
         <ChevronDown className="text-muted-foreground h-3.5 w-3.5" />
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-56">
+      <DropdownMenuContent align="end" className="w-60">
         <DropdownMenuLabel className="font-normal">
           <div className="flex flex-col gap-1">
             {user.name && (
@@ -44,6 +59,12 @@ export function UserMenu({ user }: UserMenuProps) {
           </div>
         </DropdownMenuLabel>
         <DropdownMenuSeparator />
+        <DropdownMenuItem asChild className="md:hidden">
+          <Link href="/explorer" className="cursor-pointer">
+            <Compass className="mr-2 h-4 w-4" />
+            {tExplorer("navLink")}
+          </Link>
+        </DropdownMenuItem>
         <DropdownMenuItem asChild>
           <Link href="/dashboard" className="cursor-pointer">
             <LayoutDashboard className="mr-2 h-4 w-4" />
@@ -64,6 +85,10 @@ export function UserMenu({ user }: UserMenuProps) {
             </Link>
           </DropdownMenuItem>
         )}
+        <div className="md:hidden">
+          <DropdownMenuSeparator />
+          <PreferencesBlock />
+        </div>
         <DropdownMenuSeparator />
         <DropdownMenuItem
           className="cursor-pointer"
@@ -76,5 +101,147 @@ export function UserMenu({ user }: UserMenuProps) {
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
+  );
+}
+
+function PreferencesBlock() {
+  const t = useTranslations("UserMenu.preferences");
+  return (
+    <>
+      <PreferenceRow icon={Globe} label={t("language")}>
+        <LocaleSegmented />
+      </PreferenceRow>
+      <PreferenceRow icon={Sun} label={t("theme")}>
+        <ThemeSegmented lightLabel={t("light")} darkLabel={t("dark")} />
+      </PreferenceRow>
+    </>
+  );
+}
+
+function PreferenceRow({
+  icon: Icon,
+  label,
+  children,
+}: {
+  icon: LucideIcon;
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-2 px-2 py-1.5">
+      <span className="flex items-center gap-2 text-sm">
+        <Icon className="text-muted-foreground size-4" />
+        {label}
+      </span>
+      {children}
+    </div>
+  );
+}
+
+function LocaleSegmented() {
+  const locale = useLocale();
+  const router = useRouter();
+  const pathname = usePathname();
+  const [isPending, startTransition] = useTransition();
+
+  return (
+    <SegmentedGroup ariaLabel="Locale">
+      {routing.locales.map((l) => (
+        <SegmentedButton
+          key={l}
+          active={l === locale}
+          disabled={isPending}
+          onClick={() => {
+            if (l === locale) return;
+            startTransition(() => {
+              router.replace(pathname, { locale: l });
+            });
+          }}
+        >
+          {l.toUpperCase()}
+        </SegmentedButton>
+      ))}
+    </SegmentedGroup>
+  );
+}
+
+function ThemeSegmented({ lightLabel, darkLabel }: { lightLabel: string; darkLabel: string }) {
+  const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const current = mounted ? theme : undefined;
+
+  return (
+    <SegmentedGroup ariaLabel="Theme">
+      <SegmentedButton
+        active={current === "light"}
+        ariaLabel={lightLabel}
+        onClick={() => setTheme("light")}
+      >
+        <Sun className="size-3.5" />
+      </SegmentedButton>
+      <SegmentedButton
+        active={current === "dark"}
+        ariaLabel={darkLabel}
+        onClick={() => setTheme("dark")}
+      >
+        <Moon className="size-3.5" />
+      </SegmentedButton>
+    </SegmentedGroup>
+  );
+}
+
+function SegmentedGroup({
+  ariaLabel,
+  children,
+}: {
+  ariaLabel: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      role="group"
+      aria-label={ariaLabel}
+      className="border-border bg-muted inline-flex items-center rounded-md border p-0.5"
+    >
+      {children}
+    </div>
+  );
+}
+
+function SegmentedButton({
+  active,
+  disabled,
+  ariaLabel,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  disabled?: boolean;
+  ariaLabel?: string;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={ariaLabel}
+      aria-pressed={active}
+      disabled={disabled}
+      onClick={onClick}
+      className={cn(
+        "inline-flex h-6 min-w-7 items-center justify-center rounded-sm px-2 text-xs font-medium transition-colors",
+        active
+          ? "bg-card text-foreground shadow-sm"
+          : "text-muted-foreground hover:text-foreground",
+        disabled && "opacity-50"
+      )}
+    >
+      {children}
+    </button>
   );
 }

--- a/src/lib/use-locale-switcher.ts
+++ b/src/lib/use-locale-switcher.ts
@@ -1,0 +1,27 @@
+"use client";
+
+import { useLocale } from "next-intl";
+import { useTransition } from "react";
+import { usePathname, useRouter } from "@/i18n/navigation";
+import { routing } from "@/i18n/routing";
+
+export function useLocaleSwitcher() {
+  const locale = useLocale();
+  const router = useRouter();
+  const pathname = usePathname();
+  const [isPending, startTransition] = useTransition();
+
+  function switchLocale(nextLocale: string) {
+    if (nextLocale === locale) return;
+    startTransition(() => {
+      router.replace(pathname, { locale: nextLocale });
+    });
+  }
+
+  return {
+    locale,
+    locales: routing.locales,
+    switchLocale,
+    isPending,
+  };
+}


### PR DESCRIPTION
## Summary
- Replaces the mobile hamburger menu with an inline icon row matching the desktop nav (Compass, Dashboard), with a pink-dot indicator for the active route
- Mobile UserMenu dropdown now embeds the Language and Theme controls as segmented switches inside a `Preferences` block (visible only `<md`)
- Header polish: wordmark hidden on mobile, dedicated `LogIn` icon button for unauthenticated mobile users
- Broadens the dashboard greeting subtitle so it reflects the personal-space scope (events + communities), not just communities
- Refactor: new `useLocaleSwitcher` hook shared between `LocaleToggle` and the new `LocaleSegmented`

Closes #454

## Test plan
- [ ] Mobile authenticated — verify Compass + Dashboard icons visible, active route shows pink dot
- [ ] Mobile authenticated — open avatar dropdown, confirm Explorer entry, Language FR/EN segmented, Theme sun/moon segmented all work without closing the menu
- [ ] Mobile unauthenticated — confirm Compass icon + LogIn icon, no wordmark
- [ ] Desktop — verify the dropdown does NOT show the Explorer entry nor the Preferences block (`md:hidden`)
- [ ] Switch locale from the avatar dropdown on mobile, confirm the menu closes/reloads correctly
- [ ] Switch theme from the avatar dropdown on mobile, confirm dark/light applies without hydration mismatch
- [ ] Dashboard `/dashboard` — verify the new greeting subtitle in FR and EN

🤖 Generated with [Claude Code](https://claude.com/claude-code)