### PR TITLE
fix(seo): canonical per locale + x-default to address Search Console duplicate warning

### DIFF
--- a/src/app/[locale]/(routes)/(static)/about/page.tsx
+++ b/src/app/[locale]/(routes)/(static)/about/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import { getLocale, getTranslations } from "next-intl/server";
-import { getAppUrl } from "@/lib/app-url";
+import { buildAlternates } from "@/lib/seo";
 import {
   CheckIcon,
   Github,
@@ -16,18 +16,11 @@ import {
 } from "lucide-react";
 
 export async function generateMetadata(): Promise<Metadata> {
-  const t = await getTranslations("About");
-  const appUrl = getAppUrl();
+  const [locale, t] = await Promise.all([getLocale(), getTranslations("About")]);
   return {
     title: t("pageTitle"),
     description: t("pageDescription"),
-    alternates: {
-      canonical: `${appUrl}/about`,
-      languages: {
-        fr: `${appUrl}/about`,
-        en: `${appUrl}/en/about`,
-      },
-    },
+    alternates: buildAlternates(locale as "fr" | "en", "/about"),
     openGraph: {
       title: t("pageTitle"),
       description: t("pageDescription"),

--- a/src/app/[locale]/(routes)/(static)/about/page.tsx
+++ b/src/app/[locale]/(routes)/(static)/about/page.tsx
@@ -20,7 +20,7 @@ export async function generateMetadata(): Promise<Metadata> {
   return {
     title: t("pageTitle"),
     description: t("pageDescription"),
-    alternates: buildAlternates(locale as "fr" | "en", "/about"),
+    alternates: buildAlternates(locale, "/about"),
     openGraph: {
       title: t("pageTitle"),
       description: t("pageDescription"),

--- a/src/app/[locale]/(routes)/(static)/changelog/page.tsx
+++ b/src/app/[locale]/(routes)/(static)/changelog/page.tsx
@@ -10,7 +10,7 @@ export async function generateMetadata(): Promise<Metadata> {
   return {
     title: "Changelog · The Playground",
     description: "Les évolutions du Playground, jour après jour.",
-    alternates: buildAlternates(locale as "fr" | "en", "/changelog"),
+    alternates: buildAlternates(locale, "/changelog"),
   };
 }
 

--- a/src/app/[locale]/(routes)/(static)/changelog/page.tsx
+++ b/src/app/[locale]/(routes)/(static)/changelog/page.tsx
@@ -1,20 +1,16 @@
 import type { Metadata } from "next";
+import { getLocale } from "next-intl/server";
 import { getChangelog } from "@/lib/parse-changelog";
+import { buildAlternates } from "@/lib/seo";
 
 export const dynamic = "force-dynamic";
 
 export async function generateMetadata(): Promise<Metadata> {
-  const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
+  const locale = await getLocale();
   return {
     title: "Changelog · The Playground",
     description: "Les évolutions du Playground, jour après jour.",
-    alternates: {
-      canonical: `${appUrl}/changelog`,
-      languages: {
-        fr: `${appUrl}/changelog`,
-        en: `${appUrl}/en/changelog`,
-      },
-    },
+    alternates: buildAlternates(locale as "fr" | "en", "/changelog"),
   };
 }
 

--- a/src/app/[locale]/(routes)/(static)/contact/page.tsx
+++ b/src/app/[locale]/(routes)/(static)/contact/page.tsx
@@ -9,7 +9,7 @@ export async function generateMetadata(): Promise<Metadata> {
   return {
     title: t("pageTitle"),
     description: t("pageDescription"),
-    alternates: buildAlternates(locale as "fr" | "en", "/contact"),
+    alternates: buildAlternates(locale, "/contact"),
     openGraph: {
       title: t("pageTitle"),
       description: t("pageDescription"),

--- a/src/app/[locale]/(routes)/(static)/contact/page.tsx
+++ b/src/app/[locale]/(routes)/(static)/contact/page.tsx
@@ -1,22 +1,15 @@
 import type { Metadata } from "next";
-import { getTranslations } from "next-intl/server";
-import { getAppUrl } from "@/lib/app-url";
+import { getLocale, getTranslations } from "next-intl/server";
 import { Link } from "@/i18n/navigation";
 import { ContactForm } from "@/components/contact/contact-form";
+import { buildAlternates } from "@/lib/seo";
 
 export async function generateMetadata(): Promise<Metadata> {
-  const t = await getTranslations("Contact");
-  const appUrl = getAppUrl();
+  const [locale, t] = await Promise.all([getLocale(), getTranslations("Contact")]);
   return {
     title: t("pageTitle"),
     description: t("pageDescription"),
-    alternates: {
-      canonical: `${appUrl}/contact`,
-      languages: {
-        fr: `${appUrl}/contact`,
-        en: `${appUrl}/en/contact`,
-      },
-    },
+    alternates: buildAlternates(locale as "fr" | "en", "/contact"),
     openGraph: {
       title: t("pageTitle"),
       description: t("pageDescription"),

--- a/src/app/[locale]/(routes)/(static)/help/page.tsx
+++ b/src/app/[locale]/(routes)/(static)/help/page.tsx
@@ -1,22 +1,15 @@
 import type { Metadata } from "next";
-import { getTranslations } from "next-intl/server";
-import { getAppUrl } from "@/lib/app-url";
+import { getLocale, getTranslations } from "next-intl/server";
 import { HelpSidebar } from "@/components/help/help-sidebar";
 import { HelpFaqAccordion } from "@/components/help/help-faq-accordion";
+import { buildAlternates } from "@/lib/seo";
 
 export async function generateMetadata(): Promise<Metadata> {
-  const t = await getTranslations("Help");
-  const appUrl = getAppUrl();
+  const [locale, t] = await Promise.all([getLocale(), getTranslations("Help")]);
   return {
     title: t("meta.title"),
     description: t("meta.description"),
-    alternates: {
-      canonical: `${appUrl}/help`,
-      languages: {
-        fr: `${appUrl}/help`,
-        en: `${appUrl}/en/help`,
-      },
-    },
+    alternates: buildAlternates(locale as "fr" | "en", "/help"),
     openGraph: {
       title: t("meta.title"),
       description: t("meta.description"),

--- a/src/app/[locale]/(routes)/(static)/help/page.tsx
+++ b/src/app/[locale]/(routes)/(static)/help/page.tsx
@@ -9,7 +9,7 @@ export async function generateMetadata(): Promise<Metadata> {
   return {
     title: t("meta.title"),
     description: t("meta.description"),
-    alternates: buildAlternates(locale as "fr" | "en", "/help"),
+    alternates: buildAlternates(locale, "/help"),
     openGraph: {
       title: t("meta.title"),
       description: t("meta.description"),

--- a/src/app/[locale]/(routes)/blog/[slug]/page.tsx
+++ b/src/app/[locale]/(routes)/blog/[slug]/page.tsx
@@ -29,8 +29,7 @@ export async function generateMetadata({
 }: {
   params: Promise<{ slug: string }>;
 }): Promise<Metadata> {
-  const { slug } = await params;
-  const locale = await getLocale();
+  const [{ slug }, locale] = await Promise.all([params, getLocale()]);
   const post = await getPostBySlug(slug, locale);
   if (!post) return {};
 
@@ -38,7 +37,7 @@ export async function generateMetadata({
     title: post.title,
     description: post.description,
     keywords: post.keywords,
-    alternates: buildAlternates(locale as "fr" | "en", `/blog/${slug}`),
+    alternates: buildAlternates(locale, `/blog/${slug}`),
     openGraph: {
       title: post.title,
       description: post.description,

--- a/src/app/[locale]/(routes)/blog/[slug]/page.tsx
+++ b/src/app/[locale]/(routes)/blog/[slug]/page.tsx
@@ -10,6 +10,7 @@ import {
   formatBlogDate,
   estimateReadingTime,
 } from "@/lib/blog";
+import { buildAlternates } from "@/lib/seo";
 import { Button } from "@/components/ui/button";
 
 export async function generateStaticParams() {
@@ -30,7 +31,6 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { slug } = await params;
   const locale = await getLocale();
-  const appUrl = getAppUrl();
   const post = await getPostBySlug(slug, locale);
   if (!post) return {};
 
@@ -38,13 +38,7 @@ export async function generateMetadata({
     title: post.title,
     description: post.description,
     keywords: post.keywords,
-    alternates: {
-      canonical: `${appUrl}/blog/${slug}`,
-      languages: {
-        fr: `${appUrl}/blog/${slug}`,
-        en: `${appUrl}/en/blog/${slug}`,
-      },
-    },
+    alternates: buildAlternates(locale as "fr" | "en", `/blog/${slug}`),
     openGraph: {
       title: post.title,
       description: post.description,

--- a/src/app/[locale]/(routes)/blog/page.tsx
+++ b/src/app/[locale]/(routes)/blog/page.tsx
@@ -10,7 +10,7 @@ export async function generateMetadata(): Promise<Metadata> {
   return {
     title: t("pageTitle"),
     description: t("pageDescription"),
-    alternates: buildAlternates(locale as "fr" | "en", "/blog"),
+    alternates: buildAlternates(locale, "/blog"),
     openGraph: {
       title: t("pageTitle"),
       description: t("pageDescription"),

--- a/src/app/[locale]/(routes)/blog/page.tsx
+++ b/src/app/[locale]/(routes)/blog/page.tsx
@@ -2,22 +2,15 @@ import type { Metadata } from "next";
 import { getLocale, getTranslations } from "next-intl/server";
 import { Link } from "@/i18n/navigation";
 import { ArrowRight } from "lucide-react";
-import { getAppUrl } from "@/lib/app-url";
 import { getAllPosts, formatBlogDate } from "@/lib/blog";
+import { buildAlternates } from "@/lib/seo";
 
 export async function generateMetadata(): Promise<Metadata> {
-  const t = await getTranslations("Blog");
-  const appUrl = getAppUrl();
+  const [locale, t] = await Promise.all([getLocale(), getTranslations("Blog")]);
   return {
     title: t("pageTitle"),
     description: t("pageDescription"),
-    alternates: {
-      canonical: `${appUrl}/blog`,
-      languages: {
-        fr: `${appUrl}/blog`,
-        en: `${appUrl}/en/blog`,
-      },
-    },
+    alternates: buildAlternates(locale as "fr" | "en", "/blog"),
     openGraph: {
       title: t("pageTitle"),
       description: t("pageDescription"),

--- a/src/app/[locale]/(routes)/circles/[slug]/page.tsx
+++ b/src/app/[locale]/(routes)/circles/[slug]/page.tsx
@@ -22,6 +22,7 @@ import { getMomentGradient } from "@/lib/gradient";
 import { formatLongDate } from "@/lib/format-date";
 import { collapseWhitespace } from "@/lib/text";
 import { buildAlternates } from "@/lib/seo";
+import { getAppUrl } from "@/lib/app-url";
 import { JoinCircleButton } from "@/components/circles/join-circle-button";
 import { CollapsibleDescription } from "@/components/moments/collapsible-description";
 import { HostLink } from "@/components/circles/host-link";
@@ -97,7 +98,7 @@ export async function generateMetadata({
     return {
       title,
       description,
-      alternates: buildAlternates(locale as "fr" | "en", `/circles/${slug}`),
+      alternates: buildAlternates(locale, `/circles/${slug}`),
       ...(isPrivate && { robots: { index: false, follow: false } }),
       ...(!isPrivate && {
         openGraph: {
@@ -206,7 +207,7 @@ export default async function PublicCirclePage({
 
   const gradient = getMomentGradient(circle.name);
 
-  const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
+  const appUrl = getAppUrl();
   const jsonLd =
     circle.visibility === "PUBLIC"
       ? {

--- a/src/app/[locale]/(routes)/circles/[slug]/page.tsx
+++ b/src/app/[locale]/(routes)/circles/[slug]/page.tsx
@@ -21,6 +21,7 @@ import { Button } from "@/components/ui/button";
 import { getMomentGradient } from "@/lib/gradient";
 import { formatLongDate } from "@/lib/format-date";
 import { collapseWhitespace } from "@/lib/text";
+import { buildAlternates } from "@/lib/seo";
 import { JoinCircleButton } from "@/components/circles/join-circle-button";
 import { CollapsibleDescription } from "@/components/moments/collapsible-description";
 import { HostLink } from "@/components/circles/host-link";
@@ -78,7 +79,6 @@ export async function generateMetadata({
     const circle = await getCachedCircle(slug);
     if (!circle) return {};
     const isPrivate = circle.visibility !== "PUBLIC";
-    const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
 
     const [memberCount, t] = await Promise.all([
       getCachedMemberCount(circle.id),
@@ -97,13 +97,7 @@ export async function generateMetadata({
     return {
       title,
       description,
-      alternates: {
-        canonical: `${appUrl}/circles/${slug}`,
-        languages: {
-          fr: `${appUrl}/circles/${slug}`,
-          en: `${appUrl}/en/circles/${slug}`,
-        },
-      },
+      alternates: buildAlternates(locale as "fr" | "en", `/circles/${slug}`),
       ...(isPrivate && { robots: { index: false, follow: false } }),
       ...(!isPrivate && {
         openGraph: {

--- a/src/app/[locale]/(routes)/explorer/page.tsx
+++ b/src/app/[locale]/(routes)/explorer/page.tsx
@@ -1,10 +1,11 @@
-import { getTranslations } from "next-intl/server";
+import { getLocale, getTranslations } from "next-intl/server";
 import {
   prismaCircleRepository,
   prismaMomentRepository,
   prismaRegistrationRepository,
 } from "@/infrastructure/repositories";
 import { measureTime } from "@/lib/perf-logger";
+import { buildAlternates } from "@/lib/seo";
 
 // Revalide toutes les 5 minutes — la page Découvrir ne nécessite pas un temps réel strict.
 // Les filtres par catégorie + onglets sont gérés côté SSR via searchParams.
@@ -27,18 +28,11 @@ const PAGE_SIZE = 10;
 const FETCH_SIZE = PAGE_SIZE + 1;
 
 export async function generateMetadata() {
-  const t = await getTranslations("Explorer");
-  const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
+  const [locale, t] = await Promise.all([getLocale(), getTranslations("Explorer")]);
   return {
     title: t("title"),
     description: t("description"),
-    alternates: {
-      canonical: `${appUrl}/explorer`,
-      languages: {
-        fr: `${appUrl}/explorer`,
-        en: `${appUrl}/en/explorer`,
-      },
-    },
+    alternates: buildAlternates(locale as "fr" | "en", "/explorer"),
     openGraph: {
       title: t("title"),
       description: t("description"),

--- a/src/app/[locale]/(routes)/explorer/page.tsx
+++ b/src/app/[locale]/(routes)/explorer/page.tsx
@@ -32,7 +32,7 @@ export async function generateMetadata() {
   return {
     title: t("title"),
     description: t("description"),
-    alternates: buildAlternates(locale as "fr" | "en", "/explorer"),
+    alternates: buildAlternates(locale, "/explorer"),
     openGraph: {
       title: t("title"),
       description: t("description"),

--- a/src/app/[locale]/(routes)/legal/cgu/page.tsx
+++ b/src/app/[locale]/(routes)/legal/cgu/page.tsx
@@ -1,20 +1,13 @@
-import { getTranslations } from "next-intl/server";
+import { getLocale, getTranslations } from "next-intl/server";
 import type { Metadata } from "next";
-import { getAppUrl } from "@/lib/app-url";
+import { buildAlternates } from "@/lib/seo";
 
 export async function generateMetadata(): Promise<Metadata> {
-  const t = await getTranslations("Legal");
-  const appUrl = getAppUrl();
+  const [locale, t] = await Promise.all([getLocale(), getTranslations("Legal")]);
   return {
     title: t("terms.title"),
     description: t("terms.metaDescription"),
-    alternates: {
-      canonical: `${appUrl}/legal/cgu`,
-      languages: {
-        fr: `${appUrl}/legal/cgu`,
-        en: `${appUrl}/en/legal/cgu`,
-      },
-    },
+    alternates: buildAlternates(locale as "fr" | "en", "/legal/cgu"),
   };
 }
 

--- a/src/app/[locale]/(routes)/legal/cgu/page.tsx
+++ b/src/app/[locale]/(routes)/legal/cgu/page.tsx
@@ -7,7 +7,7 @@ export async function generateMetadata(): Promise<Metadata> {
   return {
     title: t("terms.title"),
     description: t("terms.metaDescription"),
-    alternates: buildAlternates(locale as "fr" | "en", "/legal/cgu"),
+    alternates: buildAlternates(locale, "/legal/cgu"),
   };
 }
 

--- a/src/app/[locale]/(routes)/legal/confidentialite/page.tsx
+++ b/src/app/[locale]/(routes)/legal/confidentialite/page.tsx
@@ -7,7 +7,7 @@ export async function generateMetadata(): Promise<Metadata> {
   return {
     title: t("privacy.title"),
     description: t("privacy.metaDescription"),
-    alternates: buildAlternates(locale as "fr" | "en", "/legal/confidentialite"),
+    alternates: buildAlternates(locale, "/legal/confidentialite"),
   };
 }
 

--- a/src/app/[locale]/(routes)/legal/confidentialite/page.tsx
+++ b/src/app/[locale]/(routes)/legal/confidentialite/page.tsx
@@ -1,20 +1,13 @@
-import { getTranslations } from "next-intl/server";
+import { getLocale, getTranslations } from "next-intl/server";
 import type { Metadata } from "next";
-import { getAppUrl } from "@/lib/app-url";
+import { buildAlternates } from "@/lib/seo";
 
 export async function generateMetadata(): Promise<Metadata> {
-  const t = await getTranslations("Legal");
-  const appUrl = getAppUrl();
+  const [locale, t] = await Promise.all([getLocale(), getTranslations("Legal")]);
   return {
     title: t("privacy.title"),
     description: t("privacy.metaDescription"),
-    alternates: {
-      canonical: `${appUrl}/legal/confidentialite`,
-      languages: {
-        fr: `${appUrl}/legal/confidentialite`,
-        en: `${appUrl}/en/legal/confidentialite`,
-      },
-    },
+    alternates: buildAlternates(locale as "fr" | "en", "/legal/confidentialite"),
   };
 }
 

--- a/src/app/[locale]/(routes)/legal/mentions-legales/page.tsx
+++ b/src/app/[locale]/(routes)/legal/mentions-legales/page.tsx
@@ -7,7 +7,7 @@ export async function generateMetadata(): Promise<Metadata> {
   return {
     title: t("legalNotice.title"),
     description: t("legalNotice.metaDescription"),
-    alternates: buildAlternates(locale as "fr" | "en", "/legal/mentions-legales"),
+    alternates: buildAlternates(locale, "/legal/mentions-legales"),
   };
 }
 

--- a/src/app/[locale]/(routes)/legal/mentions-legales/page.tsx
+++ b/src/app/[locale]/(routes)/legal/mentions-legales/page.tsx
@@ -1,20 +1,13 @@
-import { getTranslations } from "next-intl/server";
+import { getLocale, getTranslations } from "next-intl/server";
 import type { Metadata } from "next";
-import { getAppUrl } from "@/lib/app-url";
+import { buildAlternates } from "@/lib/seo";
 
 export async function generateMetadata(): Promise<Metadata> {
-  const t = await getTranslations("Legal");
-  const appUrl = getAppUrl();
+  const [locale, t] = await Promise.all([getLocale(), getTranslations("Legal")]);
   return {
     title: t("legalNotice.title"),
     description: t("legalNotice.metaDescription"),
-    alternates: {
-      canonical: `${appUrl}/legal/mentions-legales`,
-      languages: {
-        fr: `${appUrl}/legal/mentions-legales`,
-        en: `${appUrl}/en/legal/mentions-legales`,
-      },
-    },
+    alternates: buildAlternates(locale as "fr" | "en", "/legal/mentions-legales"),
   };
 }
 

--- a/src/app/[locale]/(routes)/m/[slug]/page.tsx
+++ b/src/app/[locale]/(routes)/m/[slug]/page.tsx
@@ -7,6 +7,7 @@ import { getTranslations } from "next-intl/server";
 import { formatLongDate, formatLocalizedTime } from "@/lib/format-date";
 import { collapseWhitespace } from "@/lib/text";
 import { buildAlternates } from "@/lib/seo";
+import { getAppUrl } from "@/lib/app-url";
 
 // Revalide toutes les 30 secondes — équilibre entre fraîcheur et performance.
 // Les inscriptions en temps réel passent par les Server Actions (revalidatePath),
@@ -70,7 +71,7 @@ export async function generateMetadata({
   return {
     title,
     description,
-    alternates: buildAlternates(locale as "fr" | "en", `/m/${slug}`),
+    alternates: buildAlternates(locale, `/m/${slug}`),
     openGraph: {
       title,
       description,
@@ -158,7 +159,7 @@ export default async function PublicMomentPage({
   const waitlistedCount = allAttendees.filter(
     (r) => r.status === "WAITLISTED"
   ).length;
-  const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
+  const appUrl = getAppUrl();
   const calendarData = {
     title: moment.title,
     startsAt: moment.startsAt,

--- a/src/app/[locale]/(routes)/m/[slug]/page.tsx
+++ b/src/app/[locale]/(routes)/m/[slug]/page.tsx
@@ -6,6 +6,7 @@ import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 import { formatLongDate, formatLocalizedTime } from "@/lib/format-date";
 import { collapseWhitespace } from "@/lib/text";
+import { buildAlternates } from "@/lib/seo";
 
 // Revalide toutes les 30 secondes — équilibre entre fraîcheur et performance.
 // Les inscriptions en temps réel passent par les Server Actions (revalidatePath),
@@ -66,18 +67,10 @@ export async function generateMetadata({
     `${date}${connector}${time} · ${location}${circle ? ` — ${circle.name}` : ""}`,
   );
 
-  const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
-
   return {
     title,
     description,
-    alternates: {
-      canonical: `${appUrl}/m/${slug}`,
-      languages: {
-        fr: `${appUrl}/m/${slug}`,
-        en: `${appUrl}/en/m/${slug}`,
-      },
-    },
+    alternates: buildAlternates(locale as "fr" | "en", `/m/${slug}`),
     openGraph: {
       title,
       description,

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,9 +1,10 @@
 import type { Metadata } from "next";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
-import { getTranslations } from "next-intl/server";
+import { getLocale, getTranslations } from "next-intl/server";
 import { getCachedSession } from "@/lib/auth-cache";
 import { getAppUrl } from "@/lib/app-url";
+import { buildAlternates } from "@/lib/seo";
 import { prisma } from "@/infrastructure/db/prisma";
 import { SiteHeader } from "@/components/site-header";
 import { SiteFooter } from "@/components/site-footer";
@@ -30,25 +31,19 @@ const FAQ_COUNT = 7;
 export const dynamic = "force-dynamic";
 
 export async function generateMetadata(): Promise<Metadata> {
-  const t = await getTranslations("HomePage");
-  const appUrl = getAppUrl();
+  const [locale, t] = await Promise.all([getLocale(), getTranslations("HomePage")]);
   const title = `The Playground — ${t("metaTitle")}`;
   const description = t("metaDescription");
+  const alternates = buildAlternates(locale as "fr" | "en", "");
   return {
     title,
     description,
-    alternates: {
-      canonical: appUrl,
-      languages: {
-        fr: appUrl,
-        en: `${appUrl}/en`,
-      },
-    },
+    alternates,
     openGraph: {
       title,
       description,
       siteName: "The Playground",
-      url: appUrl,
+      url: alternates.canonical,
     },
     twitter: {
       title,

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -34,7 +34,7 @@ export async function generateMetadata(): Promise<Metadata> {
   const [locale, t] = await Promise.all([getLocale(), getTranslations("HomePage")]);
   const title = `The Playground — ${t("metaTitle")}`;
   const description = t("metaDescription");
-  const alternates = buildAlternates(locale as "fr" | "en", "");
+  const alternates = buildAlternates(locale, "");
   return {
     title,
     description,

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -20,6 +20,7 @@ function withAlternates(
       languages: {
         fr: frUrl,
         en: enUrl,
+        "x-default": frUrl,
       },
     },
   };

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,46 +1,38 @@
 import type { MetadataRoute } from "next";
 import { prisma } from "@/infrastructure/db/prisma";
-import { getAppUrl } from "@/lib/app-url";
 import { getAllPosts } from "@/lib/blog";
+import { buildLocalizedUrls } from "@/lib/seo";
 
 function withAlternates(
-  baseUrl: string,
   path: string,
   opts: { lastModified: Date; changeFrequency: MetadataRoute.Sitemap[number]["changeFrequency"]; priority: number },
 ): MetadataRoute.Sitemap[number] {
-  const frUrl = path ? `${baseUrl}/${path}` : baseUrl;
-  const enUrl = path ? `${baseUrl}/en/${path}` : `${baseUrl}/en`;
-
+  const urls = buildLocalizedUrls(path);
   return {
-    url: frUrl,
+    url: urls.fr,
     lastModified: opts.lastModified,
     changeFrequency: opts.changeFrequency,
     priority: opts.priority,
     alternates: {
-      languages: {
-        fr: frUrl,
-        en: enUrl,
-        "x-default": frUrl,
-      },
+      languages: { ...urls, "x-default": urls.fr },
     },
   };
 }
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const baseUrl = getAppUrl();
   const now = new Date();
 
   // Static pages
   const staticPages: MetadataRoute.Sitemap = [
-    withAlternates(baseUrl, "", { lastModified: now, changeFrequency: "weekly", priority: 1 }),
-    withAlternates(baseUrl, "explorer", { lastModified: now, changeFrequency: "daily", priority: 0.9 }),
-    withAlternates(baseUrl, "about", { lastModified: now, changeFrequency: "monthly", priority: 0.6 }),
-    withAlternates(baseUrl, "help", { lastModified: now, changeFrequency: "monthly", priority: 0.5 }),
-    withAlternates(baseUrl, "contact", { lastModified: now, changeFrequency: "monthly", priority: 0.5 }),
-    withAlternates(baseUrl, "changelog", { lastModified: now, changeFrequency: "weekly", priority: 0.4 }),
-    withAlternates(baseUrl, "legal/mentions-legales", { lastModified: now, changeFrequency: "yearly", priority: 0.2 }),
-    withAlternates(baseUrl, "legal/confidentialite", { lastModified: now, changeFrequency: "yearly", priority: 0.2 }),
-    withAlternates(baseUrl, "legal/cgu", { lastModified: now, changeFrequency: "yearly", priority: 0.2 }),
+    withAlternates("", { lastModified: now, changeFrequency: "weekly", priority: 1 }),
+    withAlternates("/explorer", { lastModified: now, changeFrequency: "daily", priority: 0.9 }),
+    withAlternates("/about", { lastModified: now, changeFrequency: "monthly", priority: 0.6 }),
+    withAlternates("/help", { lastModified: now, changeFrequency: "monthly", priority: 0.5 }),
+    withAlternates("/contact", { lastModified: now, changeFrequency: "monthly", priority: 0.5 }),
+    withAlternates("/changelog", { lastModified: now, changeFrequency: "weekly", priority: 0.4 }),
+    withAlternates("/legal/mentions-legales", { lastModified: now, changeFrequency: "yearly", priority: 0.2 }),
+    withAlternates("/legal/confidentialite", { lastModified: now, changeFrequency: "yearly", priority: 0.2 }),
+    withAlternates("/legal/cgu", { lastModified: now, changeFrequency: "yearly", priority: 0.2 }),
   ];
 
   // Exclude circles owned by test/demo users
@@ -77,7 +69,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   ]);
 
   const circlePages: MetadataRoute.Sitemap = circles.map((circle) =>
-    withAlternates(baseUrl, `circles/${circle.slug}`, {
+    withAlternates(`/circles/${circle.slug}`, {
       lastModified: circle.updatedAt,
       changeFrequency: "weekly",
       priority: 0.8,
@@ -85,7 +77,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   );
 
   const momentPages: MetadataRoute.Sitemap = moments.map((moment) =>
-    withAlternates(baseUrl, `m/${moment.slug}`, {
+    withAlternates(`/m/${moment.slug}`, {
       lastModified: moment.updatedAt,
       changeFrequency: "weekly",
       priority: 0.7,
@@ -95,9 +87,9 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   // Blog posts
   const blogPosts = getAllPosts("fr");
   const blogPages: MetadataRoute.Sitemap = [
-    withAlternates(baseUrl, "blog", { lastModified: now, changeFrequency: "weekly", priority: 0.5 }),
+    withAlternates("/blog", { lastModified: now, changeFrequency: "weekly", priority: 0.5 }),
     ...blogPosts.map((post) =>
-      withAlternates(baseUrl, `blog/${post.slug}`, {
+      withAlternates(`/blog/${post.slug}`, {
         lastModified: new Date(post.date),
         changeFrequency: "monthly" as const,
         priority: 0.6,

--- a/src/lib/__tests__/seo.test.ts
+++ b/src/lib/__tests__/seo.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { buildAlternates } from "@/lib/seo";
+
+const APP_URL = "https://the-playground.fr";
+
+describe("buildAlternates", () => {
+  let originalAppUrl: string | undefined;
+
+  beforeEach(() => {
+    originalAppUrl = process.env.NEXT_PUBLIC_APP_URL;
+    process.env.NEXT_PUBLIC_APP_URL = APP_URL;
+  });
+
+  afterEach(() => {
+    if (originalAppUrl === undefined) delete process.env.NEXT_PUBLIC_APP_URL;
+    else process.env.NEXT_PUBLIC_APP_URL = originalAppUrl;
+  });
+
+  describe("given a sub-path", () => {
+    it("on FR locale, canonical points to the FR URL", () => {
+      const result = buildAlternates("fr", "/m/abc");
+      expect(result.canonical).toBe(`${APP_URL}/m/abc`);
+    });
+
+    it("on EN locale, canonical points to the EN URL (self-reference, not FR)", () => {
+      const result = buildAlternates("en", "/m/abc");
+      expect(result.canonical).toBe(`${APP_URL}/en/m/abc`);
+    });
+
+    it("languages are identical across locales", () => {
+      const fr = buildAlternates("fr", "/m/abc");
+      const en = buildAlternates("en", "/m/abc");
+      expect(fr.languages).toEqual(en.languages);
+    });
+
+    it("languages include fr, en and x-default with x-default pointing to FR", () => {
+      const result = buildAlternates("fr", "/circles/xyz");
+      expect(result.languages).toEqual({
+        fr: `${APP_URL}/circles/xyz`,
+        en: `${APP_URL}/en/circles/xyz`,
+        "x-default": `${APP_URL}/circles/xyz`,
+      });
+    });
+  });
+
+  describe("given the home page", () => {
+    it("with empty path, FR canonical has no trailing slash", () => {
+      const result = buildAlternates("fr", "");
+      expect(result.canonical).toBe(APP_URL);
+      expect(result.languages.fr).toBe(APP_URL);
+      expect(result.languages.en).toBe(`${APP_URL}/en`);
+      expect(result.languages["x-default"]).toBe(APP_URL);
+    });
+
+    it("with empty path on EN, canonical is /en (no trailing slash)", () => {
+      const result = buildAlternates("en", "");
+      expect(result.canonical).toBe(`${APP_URL}/en`);
+    });
+
+    it("with '/' path, behaves like empty path (no double slash)", () => {
+      const result = buildAlternates("fr", "/");
+      expect(result.canonical).toBe(APP_URL);
+    });
+  });
+
+  describe("given a nested path", () => {
+    it("preserves the full path on both locales", () => {
+      const result = buildAlternates("fr", "/legal/mentions-legales");
+      expect(result.languages.fr).toBe(`${APP_URL}/legal/mentions-legales`);
+      expect(result.languages.en).toBe(`${APP_URL}/en/legal/mentions-legales`);
+    });
+  });
+});

--- a/src/lib/__tests__/seo.test.ts
+++ b/src/lib/__tests__/seo.test.ts
@@ -70,4 +70,11 @@ describe("buildAlternates", () => {
       expect(result.languages.en).toBe(`${APP_URL}/en/legal/mentions-legales`);
     });
   });
+
+  describe("given an unknown locale string", () => {
+    it("falls back to FR as the canonical (defensive default)", () => {
+      const result = buildAlternates("de", "/about");
+      expect(result.canonical).toBe(`${APP_URL}/about`);
+    });
+  });
 });

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,30 +1,37 @@
+import { routing } from "@/i18n/routing";
 import { getAppUrl } from "./app-url";
 
-type Locale = "fr" | "en";
+type Locale = (typeof routing.locales)[number];
+type LocaleUrls = Record<Locale, string>;
 
-type Alternates = {
-  canonical: string;
-  languages: { fr: string; en: string; "x-default": string };
-};
+function isSupportedLocale(value: string): value is Locale {
+  return (routing.locales as readonly string[]).includes(value);
+}
 
-// Build canonical + hreflang alternates for a localized page.
-// Each locale auto-references itself (avoids Google's "duplicate without
-// user-selected canonical"), and x-default points to the FR version.
-//
-// `path` is the URL after the locale segment, with leading slash for sub-paths
-// (e.g. "/m/abc", "/blog"). Use "" for the home page.
-export function buildAlternates(locale: Locale, path: string): Alternates {
+// Per-locale absolute URLs for a path. `path` is the URL after the locale
+// segment, with a leading slash for sub-paths (e.g. "/m/abc"). Use "" for the
+// home page. Shared between page metadata and the sitemap.
+export function buildLocalizedUrls(path: string): LocaleUrls {
   const appUrl = getAppUrl();
   const suffix = path === "/" ? "" : path;
-  const frUrl = `${appUrl}${suffix}`;
-  const enUrl = `${appUrl}/en${suffix}`;
-
   return {
-    canonical: locale === "fr" ? frUrl : enUrl,
+    fr: `${appUrl}${suffix}`,
+    en: `${appUrl}/en${suffix}`,
+  };
+}
+
+// Canonical + hreflang alternates for a localized page. Each locale
+// self-references so Google never sees the EN version pointing to the FR
+// canonical (the "duplicate without user-selected canonical" warning).
+// x-default points to FR.
+export function buildAlternates(locale: string, path: string) {
+  const urls = buildLocalizedUrls(path);
+  const safe = isSupportedLocale(locale) ? locale : routing.defaultLocale;
+  return {
+    canonical: urls[safe],
     languages: {
-      fr: frUrl,
-      en: enUrl,
-      "x-default": frUrl,
+      ...urls,
+      "x-default": urls.fr,
     },
   };
 }

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,0 +1,30 @@
+import { getAppUrl } from "./app-url";
+
+type Locale = "fr" | "en";
+
+type Alternates = {
+  canonical: string;
+  languages: { fr: string; en: string; "x-default": string };
+};
+
+// Build canonical + hreflang alternates for a localized page.
+// Each locale auto-references itself (avoids Google's "duplicate without
+// user-selected canonical"), and x-default points to the FR version.
+//
+// `path` is the URL after the locale segment, with leading slash for sub-paths
+// (e.g. "/m/abc", "/blog"). Use "" for the home page.
+export function buildAlternates(locale: Locale, path: string): Alternates {
+  const appUrl = getAppUrl();
+  const suffix = path === "/" ? "" : path;
+  const frUrl = `${appUrl}${suffix}`;
+  const enUrl = `${appUrl}/en${suffix}`;
+
+  return {
+    canonical: locale === "fr" ? frUrl : enUrl,
+    languages: {
+      fr: frUrl,
+      en: enUrl,
+      "x-default": frUrl,
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Each localized page now self-references its own canonical (FR canonical `/path`, EN canonical `/en/path`) instead of every locale pointing at the FR URL — addresses the Search Console **« Page en double sans URL canonique sélectionnée »** warning that flagged EN pages declaring the FR version as canonical.
- `x-default` added to every page and to the sitemap to complete the hreflang signaling.
- Centralized in `src/lib/seo.ts` (`buildAlternates` + `buildLocalizedUrls`), applied to 13 `generateMetadata` callsites and to the sitemap so the URL construction logic lives in a single place.

## What changed

- New `src/lib/seo.ts` (and tests in `src/lib/__tests__/seo.test.ts`).
- `buildAlternates(locale, path)` returns canonical + hreflang languages; accepts a `string` locale and falls back to FR if unknown (matches the `magic-link-url.ts` defensive pattern).
- `buildLocalizedUrls(path)` extracted and reused by `sitemap.ts` to remove the parallel URL-building logic.
- 13 pages migrated from inline `alternates: { canonical, languages }` literals to `buildAlternates`.
- Sitemap aligned on the same path convention (leading slash, `""` for home).
- Two leftover `process.env.NEXT_PUBLIC_APP_URL ?? "..."` in the same edited files (`m/[slug]:161`, `circles/[slug]:209`) replaced with `getAppUrl()`.
- `blog/[slug]` `generateMetadata` parallelizes `params` and `getLocale()`.

## Verified end-to-end

Hit the dev server and confirmed `<link rel="canonical">` and `hreflang` headers on every page family:

| Page | FR canonical | EN canonical |
|---|---|---|
| Home | `/` | `/en` |
| `/about`, `/help`, `/contact`, `/changelog`, `/blog`, `/explorer`, `/legal/*` | `/path` | `/en/path` |
| `/m/[slug]` | `/m/slug` | `/en/m/slug` |
| `/circles/[slug]` | `/circles/slug` | `/en/circles/slug` |
| `/blog/[slug]` | `/blog/slug` | `/en/blog/slug` |

Sitemap : 88 `<xhtml:link rel="alternate" hreflang="x-default">` entries verified in the rendered `/sitemap.xml`.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test:unit` — 1142 tests pass (8 new for `buildAlternates`)
- [x] `pnpm build` — all routes build cleanly
- [x] Dev server: canonical + hreflang verified on home, static, and dynamic pages (FR & EN)
- [ ] Post-merge: re-validate URLs in Google Search Console (request re-indexing on a few sample pages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)