### PR TITLE
chore(vercel): redirige msl.the-playground.fr vers Le Club MSL

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,13 @@
 {
   "ignoreCommand": "bash scripts/vercel-ignore.sh",
+  "redirects": [
+    {
+      "source": "/:path*",
+      "has": [{ "type": "host", "value": "msl.the-playground.fr" }],
+      "destination": "https://the-playground.fr/circles/le-club-de-mont-saint-leger",
+      "permanent": true
+    }
+  ],
   "crons": [
     {
       "path": "/api/cron/recalculate-scores",


### PR DESCRIPTION
## Summary
- Ajoute une règle `redirects` dans `vercel.json` qui renvoie tout trafic du host `msl.the-playground.fr` vers `https://the-playground.fr/circles/le-club-de-mont-saint-leger` en 308 (Permanent Redirect).
- Le sous-domaine est déclaré côté Vercel (Production, projet `the-playground`) et le CNAME a été ajouté chez OVH (`msl IN CNAME 5ce52f4854aa7619.vercel-dns-017.com.`). DNS confirmé en "Valid Configuration".
- Approche choisie : redirect (porte d'entrée mémorisable), pas rewrite. L'URL change dans la barre après la redirection, c'est le comportement souhaité.

## Test plan
- [ ] CI vert
- [ ] Après merge et déploiement Vercel : ouvrir `https://msl.the-playground.fr` dans un navigateur → vérifier la redirection 308 vers `https://the-playground.fr/circles/le-club-de-mont-saint-leger`
- [ ] Vérifier que les autres sous-domaines (staging, www) ne sont pas impactés
- [ ] Vérifier que les pages de l'app sur `the-playground.fr` (hors sous-domaine) ne sont pas impactées

🤖 Generated with [Claude Code](https://claude.com/claude-code)