### PR TITLE
feat: embeddable event widget for external sites

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -2017,6 +2017,6 @@
     "dashboardLocaleEn": "English",
     "dashboardPreviewTitle": "Preview",
     "dashboardSnippetTitle": "HTML code",
-    "dashboardNote": "The widget updates automatically (date, capacity, status). Remember to remove the snippet from your site after the event."
+    "dashboardNote": "The widget updates automatically (date, capacity, status).\nRemember to remove the snippet from your site after the event."
   }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -2016,7 +2016,7 @@
     "dashboardLocaleFr": "Français",
     "dashboardLocaleEn": "English",
     "dashboardPreviewTitle": "Preview",
-    "dashboardSnippetTitle": "Paste this snippet into your site",
+    "dashboardSnippetTitle": "HTML code",
     "dashboardNote": "The widget updates automatically (date, capacity, status). Remember to remove the snippet from your site after the event."
   }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -1381,14 +1381,62 @@
           "hosting": "Data hosting",
           "safeguards": "Safeguards"
         },
-        "vercel": { "purpose": "Application hosting", "data": "IP address, session cookies, HTTP requests (transit)", "hq": "United States", "hosting": "European Union (Frankfurt)", "safeguards": "Vercel DPA, data hosted in EU" },
-        "neon": { "purpose": "Database hosting", "data": "All account data: email, name, profile picture, registrations, comments", "hq": "United States", "hosting": "European Union (Frankfurt)", "safeguards": "Neon DPA, data hosted in EU" },
-        "posthog": { "purpose": "Service usage analytics", "data": "User identifier, email, name, pages visited", "hq": "United States", "hosting": "European Union (eu.posthog.com)", "safeguards": "PostHog DPA, data hosted in EU" },
-        "sentry": { "purpose": "Technical error monitoring", "data": "Technical error traces (no personal data explicitly transmitted)", "hq": "United States", "hosting": "European Union (Germany, de.sentry.io)", "safeguards": "Sentry DPA, data hosted in EU" },
-        "resend": { "purpose": "Transactional and notification emails", "data": "Recipient email address, name (in some emails)", "hq": "United States", "hosting": "United States", "safeguards": "Resend DPA, EU standard contractual clauses" },
-        "stripe": { "purpose": "Payment processing (paid Events)", "data": "Email address, user identifier", "hq": "United States", "hosting": "United States / European Union (global infrastructure)", "safeguards": "PCI-DSS certified, Stripe DPA, EU standard contractual clauses" },
-        "anthropic": { "purpose": "AI features (description generation)", "data": "User-entered content (event titles and descriptions) — no personal data", "hq": "United States", "hosting": "United States", "safeguards": "Anthropic DPA, EU standard contractual clauses" },
-        "slack": { "purpose": "Internal administration notifications (new users, new communities)", "data": "User name and email (admin notifications only)", "hq": "United States", "hosting": "United States", "safeguards": "Slack/Salesforce DPA, EU standard contractual clauses" },
+        "vercel": {
+          "purpose": "Application hosting",
+          "data": "IP address, session cookies, HTTP requests (transit)",
+          "hq": "United States",
+          "hosting": "European Union (Frankfurt)",
+          "safeguards": "Vercel DPA, data hosted in EU"
+        },
+        "neon": {
+          "purpose": "Database hosting",
+          "data": "All account data: email, name, profile picture, registrations, comments",
+          "hq": "United States",
+          "hosting": "European Union (Frankfurt)",
+          "safeguards": "Neon DPA, data hosted in EU"
+        },
+        "posthog": {
+          "purpose": "Service usage analytics",
+          "data": "User identifier, email, name, pages visited",
+          "hq": "United States",
+          "hosting": "European Union (eu.posthog.com)",
+          "safeguards": "PostHog DPA, data hosted in EU"
+        },
+        "sentry": {
+          "purpose": "Technical error monitoring",
+          "data": "Technical error traces (no personal data explicitly transmitted)",
+          "hq": "United States",
+          "hosting": "European Union (Germany, de.sentry.io)",
+          "safeguards": "Sentry DPA, data hosted in EU"
+        },
+        "resend": {
+          "purpose": "Transactional and notification emails",
+          "data": "Recipient email address, name (in some emails)",
+          "hq": "United States",
+          "hosting": "United States",
+          "safeguards": "Resend DPA, EU standard contractual clauses"
+        },
+        "stripe": {
+          "purpose": "Payment processing (paid Events)",
+          "data": "Email address, user identifier",
+          "hq": "United States",
+          "hosting": "United States / European Union (global infrastructure)",
+          "safeguards": "PCI-DSS certified, Stripe DPA, EU standard contractual clauses"
+        },
+        "anthropic": {
+          "purpose": "AI features (description generation)",
+          "data": "User-entered content (event titles and descriptions) — no personal data",
+          "hq": "United States",
+          "hosting": "United States",
+          "safeguards": "Anthropic DPA, EU standard contractual clauses"
+        },
+        "slack": {
+          "purpose": "Internal administration notifications (new users, new communities)",
+          "data": "User name and email (admin notifications only)",
+          "hq": "United States",
+          "hosting": "United States",
+          "safeguards": "Slack/Salesforce DPA, EU standard contractual clauses"
+        },
         "noSale": "Your data is never sold or shared with third parties for commercial or advertising purposes."
       },
       "transfers": {
@@ -1622,7 +1670,7 @@
         "step3": "If you don't have an account yet, you can sign in in seconds (magic link by email or via Google / GitHub) — no form to fill out",
         "step4": "Once registered, you receive a <strong>confirmation email</strong> with the details and a link to add the event to your calendar (Google Calendar, Apple Calendar, or .ics file)",
         "callout": "No prior account is needed to view an event page. Registration takes less than a minute.",
-        "approvalNote": "Some events require approval by the organizer. In that case, the button reads \u201cJoin (subject to approval)\u201d. Your request is sent to the organizer, and you receive a confirmation email once it is accepted. If your request is declined, you are notified by email. While your request is pending, it appears in Dashboard with the status \u201cPending approval\u201d."
+        "approvalNote": "Some events require approval by the organizer. In that case, the button reads “Join (subject to approval)”. Your request is sent to the organizer, and you receive a confirmation email once it is accepted. If your request is declined, you are notified by email. While your request is pending, it appears in Dashboard with the status “Pending approval”."
       },
       "join": {
         "title": "Join a community",
@@ -1943,5 +1991,32 @@
   "About": {
     "pageTitle": "About",
     "pageDescription": "The Playground is the free community platform for organizing events — an alternative to Meetup and Luma, with no fees or subscriptions."
+  },
+  "EmbedWidget": {
+    "register": "Join",
+    "viewUpcoming": "View upcoming",
+    "attendingCount": "+{count} attending",
+    "attendedCount": "{count} attended",
+    "badgePast": "Past",
+    "badgeCancelled": "Cancelled",
+    "cancelledExplanation": "This event has been cancelled.",
+    "online": "Online",
+    "poweredBy": "Powered by",
+    "titleAlt": "Event: {title}",
+    "dashboardTitle": "Embed on your site",
+    "dashboardCardLabel": "Event widget",
+    "dashboardCardDescription": "Show this event on your site, blog or newsletter.",
+    "dashboardOpen": "Get the code",
+    "dashboardCta": "Copy code",
+    "dashboardCopied": "Copied",
+    "dashboardLabelLocale": "Language",
+    "dashboardLabelTheme": "Theme",
+    "dashboardThemeLight": "Light",
+    "dashboardThemeDark": "Dark",
+    "dashboardLocaleFr": "Français",
+    "dashboardLocaleEn": "English",
+    "dashboardPreviewTitle": "Preview",
+    "dashboardSnippetTitle": "Paste this snippet into your site",
+    "dashboardNote": "The widget updates automatically (date, capacity, status). Remember to remove the snippet from your site after the event."
   }
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1381,14 +1381,62 @@
           "hosting": "Hébergement des données",
           "safeguards": "Garanties"
         },
-        "vercel": { "purpose": "Hébergement de l'application", "data": "Adresse IP, cookies de session, requêtes HTTP (transit)", "hq": "États-Unis", "hosting": "Union européenne (Frankfurt)", "safeguards": "DPA Vercel, données hébergées en UE" },
-        "neon": { "purpose": "Hébergement de la base de données", "data": "Toutes les données du compte : email, nom, photo de profil, inscriptions, commentaires", "hq": "États-Unis", "hosting": "Union européenne (Frankfurt)", "safeguards": "DPA Neon, données hébergées en UE" },
-        "posthog": { "purpose": "Analyse d'utilisation du service", "data": "Identifiant utilisateur, email, nom, pages visitées", "hq": "États-Unis", "hosting": "Union européenne (eu.posthog.com)", "safeguards": "DPA PostHog, données hébergées en UE" },
-        "sentry": { "purpose": "Surveillance des erreurs techniques", "data": "Traces d'erreur techniques (aucune donnée personnelle explicitement transmise)", "hq": "États-Unis", "hosting": "Union européenne (Allemagne, de.sentry.io)", "safeguards": "DPA Sentry, données hébergées en UE" },
-        "resend": { "purpose": "Envoi d'emails transactionnels et de notifications", "data": "Adresse email du destinataire, nom (dans certains emails)", "hq": "États-Unis", "hosting": "États-Unis", "safeguards": "DPA Resend, clauses contractuelles types UE" },
-        "stripe": { "purpose": "Traitement des paiements (événements payants)", "data": "Adresse email, identifiant utilisateur", "hq": "États-Unis", "hosting": "États-Unis / Union européenne (infrastructure globale)", "safeguards": "Certifié PCI-DSS, DPA Stripe, clauses contractuelles types UE" },
-        "anthropic": { "purpose": "Fonctionnalités d'intelligence artificielle (génération de descriptions)", "data": "Contenu saisi par l'utilisateur (titres et descriptions d'événements) — aucune donnée personnelle", "hq": "États-Unis", "hosting": "États-Unis", "safeguards": "DPA Anthropic, clauses contractuelles types UE" },
-        "slack": { "purpose": "Notifications internes d'administration (nouveaux utilisateurs, nouvelles communautés)", "data": "Nom et email de l'utilisateur (notifications administrateur uniquement)", "hq": "États-Unis", "hosting": "États-Unis", "safeguards": "DPA Slack/Salesforce, clauses contractuelles types UE" },
+        "vercel": {
+          "purpose": "Hébergement de l'application",
+          "data": "Adresse IP, cookies de session, requêtes HTTP (transit)",
+          "hq": "États-Unis",
+          "hosting": "Union européenne (Frankfurt)",
+          "safeguards": "DPA Vercel, données hébergées en UE"
+        },
+        "neon": {
+          "purpose": "Hébergement de la base de données",
+          "data": "Toutes les données du compte : email, nom, photo de profil, inscriptions, commentaires",
+          "hq": "États-Unis",
+          "hosting": "Union européenne (Frankfurt)",
+          "safeguards": "DPA Neon, données hébergées en UE"
+        },
+        "posthog": {
+          "purpose": "Analyse d'utilisation du service",
+          "data": "Identifiant utilisateur, email, nom, pages visitées",
+          "hq": "États-Unis",
+          "hosting": "Union européenne (eu.posthog.com)",
+          "safeguards": "DPA PostHog, données hébergées en UE"
+        },
+        "sentry": {
+          "purpose": "Surveillance des erreurs techniques",
+          "data": "Traces d'erreur techniques (aucune donnée personnelle explicitement transmise)",
+          "hq": "États-Unis",
+          "hosting": "Union européenne (Allemagne, de.sentry.io)",
+          "safeguards": "DPA Sentry, données hébergées en UE"
+        },
+        "resend": {
+          "purpose": "Envoi d'emails transactionnels et de notifications",
+          "data": "Adresse email du destinataire, nom (dans certains emails)",
+          "hq": "États-Unis",
+          "hosting": "États-Unis",
+          "safeguards": "DPA Resend, clauses contractuelles types UE"
+        },
+        "stripe": {
+          "purpose": "Traitement des paiements (événements payants)",
+          "data": "Adresse email, identifiant utilisateur",
+          "hq": "États-Unis",
+          "hosting": "États-Unis / Union européenne (infrastructure globale)",
+          "safeguards": "Certifié PCI-DSS, DPA Stripe, clauses contractuelles types UE"
+        },
+        "anthropic": {
+          "purpose": "Fonctionnalités d'intelligence artificielle (génération de descriptions)",
+          "data": "Contenu saisi par l'utilisateur (titres et descriptions d'événements) — aucune donnée personnelle",
+          "hq": "États-Unis",
+          "hosting": "États-Unis",
+          "safeguards": "DPA Anthropic, clauses contractuelles types UE"
+        },
+        "slack": {
+          "purpose": "Notifications internes d'administration (nouveaux utilisateurs, nouvelles communautés)",
+          "data": "Nom et email de l'utilisateur (notifications administrateur uniquement)",
+          "hq": "États-Unis",
+          "hosting": "États-Unis",
+          "safeguards": "DPA Slack/Salesforce, clauses contractuelles types UE"
+        },
         "noSale": "Vos données ne sont jamais vendues ni partagées avec des tiers à des fins commerciales ou publicitaires."
       },
       "transfers": {
@@ -1943,5 +1991,32 @@
   "About": {
     "pageTitle": "À propos",
     "pageDescription": "The Playground est la plateforme communautaire gratuite pour organiser des événements — alternative à Meetup et Luma, sans commission ni abonnement."
+  },
+  "EmbedWidget": {
+    "register": "S'inscrire",
+    "viewUpcoming": "Voir les prochains",
+    "attendingCount": "+{count} inscrits",
+    "attendedCount": "{count} ont participé",
+    "badgePast": "Passé",
+    "badgeCancelled": "Annulé",
+    "cancelledExplanation": "Cet événement a été annulé.",
+    "online": "En ligne",
+    "poweredBy": "Powered by",
+    "titleAlt": "Événement : {title}",
+    "dashboardTitle": "Intégrer sur mon site",
+    "dashboardCardLabel": "Widget événement",
+    "dashboardCardDescription": "Affichez cet événement sur votre site, blog ou newsletter.",
+    "dashboardOpen": "Obtenir le code",
+    "dashboardCta": "Copier le code",
+    "dashboardCopied": "Copié",
+    "dashboardLabelLocale": "Langue",
+    "dashboardLabelTheme": "Thème",
+    "dashboardThemeLight": "Clair",
+    "dashboardThemeDark": "Sombre",
+    "dashboardLocaleFr": "Français",
+    "dashboardLocaleEn": "English",
+    "dashboardPreviewTitle": "Aperçu",
+    "dashboardSnippetTitle": "Code à coller dans votre site",
+    "dashboardNote": "Le widget se met à jour automatiquement (date, places, état). Pensez à retirer le code de votre site quand l'événement sera passé."
   }
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -2017,6 +2017,6 @@
     "dashboardLocaleEn": "English",
     "dashboardPreviewTitle": "Aperçu",
     "dashboardSnippetTitle": "Code HTML",
-    "dashboardNote": "Le widget se met à jour automatiquement (date, places, état). Pensez à retirer le code de votre site quand l'événement sera passé."
+    "dashboardNote": "Le widget se met à jour automatiquement (date, places, état).\nPensez à retirer le code de votre site quand l'événement sera passé."
   }
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -2016,7 +2016,7 @@
     "dashboardLocaleFr": "Français",
     "dashboardLocaleEn": "English",
     "dashboardPreviewTitle": "Aperçu",
-    "dashboardSnippetTitle": "Code à coller dans votre site",
+    "dashboardSnippetTitle": "Code HTML",
     "dashboardNote": "Le widget se met à jour automatiquement (date, places, état). Pensez à retirer le code de votre site quand l'événement sera passé."
   }
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -48,7 +48,8 @@ const baseCspDirectives = [
   "font-src 'self'",
   // Stripe Elements + Google Maps Embed API (www.google.com/maps/embed/v1/...)
   // + Vercel Blob (PDF preview dans la modale des pièces jointes Moment)
-  "frame-src js.stripe.com www.google.com *.public.blob.vercel-storage.com",
+  // + 'self' pour l'aperçu live du widget /embed/m/* dans la modale dashboard
+  "frame-src 'self' js.stripe.com www.google.com *.public.blob.vercel-storage.com",
   // Formulaires : uniquement vers le domaine propre
   "form-action 'self'",
 ];

--- a/next.config.ts
+++ b/next.config.ts
@@ -16,11 +16,9 @@ const withPWA = withPWAInit({
   disable: process.env.NODE_ENV === "development",
 });
 
-const securityHeaders = [
+const baseSecurityHeaders = [
   // Empêche le navigateur de détecter (sniffer) le Content-Type
   { key: "X-Content-Type-Options", value: "nosniff" },
-  // Empêche l'intégration dans des iframes (clickjacking)
-  { key: "X-Frame-Options", value: "DENY" },
   // Politique de référent : transmet l'origine uniquement en cross-origin HTTPS
   { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
   // Désactive les fonctionnalités navigateur non utilisées (privacy + sécurité)
@@ -33,30 +31,50 @@ const securityHeaders = [
     key: "Strict-Transport-Security",
     value: "max-age=63072000; includeSubDomains; preload",
   },
-  // Content Security Policy — restreint les sources de scripts, styles et images
+];
+
+const baseCspDirectives = [
+  "default-src 'self'",
+  // Next.js requiert 'unsafe-inline' pour les styles injectés et 'unsafe-eval' pour le HMR dev
+  // Stripe.js doit être chargé depuis js.stripe.com (exigence PCI-DSS)
+  "script-src 'self' 'unsafe-inline' 'unsafe-eval' js.stripe.com",
+  "style-src 'self' 'unsafe-inline'",
+  // Images : domaine propre + blobs + avatars OAuth + Unsplash + Stripe
+  "img-src 'self' data: blob: *.unsplash.com *.public.blob.vercel-storage.com avatars.githubusercontent.com lh3.googleusercontent.com q.stripe.com",
+  // Connexions : domaine propre + Sentry (tunnel via /monitoring) + Stripe API + PostHog (tunnel via /ingest)
+  "connect-src 'self' *.sentry.io api.stripe.com api-adresse.data.gouv.fr",
+  // Service Worker PWA
+  "worker-src 'self'",
+  "font-src 'self'",
+  // Stripe Elements + Google Maps Embed API (www.google.com/maps/embed/v1/...)
+  // + Vercel Blob (PDF preview dans la modale des pièces jointes Moment)
+  "frame-src js.stripe.com www.google.com *.public.blob.vercel-storage.com",
+  // Formulaires : uniquement vers le domaine propre
+  "form-action 'self'",
+];
+
+const securityHeaders = [
+  ...baseSecurityHeaders,
+  // Empêche l'intégration dans des iframes (clickjacking)
+  { key: "X-Frame-Options", value: "DENY" },
   {
     key: "Content-Security-Policy",
     value: [
-      "default-src 'self'",
-      // Next.js requiert 'unsafe-inline' pour les styles injectés et 'unsafe-eval' pour le HMR dev
-      // Stripe.js doit être chargé depuis js.stripe.com (exigence PCI-DSS)
-      "script-src 'self' 'unsafe-inline' 'unsafe-eval' js.stripe.com",
-      "style-src 'self' 'unsafe-inline'",
-      // Images : domaine propre + blobs + avatars OAuth + Unsplash + Stripe
-      "img-src 'self' data: blob: *.unsplash.com *.public.blob.vercel-storage.com avatars.githubusercontent.com lh3.googleusercontent.com q.stripe.com",
-      // Connexions : domaine propre + Sentry (tunnel via /monitoring) + Stripe API + PostHog (tunnel via /ingest)
-      "connect-src 'self' *.sentry.io api.stripe.com api-adresse.data.gouv.fr",
-      // Service Worker PWA
-      "worker-src 'self'",
-      "font-src 'self'",
-      // Stripe Elements + Google Maps Embed API (www.google.com/maps/embed/v1/...)
-      // + Vercel Blob (PDF preview dans la modale des pièces jointes Moment)
-      "frame-src js.stripe.com www.google.com *.public.blob.vercel-storage.com",
+      ...baseCspDirectives,
       // Interdire l'intégration de NOTRE page dans des iframes tierces (anti-clickjacking)
       "frame-ancestors 'none'",
-      // Formulaires : uniquement vers le domaine propre
-      "form-action 'self'",
     ].join("; "),
+  },
+];
+
+// Headers pour la route /embed/* : on autorise volontairement l'embedding
+// par des sites externes (c'est l'objectif du widget). X-Frame-Options retiré
+// et CSP frame-ancestors * pour permettre l'intégration n'importe où.
+const embedHeaders = [
+  ...baseSecurityHeaders,
+  {
+    key: "Content-Security-Policy",
+    value: [...baseCspDirectives, "frame-ancestors *"].join("; "),
   },
 ];
 
@@ -91,8 +109,13 @@ const nextConfig: NextConfig = {
   async headers() {
     return [
       {
-        // Applique les headers de sécurité sur toutes les routes
-        source: "/(.*)",
+        // Widget embeddable : autorise l'intégration sur tout domaine externe.
+        source: "/embed/:path*",
+        headers: embedHeaders,
+      },
+      {
+        // Applique les headers de sécurité stricts sur toutes les autres routes.
+        source: "/((?!embed).*)",
         headers: securityHeaders,
       },
     ];

--- a/spec/features/embed-event-widget.md
+++ b/spec/features/embed-event-widget.md
@@ -31,7 +31,7 @@ Un Organisateur a un site externe (blog, page d'association, landing page Notion
 | D13 | Pas de tracking PostHog dans l'iframe (RGPD : on est dans le contexte d'un site tiers). |
 | D14 | Pas de personnalisation de design côté Organisateur (couleurs, logo). Look uniforme = brand awareness. |
 | D15 | Tracking server-side via PostHog (event `embed_widget_view` avec props `momentSlug`, `locale`, `theme`, `circleSlug`). Aucun cookie, aucun identifiant visiteur — RGPD-safe. Vues exploitables en interne pour dashboards futurs. |
-| D16 | Hauteur du snippet : ~260px desktop (cover 192px + paddings + footer), ~530px mobile (cover pleine largeur 1:1 + contenu vertical). À arbitrer en début d'impl : hauteur unique conservative (530px, du vide en bas sur desktop) ou auto-resize via `postMessage` (hors scope V1, à reconsidérer). |
+| D16 | Hauteur du snippet : **250px desktop** (= cover w-48 + p-4 + footer mention), à utiliser tel quel dans le `<iframe height="250">` généré. Mobile : si l'iframe est plus étroite que ~480px, la carte bascule en layout vertical et l'utilisateur doit ajuster `height` manuellement (auto-resize via `postMessage` hors scope V1). |
 
 ---
 
@@ -167,8 +167,8 @@ Contient :
    ```html
    <iframe
      src="https://the-playground.fr/embed/m/[slug]?locale=fr&theme=light"
-     width="100%"
-     height="450"
+     width="480"
+     height="250"
      frameborder="0"
      title="Événement : [titre]"
      loading="lazy"

--- a/spec/mockups/embed-snippet-dialog.mockup.html
+++ b/spec/mockups/embed-snippet-dialog.mockup.html
@@ -1,0 +1,224 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Mockup — Modale "Intégrer sur mon site"</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet" />
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          colors: {
+            primary: '#E91E63',
+            'primary-hover': '#D81557',
+            border: 'rgba(255,255,255,0.08)',
+            background: '#0b0e14',
+            card: '#0f1320',
+            muted: '#1a2030',
+            'muted-foreground': '#94a3b8',
+            foreground: '#f1f5f9',
+            accent: '#1a2030',
+          },
+          fontFamily: {
+            sans: ['Geist', 'system-ui', 'sans-serif'],
+            mono: ['Geist Mono', 'monospace'],
+          },
+        },
+      },
+    };
+  </script>
+  <style>
+    body { font-family: 'Geist', system-ui, sans-serif; }
+    .label-section {
+      font-size: 11px;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      color: #64748b;
+      margin-bottom: 12px;
+      font-weight: 600;
+    }
+  </style>
+</head>
+<body class="bg-slate-950 text-foreground min-h-screen p-6">
+
+  <header class="max-w-7xl mx-auto mb-8">
+    <p class="text-xs uppercase tracking-widest text-primary font-semibold mb-2">Spec embed-snippet-dialog · 2 états</p>
+    <h1 class="text-2xl font-bold mb-1">Modale « Intégrer sur mon site »</h1>
+    <p class="text-slate-400 text-sm max-w-3xl">
+      Hauteur stable entre tabs (320px sur le content). Bouton Copier sorti des tabs : dans la barre top à côté des sélecteurs. Sélecteurs alignés sur LocaleToggle / ThemeToggle du site (DropdownMenu ghost). Preview iframe à la taille réelle 480×280.
+    </p>
+  </header>
+
+  <div class="max-w-7xl mx-auto grid grid-cols-1 lg:grid-cols-2 gap-6">
+
+    <!-- ÉTAT 1 : Tab Aperçu actif -->
+    <section>
+      <p class="label-section">État 1 · Tab « Aperçu » actif</p>
+      <!-- Faux dialog -->
+      <div class="bg-card border-border rounded-xl border shadow-2xl" style="width: 100%;">
+        <div class="p-6">
+          <!-- Header -->
+          <div class="flex items-start justify-between gap-3 mb-2">
+            <h2 class="text-lg font-semibold leading-tight">Intégrer sur mon site</h2>
+            <button class="text-slate-400 hover:text-slate-200 transition-colors -mt-1 -mr-1">
+              <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18M6 6l12 12"/></svg>
+            </button>
+          </div>
+          <p class="text-sm text-slate-400 mb-5 leading-relaxed">
+            Le widget se met à jour automatiquement (date, places, état). Pensez à retirer le code de votre site quand l'événement sera passé.
+          </p>
+
+          <!-- Toolbar : sélecteurs + bouton Copier -->
+          <div class="flex items-center justify-between gap-2 mb-3">
+            <div class="flex items-center gap-1">
+              <!-- Locale dropdown style ghost -->
+              <button class="inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium text-slate-200 hover:bg-slate-800/60 transition-colors">
+                <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M2 12h20M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
+                FR
+              </button>
+              <!-- Theme dropdown style ghost -->
+              <button class="inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium text-slate-200 hover:bg-slate-800/60 transition-colors">
+                <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/></svg>
+                Clair
+              </button>
+            </div>
+            <!-- Copy button ghost -->
+            <button class="inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium text-slate-200 hover:bg-slate-800/60 transition-colors">
+              <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>
+              Copier le code
+            </button>
+          </div>
+
+          <!-- Tabs -->
+          <div class="bg-slate-800/60 inline-flex w-full rounded-lg p-0.5 mb-3" role="tablist">
+            <button class="flex-1 rounded-md bg-slate-900 px-3 py-1.5 text-sm font-medium text-slate-100 shadow-sm" aria-selected="true">
+              Aperçu
+            </button>
+            <button class="flex-1 rounded-md px-3 py-1.5 text-sm font-medium text-slate-400 hover:text-slate-200">
+              Code HTML
+            </button>
+          </div>
+
+          <!-- Tab content : Aperçu (h-[320px] fixe) -->
+          <div class="bg-slate-800/30 flex items-center justify-center overflow-auto rounded-lg border border-slate-800 p-4" style="height: 320px;">
+            <!-- Faux widget preview : carte 480x280 alignée sur le mockup embed-event-widget -->
+            <div class="bg-white rounded-2xl border border-slate-200 shadow-sm p-4" style="width: 480px;">
+              <div class="flex gap-4">
+                <div class="flex-shrink-0">
+                  <img src="https://picsum.photos/seed/preview/200/200" alt="" class="w-44 h-44 rounded-xl object-cover" />
+                </div>
+                <div class="flex-1 min-w-0 flex flex-col">
+                  <h3 class="text-base font-semibold text-slate-900 leading-snug line-clamp-2">Meetup IA & Créativité</h3>
+                  <div class="mt-3 space-y-1.5 text-xs text-slate-600">
+                    <p class="flex items-center gap-2">
+                      <svg class="w-3.5 h-3.5 flex-shrink-0 text-slate-400" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/></svg>
+                      Mardi 27 mai · 19h30
+                    </p>
+                    <p class="flex items-center gap-2">
+                      <svg class="w-3.5 h-3.5 flex-shrink-0 text-slate-400" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M17.657 16.657L13.414 20.9a2 2 0 01-2.828 0l-4.244-4.243a8 8 0 1111.314 0z"/><path stroke-linecap="round" stroke-linejoin="round" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"/></svg>
+                      Station F, Paris
+                    </p>
+                  </div>
+                  <div class="mt-3 flex items-center gap-2">
+                    <div class="flex -space-x-1.5">
+                      <div class="w-5 h-5 rounded-full ring-2 ring-white bg-gradient-to-br from-violet-500 to-indigo-500"></div>
+                      <div class="w-5 h-5 rounded-full ring-2 ring-white bg-gradient-to-br from-rose-500 to-fuchsia-600"></div>
+                      <div class="w-5 h-5 rounded-full ring-2 ring-white bg-gradient-to-br from-emerald-500 to-cyan-500"></div>
+                      <div class="w-5 h-5 rounded-full ring-2 ring-white bg-gradient-to-br from-amber-500 to-rose-500"></div>
+                    </div>
+                    <span class="text-xs text-slate-500">+12 inscrits</span>
+                  </div>
+                  <button class="mt-auto w-full bg-primary text-white text-sm font-semibold py-2.5 rounded-lg inline-flex items-center justify-center gap-1.5">
+                    <span>S'inscrire</span>
+                    <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M17 8l4 4m0 0l-4 4m4-4H3"/></svg>
+                  </button>
+                </div>
+              </div>
+              <p class="mt-3 text-center text-[9px] tracking-wide text-slate-300">
+                Powered by <span class="text-slate-400 font-semibold">The Playground</span>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ÉTAT 2 : Tab Code HTML actif -->
+    <section>
+      <p class="label-section">État 2 · Tab « Code HTML » actif</p>
+      <!-- Faux dialog (même structure exacte que l'État 1) -->
+      <div class="bg-card border-border rounded-xl border shadow-2xl" style="width: 100%;">
+        <div class="p-6">
+          <!-- Header (identique) -->
+          <div class="flex items-start justify-between gap-3 mb-2">
+            <h2 class="text-lg font-semibold leading-tight">Intégrer sur mon site</h2>
+            <button class="text-slate-400 hover:text-slate-200 transition-colors -mt-1 -mr-1">
+              <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18M6 6l12 12"/></svg>
+            </button>
+          </div>
+          <p class="text-sm text-slate-400 mb-5 leading-relaxed">
+            Le widget se met à jour automatiquement (date, places, état). Pensez à retirer le code de votre site quand l'événement sera passé.
+          </p>
+
+          <!-- Toolbar (identique) -->
+          <div class="flex items-center justify-between gap-2 mb-3">
+            <div class="flex items-center gap-1">
+              <button class="inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium text-slate-200 hover:bg-slate-800/60 transition-colors">
+                <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M2 12h20M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
+                FR
+              </button>
+              <button class="inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium text-slate-200 hover:bg-slate-800/60 transition-colors">
+                <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/></svg>
+                Clair
+              </button>
+            </div>
+            <button class="inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium text-slate-200 hover:bg-slate-800/60 transition-colors">
+              <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>
+              Copier le code
+            </button>
+          </div>
+
+          <!-- Tabs (Code HTML actif) -->
+          <div class="bg-slate-800/60 inline-flex w-full rounded-lg p-0.5 mb-3" role="tablist">
+            <button class="flex-1 rounded-md px-3 py-1.5 text-sm font-medium text-slate-400 hover:text-slate-200">
+              Aperçu
+            </button>
+            <button class="flex-1 rounded-md bg-slate-900 px-3 py-1.5 text-sm font-medium text-slate-100 shadow-sm" aria-selected="true">
+              Code HTML
+            </button>
+          </div>
+
+          <!-- Tab content : Code HTML (h-[320px] fixe) -->
+          <pre class="bg-slate-800/60 rounded-lg p-4 text-xs font-mono leading-relaxed overflow-auto text-slate-200" style="height: 320px;">&lt;iframe
+  src=&quot;https://the-playground.fr/embed/m/meetup-ia-creativite?locale=fr&amp;theme=light&quot;
+  width=&quot;480&quot;
+  height=&quot;280&quot;
+  frameborder=&quot;0&quot;
+  title=&quot;Événement : Meetup IA &amp; Créativité&quot;
+  loading=&quot;lazy&quot;
+&gt;&lt;/iframe&gt;</pre>
+        </div>
+      </div>
+    </section>
+
+  </div>
+
+  <footer class="max-w-7xl mx-auto mt-8 bg-slate-900/50 border border-slate-800 rounded-lg p-5 text-sm text-slate-400">
+    <p class="font-semibold mb-3 text-slate-200">Décisions de design (à valider)</p>
+    <ul class="list-disc list-inside space-y-1.5">
+      <li><strong>Hauteur identique entre tabs</strong> : <code class="bg-slate-800 px-1.5 py-0.5 rounded text-slate-200">style="height: 320px"</code> directement sur le contenu interne (pas sur TabsContent) pour ne pas dépendre du parent flex Radix.</li>
+      <li><strong>Bouton Copier sorti des tabs</strong> : dans la toolbar du haut, à droite des sélecteurs. Toujours accessible, jamais en superposition.</li>
+      <li><strong>Sélecteurs alignés sur le site</strong> : style ghost button avec icône + label court (Globe + FR, Sun + Clair). Cliquer ouvre un DropdownMenu (non rendu dans ce mockup statique).</li>
+      <li><strong>Tabs full-width</strong> : variant pill comme dans le projet, hauteur compacte.</li>
+      <li><strong>Preview iframe taille réelle</strong> : 480×280 centrée dans une zone 320px de haut avec background muted pour signifier "zone d'intégration".</li>
+      <li><strong>Pre code</strong> : font-mono, leading-relaxed, overflow-auto, fond muted pour distinction visuelle.</li>
+      <li><strong>Modale max-w-2xl (≈672px)</strong> : largeur suffisante pour les 2 tabs + iframe 480px + paddings.</li>
+    </ul>
+  </footer>
+
+</body>
+</html>

--- a/spec/mockups/embed-snippet-dialog.mockup.html
+++ b/spec/mockups/embed-snippet-dialog.mockup.html
@@ -49,7 +49,7 @@
     <p class="text-xs uppercase tracking-widest text-primary font-semibold mb-2">Spec embed-snippet-dialog · 2 états</p>
     <h1 class="text-2xl font-bold mb-1">Modale « Intégrer sur mon site »</h1>
     <p class="text-slate-400 text-sm max-w-3xl">
-      Hauteur stable entre tabs (320px sur le content). Bouton Copier sorti des tabs : dans la barre top à côté des sélecteurs. Sélecteurs alignés sur LocaleToggle / ThemeToggle du site (DropdownMenu ghost). Preview iframe à la taille réelle 480×280.
+      Hauteur stable entre tabs (320px sur le content). Bouton Copier sorti des tabs : dans la barre top à côté des sélecteurs. Sélecteurs alignés sur LocaleToggle / ThemeToggle du site (DropdownMenu ghost). Preview iframe à la taille réelle 480×250.
     </p>
   </header>
 
@@ -105,7 +105,7 @@
 
           <!-- Tab content : Aperçu (h-[320px] fixe) -->
           <div class="bg-slate-800/30 flex items-center justify-center overflow-auto rounded-lg border border-slate-800 p-4" style="height: 320px;">
-            <!-- Faux widget preview : carte 480x280 alignée sur le mockup embed-event-widget -->
+            <!-- Faux widget preview : carte 480x250 alignée sur le mockup embed-event-widget -->
             <div class="bg-white rounded-2xl border border-slate-200 shadow-sm p-4" style="width: 480px;">
               <div class="flex gap-4">
                 <div class="flex-shrink-0">
@@ -196,7 +196,7 @@
           <pre class="bg-slate-800/60 rounded-lg p-4 text-xs font-mono leading-relaxed overflow-auto text-slate-200" style="height: 320px;">&lt;iframe
   src=&quot;https://the-playground.fr/embed/m/meetup-ia-creativite?locale=fr&amp;theme=light&quot;
   width=&quot;480&quot;
-  height=&quot;280&quot;
+  height=&quot;250&quot;
   frameborder=&quot;0&quot;
   title=&quot;Événement : Meetup IA &amp; Créativité&quot;
   loading=&quot;lazy&quot;
@@ -214,7 +214,7 @@
       <li><strong>Bouton Copier sorti des tabs</strong> : dans la toolbar du haut, à droite des sélecteurs. Toujours accessible, jamais en superposition.</li>
       <li><strong>Sélecteurs alignés sur le site</strong> : style ghost button avec icône + label court (Globe + FR, Sun + Clair). Cliquer ouvre un DropdownMenu (non rendu dans ce mockup statique).</li>
       <li><strong>Tabs full-width</strong> : variant pill comme dans le projet, hauteur compacte.</li>
-      <li><strong>Preview iframe taille réelle</strong> : 480×280 centrée dans une zone 320px de haut avec background muted pour signifier "zone d'intégration".</li>
+      <li><strong>Preview iframe taille réelle</strong> : 480×250 centrée dans une zone 320px de haut avec background muted pour signifier "zone d'intégration".</li>
       <li><strong>Pre code</strong> : font-mono, leading-relaxed, overflow-auto, fond muted pour distinction visuelle.</li>
       <li><strong>Modale max-w-2xl (≈672px)</strong> : largeur suffisante pour les 2 tabs + iframe 480px + paddings.</li>
     </ul>

--- a/src/app/api/cron/posthog-daily-report/build-report-html.ts
+++ b/src/app/api/cron/posthog-daily-report/build-report-html.ts
@@ -1,3 +1,4 @@
+import { escapeHtml } from "@/lib/html";
 import type {
   PosthogDashboard,
   PosthogInsight,
@@ -54,15 +55,6 @@ const ENGAGEMENT_ORDER = [
 ];
 
 const BREAKDOWN_OTHER_LABEL = "$$_posthog_breakdown_other_$$";
-
-function escapeHtml(value: string): string {
-  return value
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
-}
 
 function findInsightByPrefix(
   dashboard: PosthogDashboard,

--- a/src/app/embed/layout.tsx
+++ b/src/app/embed/layout.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from "next";
+import { Inter } from "next/font/google";
+import "../globals.css";
+
+const inter = Inter({ subsets: ["latin"], variable: "--font-sans" });
+
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+};
+
+export default function EmbedLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html suppressHydrationWarning>
+      <body className={`${inter.variable} bg-transparent font-sans antialiased`}>
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/src/app/embed/m/[slug]/page.tsx
+++ b/src/app/embed/m/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import { notFound } from "next/navigation";
+import { after } from "next/server";
 import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 import {
@@ -11,17 +12,15 @@ import { MomentNotFoundError } from "@/domain/errors";
 import { isValidSlug } from "@/lib/slug";
 import { captureServerEvent } from "@/lib/posthog-server";
 import { EmbedEventCard } from "@/components/embed/embed-event-card";
+import type { EmbedLocale, EmbedTheme } from "@/components/embed/types";
 
 export const revalidate = 300;
 
-type SupportedLocale = "fr" | "en";
-type Theme = "light" | "dark";
-
-function parseLocale(raw: string | undefined): SupportedLocale {
+function parseLocale(raw: string | undefined): EmbedLocale {
   return raw === "en" ? "en" : "fr";
 }
 
-function parseTheme(raw: string | undefined): Theme {
+function parseTheme(raw: string | undefined): EmbedTheme {
   return raw === "dark" ? "dark" : "light";
 }
 
@@ -81,38 +80,33 @@ export default async function EmbedMomentPage({
 
   if (moment.status === "DRAFT") notFound();
 
-  const [circle, attendees] = await Promise.all([
+  const [circle, registered] = await Promise.all([
     prismaCircleRepository.findById(moment.circleId),
-    prismaRegistrationRepository.findActiveWithUserByMomentId(moment.id),
+    prismaRegistrationRepository.findRegisteredPreviewAndCount(moment.id, 4),
   ]);
 
   if (!circle) notFound();
 
-  const registered = attendees.filter((r) => r.status === "REGISTERED");
+  // distinctId stable pour compter les vues, pas créer un user PostHog par event.
+  // `after()` détache l'envoi du request lifecycle (sinon Vercel tronque).
+  after(() =>
+    captureServerEvent("embed_widget", "embed_widget_view", {
+      momentId: moment.id,
+      momentSlug: moment.slug,
+      circleSlug: circle.slug,
+      locale,
+      theme,
+      status: moment.status,
+    })
+  );
 
-  // Vue widget (server-side, sans cookie ni tracking visiteur).
-  // Émis seulement sur cache miss (revalidate=300), donc volumétrie modérée.
-  // distinctId stable ("embed_widget") pour ne pas créer un user PostHog par
-  // événement : on veut un compteur d'événements, pas une dimension user.
-  void captureServerEvent("embed_widget", "embed_widget_view", {
-    momentId: moment.id,
-    momentSlug: moment.slug,
-    circleSlug: circle.slug,
-    locale,
-    theme,
-    status: moment.status,
-  });
-
-  // No wrapper: the card renders at its natural height (~250px) and the
-  // iframe is sized to match in the snippet. The `dark` class is applied
-  // only as a context for the card's internal dark: variants.
   return (
-    <div className={theme === "dark" ? "dark" : undefined}>
+    <div className={theme === "dark" ? "dark" : ""}>
       <EmbedEventCard
         moment={moment}
         circle={circle}
-        registeredCount={registered.length}
-        registeredPreview={registered}
+        registeredCount={registered.total}
+        registeredPreview={registered.preview}
         locale={locale}
         theme={theme}
       />

--- a/src/app/embed/m/[slug]/page.tsx
+++ b/src/app/embed/m/[slug]/page.tsx
@@ -100,14 +100,11 @@ export default async function EmbedMomentPage({
     status: moment.status,
   });
 
-  // In dark mode we need to override the page background so the iframe's
-  // default white doesn't bleed around the dark card. Light mode already
-  // matches the default --background, so we keep the simple padded layout.
-  const wrapperClass =
-    theme === "dark" ? "dark min-h-screen bg-slate-900" : "p-4";
-
+  // No wrapper: the card renders at its natural height (~250px) and the
+  // iframe is sized to match in the snippet. The `dark` class is applied
+  // only as a context for the card's internal dark: variants.
   return (
-    <main className={wrapperClass}>
+    <div className={theme === "dark" ? "dark" : undefined}>
       <EmbedEventCard
         moment={moment}
         circle={circle}
@@ -116,6 +113,6 @@ export default async function EmbedMomentPage({
         locale={locale}
         theme={theme}
       />
-    </main>
+    </div>
   );
 }

--- a/src/app/embed/m/[slug]/page.tsx
+++ b/src/app/embed/m/[slug]/page.tsx
@@ -1,0 +1,115 @@
+import { notFound } from "next/navigation";
+import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
+import {
+  prismaCircleRepository,
+  prismaMomentRepository,
+  prismaRegistrationRepository,
+} from "@/infrastructure/repositories";
+import { getMomentBySlug } from "@/domain/usecases/get-moment";
+import { MomentNotFoundError } from "@/domain/errors";
+import { isValidSlug } from "@/lib/slug";
+import { captureServerEvent } from "@/lib/posthog-server";
+import { EmbedEventCard } from "@/components/embed/embed-event-card";
+
+export const revalidate = 300;
+
+type SupportedLocale = "fr" | "en";
+type Theme = "light" | "dark";
+
+function parseLocale(raw: string | undefined): SupportedLocale {
+  return raw === "en" ? "en" : "fr";
+}
+
+function parseTheme(raw: string | undefined): Theme {
+  return raw === "dark" ? "dark" : "light";
+}
+
+export async function generateMetadata({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ slug: string }>;
+  searchParams: Promise<{ locale?: string; theme?: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const sp = await searchParams;
+  const locale = parseLocale(sp.locale);
+
+  if (!isValidSlug(slug)) return { robots: { index: false, follow: false } };
+
+  let moment;
+  try {
+    moment = await getMomentBySlug(slug, {
+      momentRepository: prismaMomentRepository,
+    });
+  } catch {
+    return { robots: { index: false, follow: false } };
+  }
+
+  const t = await getTranslations({ locale, namespace: "EmbedWidget" });
+  return {
+    title: t("titleAlt", { title: moment.title }),
+    robots: { index: false, follow: false },
+  };
+}
+
+export default async function EmbedMomentPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ slug: string }>;
+  searchParams: Promise<{ locale?: string; theme?: string }>;
+}) {
+  const { slug } = await params;
+  const sp = await searchParams;
+
+  if (!isValidSlug(slug)) notFound();
+
+  const locale = parseLocale(sp.locale);
+  const theme = parseTheme(sp.theme);
+
+  let moment;
+  try {
+    moment = await getMomentBySlug(slug, {
+      momentRepository: prismaMomentRepository,
+    });
+  } catch (error) {
+    if (error instanceof MomentNotFoundError) notFound();
+    throw error;
+  }
+
+  if (moment.status === "DRAFT") notFound();
+
+  const [circle, attendees] = await Promise.all([
+    prismaCircleRepository.findById(moment.circleId),
+    prismaRegistrationRepository.findActiveWithUserByMomentId(moment.id),
+  ]);
+
+  if (!circle) notFound();
+
+  const registered = attendees.filter((r) => r.status === "REGISTERED");
+
+  // Vue widget (server-side, sans cookie ni tracking visiteur).
+  // Émis seulement sur cache miss (revalidate=300), donc volumétrie modérée.
+  void captureServerEvent(moment.id, "embed_widget_view", {
+    momentSlug: moment.slug,
+    circleSlug: circle.slug,
+    locale,
+    theme,
+    status: moment.status,
+  });
+
+  return (
+    <main className="p-4">
+      <EmbedEventCard
+        moment={moment}
+        circle={circle}
+        registeredCount={registered.length}
+        registeredPreview={registered}
+        locale={locale}
+        theme={theme}
+      />
+    </main>
+  );
+}

--- a/src/app/embed/m/[slug]/page.tsx
+++ b/src/app/embed/m/[slug]/page.tsx
@@ -100,12 +100,14 @@ export default async function EmbedMomentPage({
     status: moment.status,
   });
 
-  // Wrap with a background that matches the widget theme so the iframe's
-  // default browser background never bleeds around the card.
-  const themeBg = theme === "dark" ? "dark bg-slate-900" : "bg-white";
+  // In dark mode we need to override the page background so the iframe's
+  // default white doesn't bleed around the dark card. Light mode already
+  // matches the default --background, so we keep the simple padded layout.
+  const wrapperClass =
+    theme === "dark" ? "dark min-h-screen bg-slate-900" : "p-4";
 
   return (
-    <div className={`${themeBg} min-h-screen`}>
+    <main className={wrapperClass}>
       <EmbedEventCard
         moment={moment}
         circle={circle}
@@ -114,6 +116,6 @@ export default async function EmbedMomentPage({
         locale={locale}
         theme={theme}
       />
-    </div>
+    </main>
   );
 }

--- a/src/app/embed/m/[slug]/page.tsx
+++ b/src/app/embed/m/[slug]/page.tsx
@@ -92,7 +92,10 @@ export default async function EmbedMomentPage({
 
   // Vue widget (server-side, sans cookie ni tracking visiteur).
   // Émis seulement sur cache miss (revalidate=300), donc volumétrie modérée.
-  void captureServerEvent(moment.id, "embed_widget_view", {
+  // distinctId stable ("embed_widget") pour ne pas créer un user PostHog par
+  // événement : on veut un compteur d'événements, pas une dimension user.
+  void captureServerEvent("embed_widget", "embed_widget_view", {
+    momentId: moment.id,
     momentSlug: moment.slug,
     circleSlug: circle.slug,
     locale,

--- a/src/app/embed/m/[slug]/page.tsx
+++ b/src/app/embed/m/[slug]/page.tsx
@@ -100,8 +100,12 @@ export default async function EmbedMomentPage({
     status: moment.status,
   });
 
+  // Wrap with a background that matches the widget theme so the iframe's
+  // default browser background never bleeds around the card.
+  const themeBg = theme === "dark" ? "dark bg-slate-900" : "bg-white";
+
   return (
-    <main className="p-4">
+    <div className={`${themeBg} min-h-screen`}>
       <EmbedEventCard
         moment={moment}
         circle={circle}
@@ -110,6 +114,6 @@ export default async function EmbedMomentPage({
         locale={locale}
         theme={theme}
       />
-    </main>
+    </div>
   );
 }

--- a/src/components/embed/embed-event-card.tsx
+++ b/src/components/embed/embed-event-card.tsx
@@ -1,0 +1,288 @@
+import { getTranslations } from "next-intl/server";
+import type { Moment } from "@/domain/models/moment";
+import type { Circle } from "@/domain/models/circle";
+import type { RegistrationWithUser } from "@/domain/models/registration";
+import { formatLongDate, formatLocalizedTime } from "@/lib/format-date";
+import { getMomentGradient } from "@/lib/gradient";
+import { getPublicUserInitials } from "@/lib/display-name";
+import { getAppUrl } from "@/lib/app-url";
+
+type Theme = "light" | "dark";
+type SupportedLocale = "fr" | "en";
+
+type Props = {
+  moment: Moment;
+  circle: Pick<Circle, "slug" | "name">;
+  registeredCount: number;
+  registeredPreview: RegistrationWithUser[];
+  locale: SupportedLocale;
+  theme: Theme;
+};
+
+export async function EmbedEventCard({
+  moment,
+  circle,
+  registeredCount,
+  registeredPreview,
+  locale,
+  theme,
+}: Props) {
+  const t = await getTranslations({ locale, namespace: "EmbedWidget" });
+
+  const isDark = theme === "dark";
+  const isPast = moment.status === "PAST";
+  const isCancelled = moment.status === "CANCELLED";
+  const isPassive = isPast || isCancelled;
+
+  const appUrl = getAppUrl();
+  const publicMomentUrl = `${appUrl}/${locale}/m/${moment.slug}`;
+  const publicCircleUrl = `${appUrl}/${locale}/circles/${circle.slug}`;
+  const platformUrl = `${appUrl}?utm_source=embed_widget`;
+
+  const dateLine = `${formatLongDate(moment.startsAt, locale)} · ${formatLocalizedTime(moment.startsAt, locale)}`;
+  const locationLine =
+    moment.locationType === "ONLINE"
+      ? t("online")
+      : moment.locationName ?? moment.locationAddress ?? "";
+
+  const ctaHref = isPassive ? publicCircleUrl : publicMomentUrl;
+  const ctaLabel = isPassive ? t("viewUpcoming") : t("register");
+
+  const cardBg = isDark
+    ? "bg-slate-900 border-slate-800"
+    : "bg-white border-slate-200";
+  const titleColor = isDark
+    ? isPassive
+      ? "text-slate-400"
+      : "text-slate-50"
+    : isPassive
+      ? "text-slate-500"
+      : "text-slate-900";
+  const titleStrike = isCancelled
+    ? "line-through decoration-slate-500 decoration-1"
+    : "";
+  const dateColor = isDark ? "text-slate-400" : "text-slate-600";
+  const iconColor = isDark ? "text-slate-500" : "text-slate-400";
+  const proofColor = isDark ? "text-slate-400" : "text-slate-500";
+  const dividerRing = isDark ? "ring-slate-900" : "ring-white";
+  const footerColor = isDark ? "text-slate-600" : "text-slate-300";
+  const footerLink = isDark
+    ? "text-slate-500 hover:text-slate-400"
+    : "text-slate-400 hover:text-slate-500";
+
+  const coverClass = `h-48 w-48 rounded-xl object-cover ${
+    isPast ? "opacity-60 grayscale" : isCancelled ? "opacity-50 grayscale" : ""
+  }`;
+
+  return (
+    <div
+      className={`mx-auto w-full max-w-[480px] rounded-2xl border ${cardBg} p-4 shadow-sm`}
+    >
+      <div className="flex gap-4">
+        <div className="relative flex-shrink-0">
+          {moment.coverImage ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img src={moment.coverImage} alt="" className={coverClass} />
+          ) : (
+            <div
+              className={coverClass}
+              style={{ background: getMomentGradient(moment.slug) }}
+            />
+          )}
+          {isPast && (
+            <span className="absolute left-2 top-2 rounded bg-slate-700 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-white">
+              {t("badgePast")}
+            </span>
+          )}
+          {isCancelled && (
+            <span className="absolute left-2 top-2 rounded bg-red-900/80 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-red-100">
+              {t("badgeCancelled")}
+            </span>
+          )}
+        </div>
+        <div className="flex min-w-0 flex-1 flex-col">
+          <h2
+            className={`line-clamp-2 text-base font-semibold leading-snug ${titleColor} ${titleStrike}`}
+          >
+            {moment.title}
+          </h2>
+          <div className={`mt-4 space-y-2 text-xs ${dateColor}`}>
+            <p className="flex items-center gap-2">
+              <CalendarIcon className={iconColor} />
+              <span>{dateLine}</span>
+            </p>
+            <p className="flex items-center gap-2">
+              <MapPinIcon className={iconColor} />
+              <span className="truncate">{locationLine}</span>
+            </p>
+          </div>
+          {isCancelled ? (
+            <p className="mt-4 text-xs italic text-red-300/80">
+              {t("cancelledExplanation")}
+            </p>
+          ) : (
+            <SocialProof
+              attendees={registeredPreview}
+              totalCount={registeredCount}
+              label={
+                isPast
+                  ? t("attendedCount", { count: registeredCount })
+                  : t("attendingCount", { count: registeredCount })
+              }
+              ringClass={dividerRing}
+              labelColor={proofColor}
+              passive={isPast}
+            />
+          )}
+          <a
+            href={ctaHref}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={ctaClassName(isPassive, isDark)}
+          >
+            <span>{ctaLabel}</span>
+            <ArrowRightIcon />
+          </a>
+        </div>
+      </div>
+      <p
+        className={`mt-3 text-center text-[9px] tracking-wide ${footerColor}`}
+      >
+        {t("poweredBy")}{" "}
+        <a
+          href={platformUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={`transition-colors ${footerLink}`}
+        >
+          The Playground
+        </a>
+      </p>
+    </div>
+  );
+}
+
+function ctaClassName(passive: boolean, dark: boolean): string {
+  const base =
+    "mt-auto inline-flex w-full items-center justify-center gap-1.5 rounded-lg py-2.5 text-center text-sm font-semibold transition-colors";
+  if (!passive) {
+    return `${base} bg-primary text-white hover:bg-primary/90`;
+  }
+  if (dark) {
+    return `${base} border border-slate-700 text-slate-300 hover:border-slate-100 hover:bg-slate-100 hover:text-slate-900`;
+  }
+  return `${base} border border-slate-300 text-slate-700 hover:border-slate-900 hover:bg-slate-900 hover:text-white`;
+}
+
+function SocialProof({
+  attendees,
+  totalCount,
+  label,
+  ringClass,
+  labelColor,
+  passive,
+}: {
+  attendees: RegistrationWithUser[];
+  totalCount: number;
+  label: string;
+  ringClass: string;
+  labelColor: string;
+  passive: boolean;
+}) {
+  if (totalCount === 0) return null;
+  const visible = attendees.slice(0, 4);
+  const stackOpacity = passive ? "opacity-60" : "";
+  const avatarFilter = passive ? "grayscale" : "";
+
+  return (
+    <div className="mt-4 flex items-center gap-2">
+      <div className={`flex -space-x-1.5 ${stackOpacity}`}>
+        {visible.map((a, i) => {
+          const initials = getPublicUserInitials(a.user);
+          const gradient = getMomentGradient(a.user.email);
+          return (
+            <div
+              key={i}
+              className={`relative flex h-5 w-5 shrink-0 items-center justify-center overflow-hidden rounded-full text-[8px] font-semibold text-white ring-2 ${ringClass} ${avatarFilter}`}
+              style={{ background: gradient }}
+            >
+              {a.user.image ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={a.user.image}
+                  alt=""
+                  className="h-full w-full object-cover"
+                />
+              ) : (
+                initials
+              )}
+            </div>
+          );
+        })}
+      </div>
+      <span className={`text-xs ${labelColor}`}>{label}</span>
+    </div>
+  );
+}
+
+function CalendarIcon({ className = "" }: { className?: string }) {
+  return (
+    <svg
+      className={`h-3.5 w-3.5 flex-shrink-0 ${className}`}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+      />
+    </svg>
+  );
+}
+
+function MapPinIcon({ className = "" }: { className?: string }) {
+  return (
+    <svg
+      className={`h-3.5 w-3.5 flex-shrink-0 ${className}`}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M17.657 16.657L13.414 20.9a2 2 0 01-2.828 0l-4.244-4.243a8 8 0 1111.314 0z"
+      />
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
+      />
+    </svg>
+  );
+}
+
+function ArrowRightIcon() {
+  return (
+    <svg
+      className="h-3.5 w-3.5"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.5"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M17 8l4 4m0 0l-4 4m4-4H3"
+      />
+    </svg>
+  );
+}

--- a/src/components/embed/embed-event-card.tsx
+++ b/src/components/embed/embed-event-card.tsx
@@ -1,4 +1,5 @@
 import { getTranslations } from "next-intl/server";
+import { Calendar, MapPin, ArrowRight } from "lucide-react";
 import type { Moment } from "@/domain/models/moment";
 import type { Circle } from "@/domain/models/circle";
 import type { RegistrationWithUser } from "@/domain/models/registration";
@@ -6,17 +7,15 @@ import { formatLongDate, formatLocalizedTime } from "@/lib/format-date";
 import { getMomentGradient } from "@/lib/gradient";
 import { getPublicUserInitials } from "@/lib/display-name";
 import { getAppUrl } from "@/lib/app-url";
-
-type Theme = "light" | "dark";
-type SupportedLocale = "fr" | "en";
+import type { EmbedLocale, EmbedTheme } from "@/components/embed/types";
 
 type Props = {
   moment: Moment;
   circle: Pick<Circle, "slug" | "name">;
   registeredCount: number;
   registeredPreview: RegistrationWithUser[];
-  locale: SupportedLocale;
-  theme: Theme;
+  locale: EmbedLocale;
+  theme: EmbedTheme;
 };
 
 export async function EmbedEventCard({
@@ -48,35 +47,44 @@ export async function EmbedEventCard({
   const ctaHref = isPassive ? publicCircleUrl : publicMomentUrl;
   const ctaLabel = isPassive ? t("viewUpcoming") : t("register");
 
-  const cardBg = isDark
-    ? "bg-slate-900 border-slate-800"
-    : "bg-white border-slate-200";
-  const titleColor = isDark
-    ? isPassive
-      ? "text-slate-400"
-      : "text-slate-50"
-    : isPassive
-      ? "text-slate-500"
-      : "text-slate-900";
+  const palette = isDark
+    ? {
+        card: "bg-slate-900 border-slate-800",
+        titleActive: "text-slate-50",
+        titlePassive: "text-slate-400",
+        date: "text-slate-400",
+        icon: "text-slate-500",
+        proof: "text-slate-400",
+        ring: "ring-slate-900",
+        footer: "text-slate-600",
+        footerLink: "text-slate-500 hover:text-slate-400",
+      }
+    : {
+        card: "bg-white border-slate-200",
+        titleActive: "text-slate-900",
+        titlePassive: "text-slate-500",
+        date: "text-slate-600",
+        icon: "text-slate-400",
+        proof: "text-slate-500",
+        ring: "ring-white",
+        footer: "text-slate-300",
+        footerLink: "text-slate-400 hover:text-slate-500",
+      };
+  const titleColor = isPassive ? palette.titlePassive : palette.titleActive;
   const titleStrike = isCancelled
     ? "line-through decoration-slate-500 decoration-1"
     : "";
-  const dateColor = isDark ? "text-slate-400" : "text-slate-600";
-  const iconColor = isDark ? "text-slate-500" : "text-slate-400";
-  const proofColor = isDark ? "text-slate-400" : "text-slate-500";
-  const dividerRing = isDark ? "ring-slate-900" : "ring-white";
-  const footerColor = isDark ? "text-slate-600" : "text-slate-300";
-  const footerLink = isDark
-    ? "text-slate-500 hover:text-slate-400"
-    : "text-slate-400 hover:text-slate-500";
 
-  const coverClass = `h-48 w-48 rounded-xl object-cover ${
-    isPast ? "opacity-60 grayscale" : isCancelled ? "opacity-50 grayscale" : ""
-  }`;
+  const coverOpacity = isPast
+    ? "opacity-60 grayscale"
+    : isCancelled
+      ? "opacity-50 grayscale"
+      : "";
+  const coverClass = `h-48 w-48 rounded-xl object-cover ${coverOpacity}`;
 
   return (
     <div
-      className={`mx-auto w-full max-w-[480px] rounded-2xl border ${cardBg} p-4 shadow-sm`}
+      className={`mx-auto w-full max-w-[480px] rounded-2xl border ${palette.card} p-4 shadow-sm`}
     >
       <div className="flex gap-4">
         <div className="relative flex-shrink-0">
@@ -106,13 +114,13 @@ export async function EmbedEventCard({
           >
             {moment.title}
           </h2>
-          <div className={`mt-4 space-y-2 text-xs ${dateColor}`}>
+          <div className={`mt-4 space-y-2 text-xs ${palette.date}`}>
             <p className="flex items-center gap-2">
-              <CalendarIcon className={iconColor} />
+              <Calendar className={`size-3.5 shrink-0 ${palette.icon}`} aria-hidden="true" />
               <span>{dateLine}</span>
             </p>
             <p className="flex items-center gap-2">
-              <MapPinIcon className={iconColor} />
+              <MapPin className={`size-3.5 shrink-0 ${palette.icon}`} aria-hidden="true" />
               <span className="truncate">{locationLine}</span>
             </p>
           </div>
@@ -129,8 +137,8 @@ export async function EmbedEventCard({
                   ? t("attendedCount", { count: registeredCount })
                   : t("attendingCount", { count: registeredCount })
               }
-              ringClass={dividerRing}
-              labelColor={proofColor}
+              ringClass={palette.ring}
+              labelColor={palette.proof}
               passive={isPast}
             />
           )}
@@ -141,19 +149,19 @@ export async function EmbedEventCard({
             className={ctaClassName(isPassive, isDark)}
           >
             <span>{ctaLabel}</span>
-            <ArrowRightIcon />
+            <ArrowRight className="size-3.5" aria-hidden="true" />
           </a>
         </div>
       </div>
       <p
-        className={`mt-3 text-center text-[9px] tracking-wide ${footerColor}`}
+        className={`mt-3 text-center text-[9px] tracking-wide ${palette.footer}`}
       >
         {t("poweredBy")}{" "}
         <a
           href={platformUrl}
           target="_blank"
           rel="noopener noreferrer"
-          className={`transition-colors ${footerLink}`}
+          className={`transition-colors ${palette.footerLink}`}
         >
           The Playground
         </a>
@@ -225,64 +233,3 @@ function SocialProof({
   );
 }
 
-function CalendarIcon({ className = "" }: { className?: string }) {
-  return (
-    <svg
-      className={`h-3.5 w-3.5 flex-shrink-0 ${className}`}
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      viewBox="0 0 24 24"
-      aria-hidden="true"
-    >
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
-      />
-    </svg>
-  );
-}
-
-function MapPinIcon({ className = "" }: { className?: string }) {
-  return (
-    <svg
-      className={`h-3.5 w-3.5 flex-shrink-0 ${className}`}
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      viewBox="0 0 24 24"
-      aria-hidden="true"
-    >
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        d="M17.657 16.657L13.414 20.9a2 2 0 01-2.828 0l-4.244-4.243a8 8 0 1111.314 0z"
-      />
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
-      />
-    </svg>
-  );
-}
-
-function ArrowRightIcon() {
-  return (
-    <svg
-      className="h-3.5 w-3.5"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2.5"
-      viewBox="0 0 24 24"
-      aria-hidden="true"
-    >
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        d="M17 8l4 4m0 0l-4 4m4-4H3"
-      />
-    </svg>
-  );
-}

--- a/src/components/embed/embed-snippet-dialog.tsx
+++ b/src/components/embed/embed-snippet-dialog.tsx
@@ -147,13 +147,8 @@ function LocaleDropdown({
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button
-          variant="ghost"
-          size="sm"
-          className="text-xs font-medium"
-          aria-label={ariaLabel}
-        >
-          <Globe className="size-3.5" />
+        <Button variant="ghost" size="sm" aria-label={ariaLabel}>
+          <Globe className="size-4" />
           {value.toUpperCase()}
         </Button>
       </DropdownMenuTrigger>
@@ -187,13 +182,8 @@ function ThemeDropdown({
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button
-          variant="ghost"
-          size="sm"
-          className="text-xs font-medium"
-          aria-label={ariaLabel}
-        >
-          <Icon className="size-3.5" />
+        <Button variant="ghost" size="sm" aria-label={ariaLabel}>
+          <Icon className="size-4" />
           {labels[value]}
         </Button>
       </DropdownMenuTrigger>

--- a/src/components/embed/embed-snippet-dialog.tsx
+++ b/src/components/embed/embed-snippet-dialog.tsx
@@ -60,7 +60,7 @@ export function EmbedSnippetDialog({ momentSlug, momentTitle, appUrl }: Props) {
         </Button>
       </DialogTrigger>
       <DialogContent className="max-w-2xl">
-        <DialogHeader>
+        <DialogHeader className="gap-3">
           <DialogTitle>{t("dashboardTitle")}</DialogTitle>
           <DialogDescription className="whitespace-pre-line">
             {t("dashboardNote")}

--- a/src/components/embed/embed-snippet-dialog.tsx
+++ b/src/components/embed/embed-snippet-dialog.tsx
@@ -76,7 +76,7 @@ export function EmbedSnippetDialog({ momentSlug, momentTitle, appUrl }: Props) {
                 en: t("dashboardLocaleEn"),
               }}
             />
-            <ThemeDropdown
+            <ThemeToggleButton
               value={theme}
               onChange={setTheme}
               ariaLabel={t("dashboardLabelTheme")}
@@ -167,7 +167,7 @@ function LocaleDropdown({
   );
 }
 
-function ThemeDropdown({
+function ThemeToggleButton({
   value,
   onChange,
   ariaLabel,
@@ -180,25 +180,15 @@ function ThemeDropdown({
 }) {
   const Icon = value === "dark" ? Moon : Sun;
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button variant="ghost" size="sm" aria-label={ariaLabel}>
-          <Icon className="size-4" />
-          {labels[value]}
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="start">
-        {(Object.keys(labels) as Theme[]).map((t) => (
-          <DropdownMenuItem
-            key={t}
-            onClick={() => onChange(t)}
-            className={t === value ? "font-semibold" : ""}
-          >
-            {labels[t]}
-          </DropdownMenuItem>
-        ))}
-      </DropdownMenuContent>
-    </DropdownMenu>
+    <Button
+      variant="ghost"
+      size="sm"
+      aria-label={ariaLabel}
+      onClick={() => onChange(value === "dark" ? "light" : "dark")}
+    >
+      <Icon className="size-4" />
+      {labels[value]}
+    </Button>
   );
 }
 

--- a/src/components/embed/embed-snippet-dialog.tsx
+++ b/src/components/embed/embed-snippet-dialog.tsx
@@ -115,7 +115,7 @@ export function EmbedSnippetDialog({ momentSlug, momentTitle, appUrl }: Props) {
                 height={EMBED_HEIGHT}
                 frameBorder={0}
                 title={t("titleAlt", { title: momentTitle })}
-                className="block max-w-full"
+                className="block max-w-full rounded-2xl"
                 style={{ maxHeight: "100%" }}
               />
             </div>

--- a/src/components/embed/embed-snippet-dialog.tsx
+++ b/src/components/embed/embed-snippet-dialog.tsx
@@ -121,7 +121,7 @@ export function EmbedSnippetDialog({ momentSlug, momentTitle, appUrl }: Props) {
 
           <TabsContent value="code" className="mt-3 min-w-0">
             <pre
-              className="bg-muted max-w-full overflow-auto rounded-lg p-3 text-xs leading-relaxed"
+              className="bg-muted max-w-full overflow-auto whitespace-pre-wrap break-all rounded-lg p-3 text-xs leading-relaxed"
               style={{ height: 320 }}
             >
               <code>{snippet}</code>

--- a/src/components/embed/embed-snippet-dialog.tsx
+++ b/src/components/embed/embed-snippet-dialog.tsx
@@ -86,13 +86,13 @@ export function EmbedSnippetDialog({ momentSlug, momentTitle, appUrl }: Props) {
           />
         </div>
 
-        <Tabs defaultValue="preview" className="w-full">
+        <Tabs defaultValue="preview" className="min-w-0">
           <TabsList>
             <TabsTrigger value="preview">{t("dashboardPreviewTitle")}</TabsTrigger>
             <TabsTrigger value="code">{t("dashboardSnippetTitle")}</TabsTrigger>
           </TabsList>
 
-          <TabsContent value="preview" className="mt-3">
+          <TabsContent value="preview" className="mt-3 min-w-0">
             <div className="bg-muted/30 flex items-center justify-center overflow-auto rounded-lg border p-4">
               <iframe
                 key={embedUrl}
@@ -106,9 +106,9 @@ export function EmbedSnippetDialog({ momentSlug, momentTitle, appUrl }: Props) {
             </div>
           </TabsContent>
 
-          <TabsContent value="code" className="mt-3">
-            <div className="bg-muted relative rounded-lg p-3">
-              <div className="absolute right-2 top-2">
+          <TabsContent value="code" className="mt-3 min-w-0">
+            <div className="bg-muted relative min-w-0 rounded-lg p-3">
+              <div className="absolute right-2 top-2 z-10">
                 <CopyButton
                   value={snippet}
                   label={t("dashboardCta")}
@@ -117,7 +117,7 @@ export function EmbedSnippetDialog({ momentSlug, momentTitle, appUrl }: Props) {
                   size="sm"
                 />
               </div>
-              <pre className="overflow-auto pr-24 text-xs leading-relaxed">
+              <pre className="max-w-full overflow-x-auto pr-24 text-xs leading-relaxed">
                 <code>{snippet}</code>
               </pre>
             </div>

--- a/src/components/embed/embed-snippet-dialog.tsx
+++ b/src/components/embed/embed-snippet-dialog.tsx
@@ -92,8 +92,8 @@ export function EmbedSnippetDialog({ momentSlug, momentTitle, appUrl }: Props) {
             <TabsTrigger value="code">{t("dashboardSnippetTitle")}</TabsTrigger>
           </TabsList>
 
-          <TabsContent value="preview" className="mt-3 min-w-0">
-            <div className="bg-muted/30 flex items-center justify-center overflow-auto rounded-lg border p-4">
+          <TabsContent value="preview" className="mt-3 h-[320px] min-w-0">
+            <div className="bg-muted/30 flex h-full items-center justify-center overflow-auto rounded-lg border p-4">
               <iframe
                 key={embedUrl}
                 src={embedUrl}
@@ -106,21 +106,19 @@ export function EmbedSnippetDialog({ momentSlug, momentTitle, appUrl }: Props) {
             </div>
           </TabsContent>
 
-          <TabsContent value="code" className="mt-3 min-w-0">
-            <div className="bg-muted relative min-w-0 rounded-lg p-3">
-              <div className="absolute right-2 top-2 z-10">
-                <CopyButton
-                  value={snippet}
-                  label={t("dashboardCta")}
-                  copiedLabel={t("dashboardCopied")}
-                  variant="ghost"
-                  size="sm"
-                />
-              </div>
-              <pre className="max-w-full overflow-x-auto pr-24 text-xs leading-relaxed">
-                <code>{snippet}</code>
-              </pre>
+          <TabsContent value="code" className="mt-3 flex h-[320px] min-w-0 flex-col">
+            <div className="mb-2 flex shrink-0 justify-end">
+              <CopyButton
+                value={snippet}
+                label={t("dashboardCta")}
+                copiedLabel={t("dashboardCopied")}
+                variant="ghost"
+                size="sm"
+              />
             </div>
+            <pre className="bg-muted min-w-0 flex-1 max-w-full overflow-auto rounded-lg p-3 text-xs leading-relaxed">
+              <code>{snippet}</code>
+            </pre>
           </TabsContent>
         </Tabs>
       </DialogContent>

--- a/src/components/embed/embed-snippet-dialog.tsx
+++ b/src/components/embed/embed-snippet-dialog.tsx
@@ -96,7 +96,7 @@ export function EmbedSnippetDialog({ momentSlug, momentTitle, appUrl }: Props) {
         </div>
 
         <Tabs defaultValue="preview" className="min-w-0">
-          <TabsList>
+          <TabsList className="w-full">
             <TabsTrigger value="preview">{t("dashboardPreviewTitle")}</TabsTrigger>
             <TabsTrigger value="code">{t("dashboardSnippetTitle")}</TabsTrigger>
           </TabsList>

--- a/src/components/embed/embed-snippet-dialog.tsx
+++ b/src/components/embed/embed-snippet-dialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { Code } from "lucide-react";
+import { Code, Globe, Moon, Sun } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { CopyButton } from "@/components/ui/copy-button";
@@ -13,6 +13,18 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@/components/ui/tabs";
 
 type Locale = "fr" | "en";
 type Theme = "light" | "dark";
@@ -23,6 +35,7 @@ type Props = {
   appUrl: string;
 };
 
+const EMBED_WIDTH = 480;
 const EMBED_HEIGHT = 280;
 
 export function EmbedSnippetDialog({ momentSlug, momentTitle, appUrl }: Props) {
@@ -34,7 +47,7 @@ export function EmbedSnippetDialog({ momentSlug, momentTitle, appUrl }: Props) {
 
   const snippet = useMemo(
     () =>
-      `<iframe\n  src="${embedUrl}"\n  width="100%"\n  height="${EMBED_HEIGHT}"\n  frameborder="0"\n  title="${escapeHtmlAttr(t("titleAlt", { title: momentTitle }))}"\n  loading="lazy"\n></iframe>`,
+      `<iframe\n  src="${embedUrl}"\n  width="${EMBED_WIDTH}"\n  height="${EMBED_HEIGHT}"\n  frameborder="0"\n  title="${escapeHtmlAttr(t("titleAlt", { title: momentTitle }))}"\n  loading="lazy"\n></iframe>`,
     [embedUrl, momentTitle, t]
   );
 
@@ -52,105 +65,145 @@ export function EmbedSnippetDialog({ momentSlug, momentTitle, appUrl }: Props) {
           <DialogDescription>{t("dashboardNote")}</DialogDescription>
         </DialogHeader>
 
-        <div className="space-y-5">
-          <div className="grid grid-cols-2 gap-4">
-            <div>
-              <label className="text-muted-foreground mb-1.5 block text-xs font-medium uppercase tracking-wider">
-                {t("dashboardLabelLocale")}
-              </label>
-              <SegmentedControl
-                value={locale}
-                onChange={setLocale}
-                options={[
-                  { value: "fr", label: t("dashboardLocaleFr") },
-                  { value: "en", label: t("dashboardLocaleEn") },
-                ]}
-              />
-            </div>
-            <div>
-              <label className="text-muted-foreground mb-1.5 block text-xs font-medium uppercase tracking-wider">
-                {t("dashboardLabelTheme")}
-              </label>
-              <SegmentedControl
-                value={theme}
-                onChange={setTheme}
-                options={[
-                  { value: "light", label: t("dashboardThemeLight") },
-                  { value: "dark", label: t("dashboardThemeDark") },
-                ]}
-              />
-            </div>
-          </div>
+        <div className="flex items-center gap-1">
+          <LocaleDropdown
+            value={locale}
+            onChange={setLocale}
+            ariaLabel={t("dashboardLabelLocale")}
+            labels={{
+              fr: t("dashboardLocaleFr"),
+              en: t("dashboardLocaleEn"),
+            }}
+          />
+          <ThemeDropdown
+            value={theme}
+            onChange={setTheme}
+            ariaLabel={t("dashboardLabelTheme")}
+            labels={{
+              light: t("dashboardThemeLight"),
+              dark: t("dashboardThemeDark"),
+            }}
+          />
+        </div>
 
-          <div>
-            <p className="text-muted-foreground mb-2 text-xs font-medium uppercase tracking-wider">
-              {t("dashboardPreviewTitle")}
-            </p>
-            <div className="bg-muted/30 overflow-hidden rounded-xl border p-4">
+        <Tabs defaultValue="preview" className="w-full">
+          <TabsList>
+            <TabsTrigger value="preview">{t("dashboardPreviewTitle")}</TabsTrigger>
+            <TabsTrigger value="code">{t("dashboardSnippetTitle")}</TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="preview" className="mt-3">
+            <div className="bg-muted/30 flex items-center justify-center overflow-auto rounded-lg border p-4">
               <iframe
                 key={embedUrl}
                 src={embedUrl}
-                width="100%"
+                width={EMBED_WIDTH}
                 height={EMBED_HEIGHT}
                 frameBorder={0}
                 title={t("titleAlt", { title: momentTitle })}
                 className="block"
               />
             </div>
-          </div>
+          </TabsContent>
 
-          <div>
-            <div className="mb-2 flex items-center justify-between">
-              <p className="text-muted-foreground text-xs font-medium uppercase tracking-wider">
-                {t("dashboardSnippetTitle")}
-              </p>
-              <CopyButton
-                value={snippet}
-                label={t("dashboardCta")}
-                copiedLabel={t("dashboardCopied")}
-                variant="default"
-                size="sm"
-              />
+          <TabsContent value="code" className="mt-3">
+            <div className="bg-muted relative rounded-lg p-3">
+              <div className="absolute right-2 top-2">
+                <CopyButton
+                  value={snippet}
+                  label={t("dashboardCta")}
+                  copiedLabel={t("dashboardCopied")}
+                  variant="ghost"
+                  size="sm"
+                />
+              </div>
+              <pre className="overflow-auto pr-24 text-xs leading-relaxed">
+                <code>{snippet}</code>
+              </pre>
             </div>
-            <pre className="bg-muted overflow-x-auto rounded-lg p-3 text-xs leading-relaxed">
-              <code>{snippet}</code>
-            </pre>
-          </div>
-        </div>
+          </TabsContent>
+        </Tabs>
       </DialogContent>
     </Dialog>
   );
 }
 
-function SegmentedControl<T extends string>({
+function LocaleDropdown({
   value,
   onChange,
-  options,
+  ariaLabel,
+  labels,
 }: {
-  value: T;
-  onChange: (next: T) => void;
-  options: { value: T; label: string }[];
+  value: Locale;
+  onChange: (next: Locale) => void;
+  ariaLabel: string;
+  labels: Record<Locale, string>;
 }) {
   return (
-    <div className="bg-muted inline-flex w-full rounded-lg p-0.5">
-      {options.map((opt) => {
-        const active = opt.value === value;
-        return (
-          <button
-            key={opt.value}
-            type="button"
-            onClick={() => onChange(opt.value)}
-            className={`flex-1 rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
-              active
-                ? "bg-background text-foreground shadow-sm"
-                : "text-muted-foreground hover:text-foreground"
-            }`}
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="text-xs font-medium"
+          aria-label={ariaLabel}
+        >
+          <Globe className="size-3.5" />
+          {value.toUpperCase()}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start">
+        {(Object.keys(labels) as Locale[]).map((l) => (
+          <DropdownMenuItem
+            key={l}
+            onClick={() => onChange(l)}
+            className={l === value ? "font-semibold" : ""}
           >
-            {opt.label}
-          </button>
-        );
-      })}
-    </div>
+            {labels[l]}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+function ThemeDropdown({
+  value,
+  onChange,
+  ariaLabel,
+  labels,
+}: {
+  value: Theme;
+  onChange: (next: Theme) => void;
+  ariaLabel: string;
+  labels: Record<Theme, string>;
+}) {
+  const Icon = value === "dark" ? Moon : Sun;
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="text-xs font-medium"
+          aria-label={ariaLabel}
+        >
+          <Icon className="size-3.5" />
+          {labels[value]}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start">
+        {(Object.keys(labels) as Theme[]).map((t) => (
+          <DropdownMenuItem
+            key={t}
+            onClick={() => onChange(t)}
+            className={t === value ? "font-semibold" : ""}
+          >
+            {labels[t]}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }
 

--- a/src/components/embed/embed-snippet-dialog.tsx
+++ b/src/components/embed/embed-snippet-dialog.tsx
@@ -36,7 +36,7 @@ type Props = {
 };
 
 const EMBED_WIDTH = 480;
-const EMBED_HEIGHT = 280;
+const EMBED_HEIGHT = 250;
 
 export function EmbedSnippetDialog({ momentSlug, momentTitle, appUrl }: Props) {
   const t = useTranslations("EmbedWidget");

--- a/src/components/embed/embed-snippet-dialog.tsx
+++ b/src/components/embed/embed-snippet-dialog.tsx
@@ -121,8 +121,8 @@ export function EmbedSnippetDialog({ momentSlug, momentTitle, appUrl }: Props) {
 
           <TabsContent value="code" className="mt-3 min-w-0">
             <pre
-              className="bg-muted max-w-full overflow-auto whitespace-pre-wrap break-all rounded-lg p-3 text-xs leading-relaxed"
-              style={{ height: 320 }}
+              className="bg-muted max-w-full overflow-scroll rounded-lg p-3 text-xs leading-relaxed [&::-webkit-scrollbar]:h-2 [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-thumb]:rounded [&::-webkit-scrollbar-thumb]:bg-slate-600/60 [&::-webkit-scrollbar-track]:bg-transparent"
+              style={{ height: 320, scrollbarWidth: "thin" }}
             >
               <code>{snippet}</code>
             </pre>

--- a/src/components/embed/embed-snippet-dialog.tsx
+++ b/src/components/embed/embed-snippet-dialog.tsx
@@ -102,7 +102,10 @@ export function EmbedSnippetDialog({ momentSlug, momentTitle, appUrl }: Props) {
           </TabsList>
 
           <TabsContent value="preview" className="mt-3 min-w-0">
-            <div className="bg-muted/30 flex h-[320px] items-center justify-center overflow-auto rounded-lg border p-4">
+            <div
+              className="bg-muted/30 flex items-center justify-center overflow-hidden rounded-lg border p-4"
+              style={{ height: 320 }}
+            >
               <iframe
                 key={embedUrl}
                 src={embedUrl}
@@ -110,13 +113,17 @@ export function EmbedSnippetDialog({ momentSlug, momentTitle, appUrl }: Props) {
                 height={EMBED_HEIGHT}
                 frameBorder={0}
                 title={t("titleAlt", { title: momentTitle })}
-                className="block"
+                className="block max-w-full"
+                style={{ maxHeight: "100%" }}
               />
             </div>
           </TabsContent>
 
           <TabsContent value="code" className="mt-3 min-w-0">
-            <pre className="bg-muted h-[320px] max-w-full overflow-auto rounded-lg p-3 text-xs leading-relaxed">
+            <pre
+              className="bg-muted max-w-full overflow-auto rounded-lg p-3 text-xs leading-relaxed"
+              style={{ height: 320 }}
+            >
               <code>{snippet}</code>
             </pre>
           </TabsContent>

--- a/src/components/embed/embed-snippet-dialog.tsx
+++ b/src/components/embed/embed-snippet-dialog.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from "react";
 import { Code, Globe, Moon, Sun } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { useTheme } from "next-themes";
 import { Button } from "@/components/ui/button";
 import { CopyButton } from "@/components/ui/copy-button";
 import {
@@ -40,8 +41,18 @@ const EMBED_HEIGHT = 250;
 
 export function EmbedSnippetDialog({ momentSlug, momentTitle, appUrl }: Props) {
   const t = useTranslations("EmbedWidget");
+  const { resolvedTheme } = useTheme();
   const [locale, setLocale] = useState<Locale>("fr");
   const [theme, setTheme] = useState<Theme>("light");
+
+  // Initialise le theme du widget sur celui du site à chaque ouverture, pour
+  // que l'Organisateur démarre par défaut sur le rendu qui matche son dashboard.
+  function handleOpenChange(open: boolean) {
+    if (!open) return;
+    if (resolvedTheme === "dark" || resolvedTheme === "light") {
+      setTheme(resolvedTheme);
+    }
+  }
 
   const embedUrl = `${appUrl}/embed/m/${momentSlug}?locale=${locale}&theme=${theme}`;
 
@@ -52,7 +63,7 @@ export function EmbedSnippetDialog({ momentSlug, momentTitle, appUrl }: Props) {
   );
 
   return (
-    <Dialog>
+    <Dialog onOpenChange={handleOpenChange}>
       <DialogTrigger asChild>
         <Button variant="outline" size="sm">
           <Code className="size-4" />

--- a/src/components/embed/embed-snippet-dialog.tsx
+++ b/src/components/embed/embed-snippet-dialog.tsx
@@ -26,9 +26,8 @@ import {
   TabsList,
   TabsTrigger,
 } from "@/components/ui/tabs";
-
-type Locale = "fr" | "en";
-type Theme = "light" | "dark";
+import { escapeHtml } from "@/lib/html";
+import type { EmbedLocale, EmbedTheme } from "@/components/embed/types";
 
 type Props = {
   momentSlug: string;
@@ -42,11 +41,10 @@ const EMBED_HEIGHT = 250;
 export function EmbedSnippetDialog({ momentSlug, momentTitle, appUrl }: Props) {
   const t = useTranslations("EmbedWidget");
   const { resolvedTheme } = useTheme();
-  const [locale, setLocale] = useState<Locale>("fr");
-  const [theme, setTheme] = useState<Theme>("light");
+  const [locale, setLocale] = useState<EmbedLocale>("fr");
+  const [theme, setTheme] = useState<EmbedTheme>("light");
 
-  // Initialise le theme du widget sur celui du site à chaque ouverture, pour
-  // que l'Organisateur démarre par défaut sur le rendu qui matche son dashboard.
+  // Sync à l'ouverture: respecte un choix manuel ultérieur pendant l'usage.
   function handleOpenChange(open: boolean) {
     if (!open) return;
     if (resolvedTheme === "dark" || resolvedTheme === "light") {
@@ -58,7 +56,7 @@ export function EmbedSnippetDialog({ momentSlug, momentTitle, appUrl }: Props) {
 
   const snippet = useMemo(
     () =>
-      `<iframe\n  src="${embedUrl}"\n  width="${EMBED_WIDTH}"\n  height="${EMBED_HEIGHT}"\n  frameborder="0"\n  title="${escapeHtmlAttr(t("titleAlt", { title: momentTitle }))}"\n  loading="lazy"\n></iframe>`,
+      `<iframe\n  src="${embedUrl}"\n  width="${EMBED_WIDTH}"\n  height="${EMBED_HEIGHT}"\n  frameborder="0"\n  title="${escapeHtml(t("titleAlt", { title: momentTitle }))}"\n  loading="lazy"\n></iframe>`,
     [embedUrl, momentTitle, t]
   );
 
@@ -152,10 +150,10 @@ function LocaleDropdown({
   ariaLabel,
   labels,
 }: {
-  value: Locale;
-  onChange: (next: Locale) => void;
+  value: EmbedLocale;
+  onChange: (next: EmbedLocale) => void;
   ariaLabel: string;
-  labels: Record<Locale, string>;
+  labels: Record<EmbedLocale, string>;
 }) {
   return (
     <DropdownMenu>
@@ -166,7 +164,7 @@ function LocaleDropdown({
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start">
-        {(Object.keys(labels) as Locale[]).map((l) => (
+        {(Object.keys(labels) as EmbedLocale[]).map((l) => (
           <DropdownMenuItem
             key={l}
             onClick={() => onChange(l)}
@@ -186,10 +184,10 @@ function ThemeToggleButton({
   ariaLabel,
   labels,
 }: {
-  value: Theme;
-  onChange: (next: Theme) => void;
+  value: EmbedTheme;
+  onChange: (next: EmbedTheme) => void;
   ariaLabel: string;
-  labels: Record<Theme, string>;
+  labels: Record<EmbedTheme, string>;
 }) {
   const Icon = value === "dark" ? Moon : Sun;
   return (
@@ -205,6 +203,3 @@ function ThemeToggleButton({
   );
 }
 
-function escapeHtmlAttr(value: string): string {
-  return value.replace(/"/g, "&quot;").replace(/'/g, "&#39;");
-}

--- a/src/components/embed/embed-snippet-dialog.tsx
+++ b/src/components/embed/embed-snippet-dialog.tsx
@@ -105,7 +105,7 @@ export function EmbedSnippetDialog({ momentSlug, momentTitle, appUrl }: Props) {
 
           <TabsContent value="preview" className="mt-3 min-w-0">
             <div
-              className="bg-muted flex items-center justify-center overflow-hidden rounded-lg p-4"
+              className="flex items-center justify-center"
               style={{ height: 320 }}
             >
               <iframe

--- a/src/components/embed/embed-snippet-dialog.tsx
+++ b/src/components/embed/embed-snippet-dialog.tsx
@@ -103,10 +103,10 @@ export function EmbedSnippetDialog({ momentSlug, momentTitle, appUrl }: Props) {
             <TabsTrigger value="code">{t("dashboardSnippetTitle")}</TabsTrigger>
           </TabsList>
 
-          <TabsContent value="preview" className="mt-3 min-w-0">
+          <TabsContent value="preview" className="mt-2 min-w-0">
             <div
               className="flex items-center justify-center"
-              style={{ height: 320 }}
+              style={{ height: 260 }}
             >
               <iframe
                 key={embedUrl}
@@ -121,10 +121,10 @@ export function EmbedSnippetDialog({ momentSlug, momentTitle, appUrl }: Props) {
             </div>
           </TabsContent>
 
-          <TabsContent value="code" className="mt-3 min-w-0">
+          <TabsContent value="code" className="mt-2 min-w-0">
             <pre
               className="bg-muted max-w-full overflow-scroll rounded-lg p-3 text-xs leading-relaxed [&::-webkit-scrollbar]:h-2 [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar]:appearance-none [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-slate-500/70 [&::-webkit-scrollbar-track]:rounded-full [&::-webkit-scrollbar-track]:bg-slate-700/30"
-              style={{ height: 320, scrollbarWidth: "thin", scrollbarColor: "rgba(100,116,139,0.7) rgba(51,65,85,0.3)" }}
+              style={{ height: 260, scrollbarWidth: "thin", scrollbarColor: "rgba(100,116,139,0.7) rgba(51,65,85,0.3)" }}
             >
               <code>{snippet}</code>
             </pre>

--- a/src/components/embed/embed-snippet-dialog.tsx
+++ b/src/components/embed/embed-snippet-dialog.tsx
@@ -62,7 +62,9 @@ export function EmbedSnippetDialog({ momentSlug, momentTitle, appUrl }: Props) {
       <DialogContent className="max-w-2xl">
         <DialogHeader>
           <DialogTitle>{t("dashboardTitle")}</DialogTitle>
-          <DialogDescription>{t("dashboardNote")}</DialogDescription>
+          <DialogDescription className="whitespace-pre-line">
+            {t("dashboardNote")}
+          </DialogDescription>
         </DialogHeader>
 
         <div className="flex items-center justify-between gap-2">
@@ -121,8 +123,8 @@ export function EmbedSnippetDialog({ momentSlug, momentTitle, appUrl }: Props) {
 
           <TabsContent value="code" className="mt-3 min-w-0">
             <pre
-              className="bg-muted max-w-full overflow-scroll rounded-lg p-3 text-xs leading-relaxed [&::-webkit-scrollbar]:h-2 [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-thumb]:rounded [&::-webkit-scrollbar-thumb]:bg-slate-600/60 [&::-webkit-scrollbar-track]:bg-transparent"
-              style={{ height: 320, scrollbarWidth: "thin" }}
+              className="bg-muted max-w-full overflow-scroll rounded-lg p-3 text-xs leading-relaxed [&::-webkit-scrollbar]:h-2 [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar]:appearance-none [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-slate-500/70 [&::-webkit-scrollbar-track]:rounded-full [&::-webkit-scrollbar-track]:bg-slate-700/30"
+              style={{ height: 320, scrollbarWidth: "thin", scrollbarColor: "rgba(100,116,139,0.7) rgba(51,65,85,0.3)" }}
             >
               <code>{snippet}</code>
             </pre>

--- a/src/components/embed/embed-snippet-dialog.tsx
+++ b/src/components/embed/embed-snippet-dialog.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Code } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { Button } from "@/components/ui/button";
+import { CopyButton } from "@/components/ui/copy-button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+
+type Locale = "fr" | "en";
+type Theme = "light" | "dark";
+
+type Props = {
+  momentSlug: string;
+  momentTitle: string;
+  appUrl: string;
+};
+
+const EMBED_HEIGHT = 280;
+
+export function EmbedSnippetDialog({ momentSlug, momentTitle, appUrl }: Props) {
+  const t = useTranslations("EmbedWidget");
+  const [locale, setLocale] = useState<Locale>("fr");
+  const [theme, setTheme] = useState<Theme>("light");
+
+  const embedUrl = `${appUrl}/embed/m/${momentSlug}?locale=${locale}&theme=${theme}`;
+
+  const snippet = useMemo(
+    () =>
+      `<iframe\n  src="${embedUrl}"\n  width="100%"\n  height="${EMBED_HEIGHT}"\n  frameborder="0"\n  title="${escapeHtmlAttr(t("titleAlt", { title: momentTitle }))}"\n  loading="lazy"\n></iframe>`,
+    [embedUrl, momentTitle, t]
+  );
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm">
+          <Code className="size-4" />
+          {t("dashboardOpen")}
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>{t("dashboardTitle")}</DialogTitle>
+          <DialogDescription>{t("dashboardNote")}</DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-5">
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="text-muted-foreground mb-1.5 block text-xs font-medium uppercase tracking-wider">
+                {t("dashboardLabelLocale")}
+              </label>
+              <SegmentedControl
+                value={locale}
+                onChange={setLocale}
+                options={[
+                  { value: "fr", label: t("dashboardLocaleFr") },
+                  { value: "en", label: t("dashboardLocaleEn") },
+                ]}
+              />
+            </div>
+            <div>
+              <label className="text-muted-foreground mb-1.5 block text-xs font-medium uppercase tracking-wider">
+                {t("dashboardLabelTheme")}
+              </label>
+              <SegmentedControl
+                value={theme}
+                onChange={setTheme}
+                options={[
+                  { value: "light", label: t("dashboardThemeLight") },
+                  { value: "dark", label: t("dashboardThemeDark") },
+                ]}
+              />
+            </div>
+          </div>
+
+          <div>
+            <p className="text-muted-foreground mb-2 text-xs font-medium uppercase tracking-wider">
+              {t("dashboardPreviewTitle")}
+            </p>
+            <div className="bg-muted/30 overflow-hidden rounded-xl border p-4">
+              <iframe
+                key={embedUrl}
+                src={embedUrl}
+                width="100%"
+                height={EMBED_HEIGHT}
+                frameBorder={0}
+                title={t("titleAlt", { title: momentTitle })}
+                className="block"
+              />
+            </div>
+          </div>
+
+          <div>
+            <div className="mb-2 flex items-center justify-between">
+              <p className="text-muted-foreground text-xs font-medium uppercase tracking-wider">
+                {t("dashboardSnippetTitle")}
+              </p>
+              <CopyButton
+                value={snippet}
+                label={t("dashboardCta")}
+                copiedLabel={t("dashboardCopied")}
+                variant="default"
+                size="sm"
+              />
+            </div>
+            <pre className="bg-muted overflow-x-auto rounded-lg p-3 text-xs leading-relaxed">
+              <code>{snippet}</code>
+            </pre>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function SegmentedControl<T extends string>({
+  value,
+  onChange,
+  options,
+}: {
+  value: T;
+  onChange: (next: T) => void;
+  options: { value: T; label: string }[];
+}) {
+  return (
+    <div className="bg-muted inline-flex w-full rounded-lg p-0.5">
+      {options.map((opt) => {
+        const active = opt.value === value;
+        return (
+          <button
+            key={opt.value}
+            type="button"
+            onClick={() => onChange(opt.value)}
+            className={`flex-1 rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+              active
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            {opt.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function escapeHtmlAttr(value: string): string {
+  return value.replace(/"/g, "&quot;").replace(/'/g, "&#39;");
+}

--- a/src/components/embed/embed-snippet-dialog.tsx
+++ b/src/components/embed/embed-snippet-dialog.tsx
@@ -65,24 +65,33 @@ export function EmbedSnippetDialog({ momentSlug, momentTitle, appUrl }: Props) {
           <DialogDescription>{t("dashboardNote")}</DialogDescription>
         </DialogHeader>
 
-        <div className="flex items-center gap-1">
-          <LocaleDropdown
-            value={locale}
-            onChange={setLocale}
-            ariaLabel={t("dashboardLabelLocale")}
-            labels={{
-              fr: t("dashboardLocaleFr"),
-              en: t("dashboardLocaleEn"),
-            }}
-          />
-          <ThemeDropdown
-            value={theme}
-            onChange={setTheme}
-            ariaLabel={t("dashboardLabelTheme")}
-            labels={{
-              light: t("dashboardThemeLight"),
-              dark: t("dashboardThemeDark"),
-            }}
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex items-center gap-1">
+            <LocaleDropdown
+              value={locale}
+              onChange={setLocale}
+              ariaLabel={t("dashboardLabelLocale")}
+              labels={{
+                fr: t("dashboardLocaleFr"),
+                en: t("dashboardLocaleEn"),
+              }}
+            />
+            <ThemeDropdown
+              value={theme}
+              onChange={setTheme}
+              ariaLabel={t("dashboardLabelTheme")}
+              labels={{
+                light: t("dashboardThemeLight"),
+                dark: t("dashboardThemeDark"),
+              }}
+            />
+          </div>
+          <CopyButton
+            value={snippet}
+            label={t("dashboardCta")}
+            copiedLabel={t("dashboardCopied")}
+            variant="ghost"
+            size="sm"
           />
         </div>
 
@@ -92,8 +101,8 @@ export function EmbedSnippetDialog({ momentSlug, momentTitle, appUrl }: Props) {
             <TabsTrigger value="code">{t("dashboardSnippetTitle")}</TabsTrigger>
           </TabsList>
 
-          <TabsContent value="preview" className="mt-3 h-[320px] min-w-0">
-            <div className="bg-muted/30 flex h-full items-center justify-center overflow-auto rounded-lg border p-4">
+          <TabsContent value="preview" className="mt-3 min-w-0">
+            <div className="bg-muted/30 flex h-[320px] items-center justify-center overflow-auto rounded-lg border p-4">
               <iframe
                 key={embedUrl}
                 src={embedUrl}
@@ -106,17 +115,8 @@ export function EmbedSnippetDialog({ momentSlug, momentTitle, appUrl }: Props) {
             </div>
           </TabsContent>
 
-          <TabsContent value="code" className="mt-3 flex h-[320px] min-w-0 flex-col">
-            <div className="mb-2 flex shrink-0 justify-end">
-              <CopyButton
-                value={snippet}
-                label={t("dashboardCta")}
-                copiedLabel={t("dashboardCopied")}
-                variant="ghost"
-                size="sm"
-              />
-            </div>
-            <pre className="bg-muted min-w-0 flex-1 max-w-full overflow-auto rounded-lg p-3 text-xs leading-relaxed">
+          <TabsContent value="code" className="mt-3 min-w-0">
+            <pre className="bg-muted h-[320px] max-w-full overflow-auto rounded-lg p-3 text-xs leading-relaxed">
               <code>{snippet}</code>
             </pre>
           </TabsContent>

--- a/src/components/embed/embed-snippet-dialog.tsx
+++ b/src/components/embed/embed-snippet-dialog.tsx
@@ -103,7 +103,7 @@ export function EmbedSnippetDialog({ momentSlug, momentTitle, appUrl }: Props) {
 
           <TabsContent value="preview" className="mt-3 min-w-0">
             <div
-              className="bg-muted/30 flex items-center justify-center overflow-hidden rounded-lg border p-4"
+              className="bg-muted flex items-center justify-center overflow-hidden rounded-lg p-4"
               style={{ height: 320 }}
             >
               <iframe

--- a/src/components/embed/types.ts
+++ b/src/components/embed/types.ts
@@ -1,0 +1,2 @@
+export type EmbedLocale = "fr" | "en";
+export type EmbedTheme = "light" | "dark";

--- a/src/components/moments/moment-detail-view.tsx
+++ b/src/components/moments/moment-detail-view.tsx
@@ -675,7 +675,7 @@ export async function MomentDetailView(props: MomentDetailViewProps) {
               </div>
 
               {moment.status !== "DRAFT" && props.appUrl && (
-                <>
+                <div className="hidden md:block">
                   <div className="border-border ml-11 border-t" />
                   <div className="flex items-center gap-3 py-3">
                     <div className="bg-primary/10 text-primary flex size-8 shrink-0 items-center justify-center rounded-lg">
@@ -695,7 +695,7 @@ export async function MomentDetailView(props: MomentDetailViewProps) {
                       appUrl={props.appUrl}
                     />
                   </div>
-                </>
+                </div>
               )}
 
               {moment.status !== "PAST" && moment.status !== "CANCELLED" && (

--- a/src/components/moments/moment-detail-view.tsx
+++ b/src/components/moments/moment-detail-view.tsx
@@ -43,7 +43,9 @@ import {
   ArrowRight,
   ArrowUpRight,
   ShieldCheck,
+  Code,
 } from "lucide-react";
+import { EmbedSnippetDialog } from "@/components/embed/embed-snippet-dialog";
 
 // ── Types ────────────────────────────────────────────────────
 
@@ -221,6 +223,7 @@ export async function MomentDetailView(props: MomentDetailViewProps) {
 
   const t = await getTranslations("Moment");
   const tCommon = await getTranslations("Common");
+  const tEmbed = await getTranslations("EmbedWidget");
   const tCircle = await getTranslations("Circle");
   const tDashboard = await getTranslations("Dashboard");
   const locale = await getLocale();
@@ -670,6 +673,30 @@ export async function MomentDetailView(props: MomentDetailViewProps) {
                   </div>
                 </div>
               </div>
+
+              {moment.status !== "DRAFT" && props.appUrl && (
+                <>
+                  <div className="border-border ml-11 border-t" />
+                  <div className="flex items-center gap-3 py-3">
+                    <div className="bg-primary/10 text-primary flex size-8 shrink-0 items-center justify-center rounded-lg">
+                      <Code className="size-[15px]" />
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <p className="text-[13px] font-medium">
+                        {tEmbed("dashboardCardLabel")}
+                      </p>
+                      <p className="text-muted-foreground text-xs">
+                        {tEmbed("dashboardCardDescription")}
+                      </p>
+                    </div>
+                    <EmbedSnippetDialog
+                      momentSlug={moment.slug}
+                      momentTitle={moment.title}
+                      appUrl={props.appUrl}
+                    />
+                  </div>
+                </>
+              )}
 
               {moment.status !== "PAST" && moment.status !== "CANCELLED" && (
                 <>

--- a/src/domain/ports/repositories/registration-repository.ts
+++ b/src/domain/ports/repositories/registration-repository.ts
@@ -37,6 +37,15 @@ export interface RegistrationRepository {
   findActiveWithUserByMomentId(
     momentId: string
   ): Promise<RegistrationWithUser[]>;
+  /**
+   * Lightweight read for the embed widget social proof: only the first N
+   * REGISTERED users (avatar fields only) + the total REGISTERED count.
+   * Avoids loading all attendees of popular events.
+   */
+  findRegisteredPreviewAndCount(
+    momentId: string,
+    previewSize: number
+  ): Promise<{ preview: RegistrationWithUser[]; total: number }>;
   countByMomentIdAndStatus(
     momentId: string,
     status: RegistrationStatus

--- a/src/domain/usecases/__tests__/helpers/mock-registration-repository.ts
+++ b/src/domain/usecases/__tests__/helpers/mock-registration-repository.ts
@@ -11,6 +11,7 @@ export function createMockRegistrationRepository(
     findByMomentAndUser: vi.fn<RegistrationRepository["findByMomentAndUser"]>().mockResolvedValue(null),
     findActiveByMomentId: vi.fn<RegistrationRepository["findActiveByMomentId"]>().mockResolvedValue([]),
     findActiveWithUserByMomentId: vi.fn<RegistrationRepository["findActiveWithUserByMomentId"]>().mockResolvedValue([]),
+    findRegisteredPreviewAndCount: vi.fn<RegistrationRepository["findRegisteredPreviewAndCount"]>().mockResolvedValue({ preview: [], total: 0 }),
     countByMomentIdAndStatus: vi.fn<RegistrationRepository["countByMomentIdAndStatus"]>().mockResolvedValue(0),
     findRegisteredCountsByMomentIds: vi.fn<RegistrationRepository["findRegisteredCountsByMomentIds"]>().mockResolvedValue(new Map()),
     findByMomentIdsAndUser: vi.fn<RegistrationRepository["findByMomentIdsAndUser"]>().mockResolvedValue(new Map()),

--- a/src/infrastructure/repositories/prisma-registration-repository.ts
+++ b/src/infrastructure/repositories/prisma-registration-repository.ts
@@ -140,6 +140,35 @@ export const prismaRegistrationRepository: RegistrationRepository = {
     return records.map(toDomainRegistrationWithUser);
   },
 
+  async findRegisteredPreviewAndCount(
+    momentId: string,
+    previewSize: number
+  ): Promise<{ preview: RegistrationWithUser[]; total: number }> {
+    const [previewRecords, total] = await Promise.all([
+      prisma.registration.findMany({
+        where: { momentId, status: "REGISTERED" },
+        include: {
+          user: {
+            select: {
+              id: true,
+              firstName: true,
+              lastName: true,
+              email: true,
+              image: true,
+              publicId: true,
+            },
+          },
+        },
+        orderBy: { registeredAt: "asc" },
+        take: previewSize,
+      }),
+      prisma.registration.count({
+        where: { momentId, status: "REGISTERED" },
+      }),
+    ]);
+    return { preview: previewRecords.map(toDomainRegistrationWithUser), total };
+  },
+
   async countByMomentIdAndStatus(
     momentId: string,
     status: RegistrationStatus

--- a/src/lib/html.ts
+++ b/src/lib/html.ts
@@ -1,0 +1,12 @@
+/**
+ * Escapes a string for safe inclusion in HTML markup (text or attribute value).
+ * Covers the five reserved characters required by the HTML5 spec.
+ */
+export function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -74,5 +74,7 @@ export default function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/((?!api|_next|_vercel|monitoring|ingest|icon|embed|.*\\..*).*)"],
+  // `embed(?:/|$)` (vs simple `embed`) évite de matcher des paths futurs
+  // comme /embedded-foo qui ne sont pas l'app widget embed.
+  matcher: ["/((?!api|_next|_vercel|monitoring|ingest|icon|embed(?:/|$)|.*\\..*).*)"],
 };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -74,5 +74,5 @@ export default function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/((?!api|_next|_vercel|monitoring|ingest|icon|.*\\..*).*)"],
+  matcher: ["/((?!api|_next|_vercel|monitoring|ingest|icon|embed|.*\\..*).*)"],
 };

--- a/tests/e2e/embed-widget.spec.ts
+++ b/tests/e2e/embed-widget.spec.ts
@@ -24,9 +24,9 @@ test.describe("Embed widget — rendu public", () => {
   test("should not render the site header or footer", async ({ page }) => {
     await page.goto(`/embed/m/${SLUGS.PUBLISHED_MOMENT}`);
     await expect(page.locator("header.site-header")).toHaveCount(0);
-    await expect(page.locator("footer").filter({ hasText: /the playground/i }).first()).toBeVisible();
-    // Le footer présent est uniquement la mention "Powered by The Playground"
-    // dans la carte, pas le SiteFooter du reste de l'app.
+    // La mention "Powered by The Playground" est rendue dans un <p>, pas dans
+    // un <footer> HTML : on vérifie juste sa présence.
+    await expect(page.getByText(/powered by the playground/i)).toBeVisible();
   });
 
   test("should serve frame-ancestors * in CSP (allow embedding anywhere)", async ({ request }) => {

--- a/tests/e2e/embed-widget.spec.ts
+++ b/tests/e2e/embed-widget.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect } from "@playwright/test";
+import { SLUGS, AUTH } from "./fixtures";
+
+/**
+ * Tests E2E — Widget embed événement (#485)
+ *
+ * Couvre :
+ *   - Rendu de la carte publiée (200, contient titre + CTA S'inscrire)
+ *   - Pas de SiteHeader / SiteFooter (page dépouillée)
+ *   - Headers CSP : frame-ancestors *
+ *   - Query params locale / theme
+ *   - États : passé, annulé, DRAFT, slug inexistant
+ *   - Bouton "Intégrer sur mon site" dans le dashboard détail (Host)
+ */
+
+test.describe("Embed widget — rendu public", () => {
+  test("should render the active event card with title and CTA", async ({ page }) => {
+    const response = await page.goto(`/embed/m/${SLUGS.PUBLISHED_MOMENT}`);
+    expect(response?.status()).toBe(200);
+    await expect(page.getByRole("heading", { level: 2 })).toBeVisible();
+    await expect(page.getByRole("link", { name: /s'inscrire/i })).toBeVisible();
+  });
+
+  test("should not render the site header or footer", async ({ page }) => {
+    await page.goto(`/embed/m/${SLUGS.PUBLISHED_MOMENT}`);
+    await expect(page.locator("header.site-header")).toHaveCount(0);
+    await expect(page.locator("footer").filter({ hasText: /the playground/i }).first()).toBeVisible();
+    // Le footer présent est uniquement la mention "Powered by The Playground"
+    // dans la carte, pas le SiteFooter du reste de l'app.
+  });
+
+  test("should serve frame-ancestors * in CSP (allow embedding anywhere)", async ({ request }) => {
+    const response = await request.get(`/embed/m/${SLUGS.PUBLISHED_MOMENT}`);
+    const csp = response.headers()["content-security-policy"] ?? "";
+    expect(csp).toContain("frame-ancestors *");
+    expect(response.headers()["x-frame-options"]).toBeUndefined();
+  });
+
+  test("should switch to English with ?locale=en", async ({ page }) => {
+    await page.goto(`/embed/m/${SLUGS.PUBLISHED_MOMENT}?locale=en`);
+    await expect(page.getByRole("link", { name: /^join/i })).toBeVisible();
+  });
+
+  test("should fall back to French for invalid locale", async ({ page }) => {
+    await page.goto(`/embed/m/${SLUGS.PUBLISHED_MOMENT}?locale=xx`);
+    await expect(page.getByRole("link", { name: /s'inscrire/i })).toBeVisible();
+  });
+
+  test("should open the public moment page in a new tab (target=_blank)", async ({ page }) => {
+    await page.goto(`/embed/m/${SLUGS.PUBLISHED_MOMENT}`);
+    const cta = page.getByRole("link", { name: /s'inscrire/i });
+    await expect(cta).toHaveAttribute("target", "_blank");
+    await expect(cta).toHaveAttribute("rel", /noopener/);
+  });
+});
+
+test.describe("Embed widget — états passifs et erreurs", () => {
+  test("should render the past event with CTA towards the Circle page", async ({ page }) => {
+    await page.goto(`/embed/m/${SLUGS.PAST_MOMENT}`);
+    await expect(page.getByRole("link", { name: /voir les prochains/i })).toBeVisible();
+  });
+
+  test("should render the cancelled event with a cancelled banner", async ({ page }) => {
+    await page.goto(`/embed/m/${SLUGS.CANCELLED_MOMENT}`);
+    await expect(page.getByRole("link", { name: /voir les prochains/i })).toBeVisible();
+  });
+
+  test("should return 404 for an unknown slug", async ({ page }) => {
+    const response = await page.goto(`/embed/m/inexistant-1234`);
+    expect(response?.status()).toBe(404);
+  });
+});
+
+test.describe("Embed widget — dashboard Organisateur", () => {
+  test.use({ storageState: AUTH.HOST });
+
+  test("should show the 'Get the code' button on the dashboard event detail", async ({ page }) => {
+    await page.goto(
+      `/fr/dashboard/circles/${SLUGS.CIRCLE}/moments/${SLUGS.PUBLISHED_MOMENT}`
+    );
+    await expect(page.getByRole("button", { name: /obtenir le code/i })).toBeVisible();
+  });
+
+  test("should open the embed snippet dialog when clicked", async ({ page }) => {
+    await page.goto(
+      `/fr/dashboard/circles/${SLUGS.CIRCLE}/moments/${SLUGS.PUBLISHED_MOMENT}`
+    );
+    await page.getByRole("button", { name: /obtenir le code/i }).click();
+    await expect(page.getByRole("dialog")).toBeVisible();
+    await expect(page.locator("iframe[src*='/embed/m/']")).toBeVisible();
+    await expect(page.locator("pre code")).toContainText("<iframe");
+  });
+});

--- a/tests/e2e/embed-widget.spec.ts
+++ b/tests/e2e/embed-widget.spec.ts
@@ -81,13 +81,16 @@ test.describe("Embed widget — dashboard Organisateur", () => {
     await expect(page.getByRole("button", { name: /obtenir le code/i })).toBeVisible();
   });
 
-  test("should open the embed snippet dialog when clicked", async ({ page }) => {
+  test("should open the embed snippet dialog with preview and code tabs", async ({ page }) => {
     await page.goto(
       `/fr/dashboard/circles/${SLUGS.CIRCLE}/moments/${SLUGS.PUBLISHED_MOMENT}`
     );
     await page.getByRole("button", { name: /obtenir le code/i }).click();
     await expect(page.getByRole("dialog")).toBeVisible();
+    // Tab Aperçu actif par défaut → iframe visible
     await expect(page.locator("iframe[src*='/embed/m/']")).toBeVisible();
+    // Switch sur le tab Code HTML → snippet visible
+    await page.getByRole("tab", { name: /code html/i }).click();
     await expect(page.locator("pre code")).toContainText("<iframe");
   });
 });


### PR DESCRIPTION
## Summary

Implémentation du widget embed événement (closes #485).

Un Organisateur peut maintenant générer un snippet `<iframe>` à coller sur son site externe (blog, asso, landing page) pour afficher un de ses événements. Le widget se met à jour automatiquement (date, places, état), supporte FR/EN et light/dark, et reste 100% gratuit là où Luma et Meetup paywallent leur API.

## Architecture

- **Nouvelle route** `/embed/m/[slug]` (hors `[locale]`, layout dépouillé sans header/footer projet)
- **Composant `EmbedEventCard`** : carte event 480×250 (cover 1:1 à gauche, infos + CTA empilés à droite, footer "Powered by" centré)
- **4 variants** : active/passive × light/dark, gérés via une palette lookup
- **Modale dashboard** : bouton "Obtenir le code" sur la page event detail (caché en mobile) → modale avec tabs Aperçu / Code HTML, sélecteurs locale/theme alignés sur les conventions du site, init theme sur celui du dashboard

## Sécurité

- **CSP scoped** : `/embed/*` autorise `frame-ancestors *` (embed externe OK), le reste du site garde `frame-ancestors 'none'` + `X-Frame-Options: DENY`
- **`frame-src 'self'`** ajouté au CSP par défaut pour autoriser le live preview dans la modale dashboard
- **Middleware** : `/embed/*` exclu du matcher intl pour éviter les rewrites locale qui produisaient des 404
- **`escapeHtml` mutualisé** : couvre les 5 chars HTML pour le titre dans l'attribut `title` du snippet (anti-XSS)

## Analytics

Event PostHog server-side `embed_widget_view` avec props `momentSlug`, `circleSlug`, `locale`, `theme`, `status`. Émis via `after()` de `next/server` pour ne pas bloquer le TTFB ni être tronqué par Vercel. distinctId stable `"embed_widget"` pour compter les vues sans créer un user fantôme par événement.

## Performance

- `revalidate = 300` (cache CDN 5 min)
- Nouvelle méthode repo `findRegisteredPreviewAndCount(momentId, 4)` : fetch 4 avatars + count en parallèle au lieu de charger tous les inscrits avec 10 colonnes user (gain O(N) sur events populaires)

## Test plan

- [ ] Generate snippet depuis le dashboard event détail (`/dashboard/circles/[c]/moments/[m]` → "Obtenir le code")
- [ ] Tab Aperçu : iframe rend la carte 480×250 sans double bordure
- [ ] Tab Code HTML : snippet copier-coller correct, scroll horizontal visible si overflow
- [ ] Locale switcher (FR / EN) met à jour l'aperçu + le snippet
- [ ] Theme toggle (Clair / Sombre) met à jour l'aperçu + le snippet ; init sur le theme du site
- [ ] Coller le snippet sur un site externe → la carte s'affiche
- [ ] `/embed/m/[slug]?theme=dark` rend la version dark sans bordure blanche zombie
- [ ] `/embed/m/[event-passé]` rend la carte grisée + CTA "Voir les prochains"
- [ ] `/embed/m/[event-annulé]` rend la carte annulée + CTA Communauté
- [ ] `/embed/m/[event-DRAFT]` retourne 404
- [ ] Sur mobile, le bloc "Widget événement" n'apparaît pas dans le dashboard
- [ ] Headers : `curl -I /embed/m/foo` montre `frame-ancestors *` et **pas** de `X-Frame-Options`

🤖 Generated with [Claude Code](https://claude.com/claude-code)