### PR TITLE
fix: keep shared dashboard event links inside the funnel

### DIFF
--- a/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/moments/[momentSlug]/edit/page.tsx
+++ b/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/moments/[momentSlug]/edit/page.tsx
@@ -1,4 +1,4 @@
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 import {
   prismaCircleRepository,
@@ -6,6 +6,9 @@ import {
   prismaRegistrationRepository,
   prismaMomentAttachmentRepository,
 } from "@/infrastructure/repositories";
+import { getCachedSession } from "@/lib/auth-cache";
+import { resolveCircleRepository } from "@/lib/admin-host-mode";
+import { isActiveOrganizer } from "@/domain/models/circle";
 import { getCircleBySlug } from "@/domain/usecases/get-circle";
 import { getMomentBySlug } from "@/domain/usecases/get-moment";
 import { CircleNotFoundError, MomentNotFoundError } from "@/domain/errors";
@@ -46,7 +49,20 @@ export default async function EditMomentPage({
   }
 
   if (moment.circleId !== circle.id) {
-    notFound();
+    redirect(`/m/${moment.slug}`);
+  }
+
+  // Only an active Organizer of the Circle may edit. Anyone else (member,
+  // attendee, or unrelated user) is bounced to the public event page —
+  // same UX as the detail view, no dead-end 404 on a shared dashboard link.
+  const session = await getCachedSession();
+  if (!session?.user?.id) {
+    redirect(`/m/${moment.slug}`);
+  }
+  const circleRepo = await resolveCircleRepository(session, prismaCircleRepository);
+  const membership = await circleRepo.findMembership(circle.id, session.user.id);
+  if (!isActiveOrganizer(membership)) {
+    redirect(`/m/${moment.slug}`);
   }
 
   const boundAction = updateMomentAction.bind(null, moment.id);

--- a/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/moments/[momentSlug]/edit/page.tsx
+++ b/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/moments/[momentSlug]/edit/page.tsx
@@ -1,4 +1,4 @@
-import { notFound, redirect } from "next/navigation";
+import { notFound } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 import {
   prismaCircleRepository,
@@ -9,6 +9,7 @@ import {
 import { getCachedSession } from "@/lib/auth-cache";
 import { resolveCircleRepository } from "@/lib/admin-host-mode";
 import { isActiveOrganizer } from "@/domain/models/circle";
+import { redirectToPublicMoment } from "@/lib/dashboard-event-public-redirect";
 import { getCircleBySlug } from "@/domain/usecases/get-circle";
 import { getMomentBySlug } from "@/domain/usecases/get-moment";
 import { CircleNotFoundError, MomentNotFoundError } from "@/domain/errors";
@@ -48,33 +49,26 @@ export default async function EditMomentPage({
     throw error;
   }
 
-  if (moment.circleId !== circle.id) {
-    redirect(`/m/${moment.slug}`);
-  }
+  if (moment.circleId !== circle.id) redirectToPublicMoment(moment.slug);
 
-  // Only an active Organizer of the Circle may edit. Anyone else (member,
-  // attendee, or unrelated user) is bounced to the public event page —
-  // same UX as the detail view, no dead-end 404 on a shared dashboard link.
   const session = await getCachedSession();
-  if (!session?.user?.id) {
-    redirect(`/m/${moment.slug}`);
-  }
+  if (!session?.user?.id) redirectToPublicMoment(moment.slug);
+
   const circleRepo = await resolveCircleRepository(session, prismaCircleRepository);
-  const membership = await circleRepo.findMembership(circle.id, session.user.id);
-  if (!isActiveOrganizer(membership)) {
-    redirect(`/m/${moment.slug}`);
-  }
+
+  // Price lock excludes the host auto-registration (which doesn't count as paid).
+  const [membership, paymentSummary, initialAttachments] = await Promise.all([
+    circleRepo.findMembership(circle.id, session.user.id),
+    moment.price > 0
+      ? prismaRegistrationRepository.getPaymentSummary(moment.id)
+      : Promise.resolve(null),
+    prismaMomentAttachmentRepository.findByMoment(moment.id),
+  ]);
+
+  if (!isActiveOrganizer(membership)) redirectToPublicMoment(moment.slug);
 
   const boundAction = updateMomentAction.bind(null, moment.id);
-
-  // Check if price is locked (paid event with paid registrations — excludes host auto-registration)
-  let priceLocked = false;
-  if (moment.price > 0) {
-    const { paidCount } = await prismaRegistrationRepository.getPaymentSummary(moment.id);
-    priceLocked = paidCount > 0;
-  }
-
-  const initialAttachments = await prismaMomentAttachmentRepository.findByMoment(moment.id);
+  const priceLocked = (paymentSummary?.paidCount ?? 0) > 0;
 
   const tDashboard = await getTranslations("Dashboard");
   const tCommon = await getTranslations("Common");

--- a/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/moments/[momentSlug]/page.tsx
+++ b/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/moments/[momentSlug]/page.tsx
@@ -1,4 +1,4 @@
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import {
   prismaCircleRepository,
   prismaMomentRepository,
@@ -39,7 +39,9 @@ export default async function MomentDetailPage({
     throw error;
   }
 
-  if (moment.circleId !== circle.id) notFound();
+  // Mismatch between Circle in URL and the event's actual Circle — treat as a
+  // malformed share link and send the visitor to the public event page.
+  if (moment.circleId !== circle.id) redirect(`/m/${moment.slug}`);
 
   const circleRepo = await resolveCircleRepository(session, prismaCircleRepository);
 
@@ -50,10 +52,13 @@ export default async function MomentDetailPage({
     prismaRegistrationRepository.findByMomentAndUser(moment.id, session.user.id),
   ]);
 
-  // Accès autorisé si : membre ACTIVE du Circle OU inscrit à l'événement
+  // Accès autorisé si : membre ACTIVE du Circle OU inscrit à l'événement.
+  // Sinon, on bascule le visiteur sur la page publique pour qu'il garde une
+  // vue de l'événement au lieu de prendre un 404 (cas typique : lien dashboard
+  // partagé à quelqu'un qui n'est pas dans la Communauté).
   const hasActiveMembership = membership?.status === "ACTIVE";
   const hasActiveRegistration = userRegistration && userRegistration.status !== "CANCELLED" && userRegistration.status !== "REJECTED";
-  if (!hasActiveMembership && !hasActiveRegistration) notFound();
+  if (!hasActiveMembership && !hasActiveRegistration) redirect(`/m/${moment.slug}`);
 
   const isOrganizer = isActiveOrganizer(membership);
 

--- a/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/moments/[momentSlug]/page.tsx
+++ b/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/moments/[momentSlug]/page.tsx
@@ -1,4 +1,4 @@
-import { notFound, redirect } from "next/navigation";
+import { notFound } from "next/navigation";
 import {
   prismaCircleRepository,
   prismaMomentRepository,
@@ -14,6 +14,7 @@ import { CircleNotFoundError, MomentNotFoundError } from "@/domain/errors";
 import { MomentDetailView } from "@/components/moments/moment-detail-view";
 import { resolveCircleRepository } from "@/lib/admin-host-mode";
 import { isActiveOrganizer } from "@/domain/models/circle";
+import { redirectToPublicMoment } from "@/lib/dashboard-event-public-redirect";
 import { promoteCurrentUserFirst } from "@/lib/sort-participants";
 
 export default async function MomentDetailPage({
@@ -39,9 +40,7 @@ export default async function MomentDetailPage({
     throw error;
   }
 
-  // Mismatch between Circle in URL and the event's actual Circle — treat as a
-  // malformed share link and send the visitor to the public event page.
-  if (moment.circleId !== circle.id) redirect(`/m/${moment.slug}`);
+  if (moment.circleId !== circle.id) redirectToPublicMoment(moment.slug);
 
   const circleRepo = await resolveCircleRepository(session, prismaCircleRepository);
 
@@ -52,13 +51,11 @@ export default async function MomentDetailPage({
     prismaRegistrationRepository.findByMomentAndUser(moment.id, session.user.id),
   ]);
 
-  // Accès autorisé si : membre ACTIVE du Circle OU inscrit à l'événement.
-  // Sinon, on bascule le visiteur sur la page publique pour qu'il garde une
-  // vue de l'événement au lieu de prendre un 404 (cas typique : lien dashboard
-  // partagé à quelqu'un qui n'est pas dans la Communauté).
+  // Access granted to active Circle members or anyone with a live registration;
+  // others go to the public event page instead of a dead-end 404.
   const hasActiveMembership = membership?.status === "ACTIVE";
   const hasActiveRegistration = userRegistration && userRegistration.status !== "CANCELLED" && userRegistration.status !== "REJECTED";
-  if (!hasActiveMembership && !hasActiveRegistration) redirect(`/m/${moment.slug}`);
+  if (!hasActiveMembership && !hasActiveRegistration) redirectToPublicMoment(moment.slug);
 
   const isOrganizer = isActiveOrganizer(membership);
 

--- a/src/lib/__tests__/dashboard-event-public-redirect.test.ts
+++ b/src/lib/__tests__/dashboard-event-public-redirect.test.ts
@@ -49,6 +49,18 @@ describe("dashboardEventPublicPath", () => {
     });
   });
 
+  describe("reserved moment segments", () => {
+    // /dashboard/circles/[slug]/moments/new is the event creation page,
+    // not an event slug — must keep its normal auth redirect.
+    it.each([
+      "/dashboard/circles/the-spark/moments/new",
+      "/fr/dashboard/circles/the-spark/moments/new",
+      "/en/dashboard/circles/the-spark/moments/new",
+    ])("should return null for %s (reserved segment)", (input) => {
+      expect(dashboardEventPublicPath(input)).toBe(null);
+    });
+  });
+
   describe("invalid moment slug", () => {
     it.each([
       "/dashboard/circles/the-spark/moments/UPPERCASE",

--- a/src/lib/__tests__/dashboard-event-public-redirect.test.ts
+++ b/src/lib/__tests__/dashboard-event-public-redirect.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { dashboardEventPublicPath } from "@/lib/dashboard-event-public-redirect";
+
+describe("dashboardEventPublicPath", () => {
+  describe("matching dashboard event URLs", () => {
+    it.each([
+      [
+        "/dashboard/circles/the-spark/moments/soiree-js",
+        "/m/soiree-js",
+      ],
+      [
+        "/fr/dashboard/circles/the-spark/moments/soiree-js",
+        "/fr/m/soiree-js",
+      ],
+      [
+        "/en/dashboard/circles/the-spark/moments/soiree-js",
+        "/en/m/soiree-js",
+      ],
+      [
+        "/dashboard/circles/the-spark/moments/soiree-js/edit",
+        "/m/soiree-js",
+      ],
+      [
+        "/en/dashboard/circles/the-spark/moments/soiree-js/edit",
+        "/en/m/soiree-js",
+      ],
+      [
+        "/dashboard/circles/the-spark/moments/event-with-many-words-123",
+        "/m/event-with-many-words-123",
+      ],
+    ])("should resolve %s → %s", (input, expected) => {
+      expect(dashboardEventPublicPath(input)).toBe(expected);
+    });
+  });
+
+  describe("URLs that must not be redirected", () => {
+    it.each([
+      "/dashboard",
+      "/dashboard/circles",
+      "/dashboard/circles/the-spark",
+      "/dashboard/circles/the-spark/moments",
+      "/fr/dashboard",
+      "/auth/sign-in",
+      "/m/soiree-js",
+      "/circles/the-spark",
+      "/",
+    ])("should return null for %s", (input) => {
+      expect(dashboardEventPublicPath(input)).toBe(null);
+    });
+  });
+
+  describe("invalid moment slug", () => {
+    it.each([
+      "/dashboard/circles/the-spark/moments/UPPERCASE",
+      "/dashboard/circles/the-spark/moments/has--double-dash",
+      "/dashboard/circles/the-spark/moments/-leading-dash",
+    ])("should return null for invalid slug in %s", (input) => {
+      expect(dashboardEventPublicPath(input)).toBe(null);
+    });
+  });
+});

--- a/src/lib/dashboard-event-public-redirect.ts
+++ b/src/lib/dashboard-event-public-redirect.ts
@@ -1,3 +1,4 @@
+import { redirect } from "next/navigation";
 import { routing } from "@/i18n/routing";
 import { isValidSlug } from "./slug";
 
@@ -6,18 +7,20 @@ const dashboardEventRe = new RegExp(
   `^(?:/(${localeAlt}))?/dashboard/circles/[^/]+/moments/([^/]+)(?:/.*)?$`
 );
 
-// Reserved segments under /dashboard/circles/[slug]/moments/ that are not
-// event slugs (e.g. /moments/new is the creation page).
+// `/moments/new` is the creation route, not an event slug.
 const RESERVED_MOMENT_SEGMENTS = new Set(["new"]);
 
-/**
- * If `pathname` targets a dashboard event view, returns the matching public
- * `/m/[slug]` pathname (locale preserved). Returns `null` otherwise.
- *
- * Used by the middleware to bounce unauthenticated visitors from a shared
- * dashboard link to the public event page, so they stay in the funnel
- * instead of hitting the sign-in screen.
- */
+/** Pathname of the public event page for a given moment slug. */
+export function publicMomentPath(slug: string): string {
+  return `/m/${slug}`;
+}
+
+/** Server-side redirect to the public event page (throws NEXT_REDIRECT). */
+export function redirectToPublicMoment(slug: string): never {
+  redirect(publicMomentPath(slug));
+}
+
+/** Maps a dashboard event pathname to its public `/m/[slug]` equivalent. */
 export function dashboardEventPublicPath(pathname: string): string | null {
   const match = pathname.match(dashboardEventRe);
   if (!match) return null;
@@ -27,5 +30,5 @@ export function dashboardEventPublicPath(pathname: string): string | null {
   if (RESERVED_MOMENT_SEGMENTS.has(momentSlug)) return null;
   if (!isValidSlug(momentSlug)) return null;
 
-  return `${locale ? `/${locale}` : ""}/m/${momentSlug}`;
+  return `${locale ? `/${locale}` : ""}${publicMomentPath(momentSlug)}`;
 }

--- a/src/lib/dashboard-event-public-redirect.ts
+++ b/src/lib/dashboard-event-public-redirect.ts
@@ -6,6 +6,10 @@ const dashboardEventRe = new RegExp(
   `^(?:/(${localeAlt}))?/dashboard/circles/[^/]+/moments/([^/]+)(?:/.*)?$`
 );
 
+// Reserved segments under /dashboard/circles/[slug]/moments/ that are not
+// event slugs (e.g. /moments/new is the creation page).
+const RESERVED_MOMENT_SEGMENTS = new Set(["new"]);
+
 /**
  * If `pathname` targets a dashboard event view, returns the matching public
  * `/m/[slug]` pathname (locale preserved). Returns `null` otherwise.
@@ -20,6 +24,7 @@ export function dashboardEventPublicPath(pathname: string): string | null {
 
   const locale = match[1];
   const momentSlug = decodeURIComponent(match[2]);
+  if (RESERVED_MOMENT_SEGMENTS.has(momentSlug)) return null;
   if (!isValidSlug(momentSlug)) return null;
 
   return `${locale ? `/${locale}` : ""}/m/${momentSlug}`;

--- a/src/lib/dashboard-event-public-redirect.ts
+++ b/src/lib/dashboard-event-public-redirect.ts
@@ -1,0 +1,26 @@
+import { routing } from "@/i18n/routing";
+import { isValidSlug } from "./slug";
+
+const localeAlt = routing.locales.join("|");
+const dashboardEventRe = new RegExp(
+  `^(?:/(${localeAlt}))?/dashboard/circles/[^/]+/moments/([^/]+)(?:/.*)?$`
+);
+
+/**
+ * If `pathname` targets a dashboard event view, returns the matching public
+ * `/m/[slug]` pathname (locale preserved). Returns `null` otherwise.
+ *
+ * Used by the middleware to bounce unauthenticated visitors from a shared
+ * dashboard link to the public event page, so they stay in the funnel
+ * instead of hitting the sign-in screen.
+ */
+export function dashboardEventPublicPath(pathname: string): string | null {
+  const match = pathname.match(dashboardEventRe);
+  if (!match) return null;
+
+  const locale = match[1];
+  const momentSlug = decodeURIComponent(match[2]);
+  if (!isValidSlug(momentSlug)) return null;
+
+  return `${locale ? `/${locale}` : ""}/m/${momentSlug}`;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -60,16 +60,13 @@ export default function middleware(request: NextRequest) {
     }
   }
 
-  // 4. Bounce unauthenticated visitors from a shared dashboard event link
-  // to the public event page, so they stay in the funnel instead of hitting
-  // sign-in and dropping off.
-  if (!hasSessionCookie(request)) {
-    const publicPath = dashboardEventPublicPath(request.nextUrl.pathname);
-    if (publicPath) {
-      const url = request.nextUrl.clone();
-      url.pathname = publicPath;
-      return NextResponse.redirect(url);
-    }
+  // 4. Bounce shared dashboard event links to the public page for visitors
+  // without a session, so they stay in the funnel instead of hitting sign-in.
+  const dashboardEventPath = dashboardEventPublicPath(request.nextUrl.pathname);
+  if (dashboardEventPath && !hasSessionCookie(request)) {
+    const url = request.nextUrl.clone();
+    url.pathname = dashboardEventPath;
+    return NextResponse.redirect(url);
   }
 
   // 5. Delegate to next-intl middleware

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,6 +4,19 @@ import createMiddleware from "next-intl/middleware";
 import { routing } from "./i18n/routing";
 import { isValidSlug } from "./lib/slug";
 import { BLOCKED_BOTS } from "./lib/blocked-bots";
+import { dashboardEventPublicPath } from "./lib/dashboard-event-public-redirect";
+
+// Auth.js v5 stores the session under `authjs.session-token` (HTTP) or
+// `__Secure-authjs.session-token` (HTTPS). Presence-only check — middleware
+// stays edge-friendly and the dashboard layout still validates the session.
+const SESSION_COOKIE_NAMES = [
+  "authjs.session-token",
+  "__Secure-authjs.session-token",
+];
+
+function hasSessionCookie(request: NextRequest): boolean {
+  return SESSION_COOKIE_NAMES.some((name) => request.cookies.has(name));
+}
 
 const intlMiddleware = createMiddleware(routing);
 
@@ -47,7 +60,20 @@ export default function middleware(request: NextRequest) {
     }
   }
 
-  // 4. Delegate to next-intl middleware
+  // 4. Bounce unauthenticated visitors from a shared dashboard event link
+  // to the public event page, so they stay in the funnel instead of hitting
+  // sign-in and dropping off.
+  if (!hasSessionCookie(request)) {
+    const publicPath = dashboardEventPublicPath(request.nextUrl.pathname);
+    if (publicPath) {
+      const url = request.nextUrl.clone();
+      url.pathname = publicPath;
+      url.search = "";
+      return NextResponse.redirect(url);
+    }
+  }
+
+  // 5. Delegate to next-intl middleware
   return intlMiddleware(request);
 }
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -68,7 +68,6 @@ export default function middleware(request: NextRequest) {
     if (publicPath) {
       const url = request.nextUrl.clone();
       url.pathname = publicPath;
-      url.search = "";
       return NextResponse.redirect(url);
     }
   }

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -1,10 +1,8 @@
 import { test, expect } from "@playwright/test";
 import { SLUGS, AUTH } from "./fixtures";
 
-// PLAYER3 isn't a member of `yoga-montmartre` (seed: only host + player2/4 are
-// registered to its moments), so they're a good fit to exercise the
+// PLAYER3 isn't seeded as a member of yoga-montmartre — used to cover the
 // "authenticated but not in the circle" path.
-const YOGA_CIRCLE = "yoga-montmartre";
 const YOGA_MOMENT = "test-atelier-meditation-mars";
 
 /**
@@ -68,9 +66,6 @@ test.describe("Authentification — accès non authentifié", () => {
   test("should redirect unauthenticated user from a dashboard event URL to its public page", async ({
     page,
   }) => {
-    // Un Organisateur qui partage par erreur l'URL dashboard d'un événement
-    // ne doit pas envoyer le destinataire dans le funnel auth — on le bascule
-    // sur la page publique correspondante.
     await page.goto(
       `/fr/dashboard/circles/${SLUGS.CIRCLE}/moments/${SLUGS.PUBLISHED_MOMENT}`
     );
@@ -87,9 +82,9 @@ test.describe("Authentification — accès dashboard event hors-Communauté", ()
   test("should redirect a logged-in non-member from dashboard event detail to the public page", async ({
     page,
   }) => {
-    // PLAYER3 est connecté mais n'est ni membre de yoga-montmartre ni inscrit
-    // à l'événement — la vue dashboard renverrait 404, on bascule sur public.
-    await page.goto(`/fr/dashboard/circles/${YOGA_CIRCLE}/moments/${YOGA_MOMENT}`);
+    await page.goto(
+      `/fr/dashboard/circles/${SLUGS.PUBLIC_CIRCLE}/moments/${YOGA_MOMENT}`
+    );
     await expect(page).toHaveURL(new RegExp(`/m/${YOGA_MOMENT}$`), {
       timeout: 10_000,
     });
@@ -98,11 +93,8 @@ test.describe("Authentification — accès dashboard event hors-Communauté", ()
   test("should redirect a logged-in non-Host from dashboard event /edit to the public page", async ({
     page,
   }) => {
-    // Même logique pour la page d'édition : seul un Organisateur actif peut
-    // éditer, sinon on renvoie vers la page publique au lieu de laisser
-    // apparaître le formulaire ou un 404.
     await page.goto(
-      `/fr/dashboard/circles/${YOGA_CIRCLE}/moments/${YOGA_MOMENT}/edit`
+      `/fr/dashboard/circles/${SLUGS.PUBLIC_CIRCLE}/moments/${YOGA_MOMENT}/edit`
     );
     await expect(page).toHaveURL(new RegExp(`/m/${YOGA_MOMENT}$`), {
       timeout: 10_000,

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -1,5 +1,11 @@
 import { test, expect } from "@playwright/test";
-import { SLUGS } from "./fixtures";
+import { SLUGS, AUTH } from "./fixtures";
+
+// PLAYER3 isn't a member of `yoga-montmartre` (seed: only host + player2/4 are
+// registered to its moments), so they're a good fit to exercise the
+// "authenticated but not in the circle" path.
+const YOGA_CIRCLE = "yoga-montmartre";
+const YOGA_MOMENT = "test-atelier-meditation-mars";
 
 /**
  * Tests E2E — Authentification
@@ -72,6 +78,35 @@ test.describe("Authentification — accès non authentifié", () => {
       timeout: 10_000,
     });
     await expect(page).not.toHaveURL(/\/auth\/sign-in/);
+  });
+});
+
+test.describe("Authentification — accès dashboard event hors-Communauté", () => {
+  test.use({ storageState: AUTH.PLAYER3 });
+
+  test("should redirect a logged-in non-member from dashboard event detail to the public page", async ({
+    page,
+  }) => {
+    // PLAYER3 est connecté mais n'est ni membre de yoga-montmartre ni inscrit
+    // à l'événement — la vue dashboard renverrait 404, on bascule sur public.
+    await page.goto(`/fr/dashboard/circles/${YOGA_CIRCLE}/moments/${YOGA_MOMENT}`);
+    await expect(page).toHaveURL(new RegExp(`/m/${YOGA_MOMENT}$`), {
+      timeout: 10_000,
+    });
+  });
+
+  test("should redirect a logged-in non-Host from dashboard event /edit to the public page", async ({
+    page,
+  }) => {
+    // Même logique pour la page d'édition : seul un Organisateur actif peut
+    // éditer, sinon on renvoie vers la page publique au lieu de laisser
+    // apparaître le formulaire ou un 404.
+    await page.goto(
+      `/fr/dashboard/circles/${YOGA_CIRCLE}/moments/${YOGA_MOMENT}/edit`
+    );
+    await expect(page).toHaveURL(new RegExp(`/m/${YOGA_MOMENT}$`), {
+      timeout: 10_000,
+    });
   });
 });
 

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -58,6 +58,21 @@ test.describe("Authentification — accès non authentifié", () => {
     expect(response?.status()).not.toBe(302);
     await expect(page).not.toHaveURL(/\/auth\/sign-in/);
   });
+
+  test("should redirect unauthenticated user from a dashboard event URL to its public page", async ({
+    page,
+  }) => {
+    // Un Organisateur qui partage par erreur l'URL dashboard d'un événement
+    // ne doit pas envoyer le destinataire dans le funnel auth — on le bascule
+    // sur la page publique correspondante.
+    await page.goto(
+      `/fr/dashboard/circles/${SLUGS.CIRCLE}/moments/${SLUGS.PUBLISHED_MOMENT}`
+    );
+    await expect(page).toHaveURL(new RegExp(`/m/${SLUGS.PUBLISHED_MOMENT}$`), {
+      timeout: 10_000,
+    });
+    await expect(page).not.toHaveURL(/\/auth\/sign-in/);
+  });
 });
 
 test.describe("Magic link — protection contre les scanners email", () => {


### PR DESCRIPTION
## Summary

When an Organizer shares a dashboard event URL by mistake (instead of the public `/m/[slug]` link), the recipient used to hit a dead-end:
- **Not logged in** → bounced to sign-in, most drop off.
- **Logged in but not a member** of the Circle → 404.

Both cases now redirect to the public event page so the visitor stays in the funnel.

## Changes

- **Middleware (level 1)**: a fast pathname check detects dashboard event URLs and, when no Auth.js session cookie is present, redirects to `/m/[slug]`. Pathname is tested **before** the cookie lookup so the cost is ~zero for the 99% of requests that aren't dashboard events. The reserved `/moments/new` creation route is excluded; query strings are preserved.
- **Dashboard pages (level 2)**: detail and `/edit` pages now redirect non-members to `/m/[slug]` instead of returning `notFound()`. The `/edit` page also gained a proper Host check (it previously rendered the form for any authenticated user — minor security tightening on the way).
- **Helpers**: `dashboardEventPublicPath(pathname)` (pure, fully unit-tested) and `redirectToPublicMoment(slug)` extracted to `src/lib/dashboard-event-public-redirect.ts`.
- **Perf nit**: `/edit` page now parallelizes the membership / payment summary / attachment fetches that don't depend on each other.

Closes #483.

## Test plan

- [ ] Unauthenticated user opens `/fr/dashboard/circles/<circle>/moments/<event>` → lands on `/fr/m/<event>`, sees the public event page, no flash of sign-in.
- [ ] Same path with `?utm_source=email` → query string is preserved through the redirect.
- [ ] Logged-in user who isn't a member of the Circle opens the same URL → redirected to `/m/<event>`.
- [ ] Logged-in user who isn't a member opens `/edit` on the same event → redirected to `/m/<event>` (no form leak).
- [ ] Host of the Circle opens both URLs → normal dashboard view loads, no redirect.
- [ ] Unauthenticated user on `/fr/dashboard/circles/<circle>/moments/new` → still bounced to sign-in (creation route is reserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)