### PR TITLE
fix(redirects): déplace msl.the-playground.fr dans next.config.ts

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -2017,6 +2017,6 @@
     "dashboardLocaleEn": "English",
     "dashboardPreviewTitle": "Preview",
     "dashboardSnippetTitle": "HTML code",
-    "dashboardNote": "The widget updates automatically (date, capacity, status).\nRemember to remove the snippet from your site after the event."
+    "dashboardNote": "The widget updates automatically (date, capacity, status)."
   }
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -2017,6 +2017,6 @@
     "dashboardLocaleEn": "English",
     "dashboardPreviewTitle": "Aperçu",
     "dashboardSnippetTitle": "Code HTML",
-    "dashboardNote": "Le widget se met à jour automatiquement (date, places, état).\nPensez à retirer le code de votre site quand l'événement sera passé."
+    "dashboardNote": "Le widget se met à jour automatiquement (date, places, état)."
   }
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -99,6 +99,17 @@ const nextConfig: NextConfig = {
       },
     ];
   },
+  async redirects() {
+    return [
+      {
+        source: "/:path*",
+        has: [{ type: "host", value: "msl.the-playground.fr" }],
+        destination:
+          "https://the-playground.fr/circles/le-club-de-mont-saint-leger",
+        permanent: true,
+      },
+    ];
+  },
   images: {
     remotePatterns: [
       { protocol: "https", hostname: "**.public.blob.vercel-storage.com" },

--- a/src/components/embed/embed-snippet-dialog.tsx
+++ b/src/components/embed/embed-snippet-dialog.tsx
@@ -71,9 +71,7 @@ export function EmbedSnippetDialog({ momentSlug, momentTitle, appUrl }: Props) {
       <DialogContent className="max-w-2xl">
         <DialogHeader className="gap-3">
           <DialogTitle>{t("dashboardTitle")}</DialogTitle>
-          <DialogDescription className="whitespace-pre-line">
-            {t("dashboardNote")}
-          </DialogDescription>
+          <DialogDescription>{t("dashboardNote")}</DialogDescription>
         </DialogHeader>
 
         <div className="flex items-center justify-between gap-2">

--- a/vercel.json
+++ b/vercel.json
@@ -1,13 +1,5 @@
 {
   "ignoreCommand": "bash scripts/vercel-ignore.sh",
-  "redirects": [
-    {
-      "source": "/:path*",
-      "has": [{ "type": "host", "value": "msl.the-playground.fr" }],
-      "destination": "https://the-playground.fr/circles/le-club-de-mont-saint-leger",
-      "permanent": true
-    }
-  ],
   "crons": [
     {
       "path": "/api/cron/recalculate-scores",


### PR DESCRIPTION
## Summary
- La règle `redirects` ajoutée dans `vercel.json` (PR #489) avec une condition `has.host` est ignorée par Vercel pour les apps Next.js. Constaté en prod : `curl -I https://msl.the-playground.fr` renvoyait HTTP 200 (home de l'app) au lieu du 308 attendu.
- Migration du redirect dans `next.config.ts` (fonction `async redirects()`) qui supporte nativement `has.host`.
- `vercel.json` est nettoyé de la section `redirects` orpheline.
- Config Vercel Domains inchangée : `msl.the-playground.fr` reste en "Connect to an environment → Production".

## Test plan
- [ ] CI vert
- [ ] Après merge et déploiement Vercel : `curl -I https://msl.the-playground.fr` doit renvoyer `HTTP/2 308` + `location: https://the-playground.fr/circles/le-club-de-mont-saint-leger`
- [ ] Ouvrir `https://msl.the-playground.fr` dans un navigateur (en privé pour éviter le cache 308 du précédent essai) → arrive sur la page Communauté
- [ ] Vérifier que les autres sous-domaines (staging, www, the-playground.fr) restent fonctionnels

🤖 Generated with [Claude Code](https://claude.com/claude-code)