### PR TITLE
fix(embed): widget responsive sur mobile

### DIFF
--- a/src/app/embed/m/[slug]/page.tsx
+++ b/src/app/embed/m/[slug]/page.tsx
@@ -12,6 +12,7 @@ import { MomentNotFoundError } from "@/domain/errors";
 import { isValidSlug } from "@/lib/slug";
 import { captureServerEvent } from "@/lib/posthog-server";
 import { EmbedEventCard } from "@/components/embed/embed-event-card";
+import { EmbedHeightReporter } from "@/components/embed/embed-height-reporter";
 import type { EmbedLocale, EmbedTheme } from "@/components/embed/types";
 
 export const revalidate = 300;
@@ -110,6 +111,7 @@ export default async function EmbedMomentPage({
         locale={locale}
         theme={theme}
       />
+      <EmbedHeightReporter />
     </div>
   );
 }

--- a/src/components/embed/constants.ts
+++ b/src/components/embed/constants.ts
@@ -1,1 +1,4 @@
 export const EMBED_HEIGHT_MESSAGE_TYPE = "playground:embed:height";
+
+export const EMBED_MAX_WIDTH = 480;
+export const EMBED_INITIAL_HEIGHT = 230;

--- a/src/components/embed/constants.ts
+++ b/src/components/embed/constants.ts
@@ -1,0 +1,1 @@
+export const EMBED_HEIGHT_MESSAGE_TYPE = "playground:embed:height";

--- a/src/components/embed/embed-event-card.tsx
+++ b/src/components/embed/embed-event-card.tsx
@@ -80,13 +80,13 @@ export async function EmbedEventCard({
     : isCancelled
       ? "opacity-50 grayscale"
       : "";
-  const coverClass = `h-48 w-48 rounded-xl object-cover ${coverOpacity}`;
+  const coverClass = `aspect-square w-full rounded-xl object-cover @[400px]:aspect-auto @[400px]:h-48 @[400px]:w-48 ${coverOpacity}`;
 
   return (
     <div
-      className={`mx-auto w-full max-w-[480px] rounded-2xl border ${palette.card} p-4 shadow-sm`}
+      className={`@container mx-auto w-full max-w-[480px] rounded-2xl border ${palette.card} p-4 shadow-sm`}
     >
-      <div className="flex gap-4">
+      <div className="flex flex-col @[400px]:flex-row @[400px]:gap-4">
         <div className="relative flex-shrink-0">
           {moment.coverImage ? (
             // eslint-disable-next-line @next/next/no-img-element
@@ -108,24 +108,24 @@ export async function EmbedEventCard({
             </span>
           )}
         </div>
-        <div className="flex min-w-0 flex-1 flex-col">
+        <div className="mt-4 flex min-w-0 flex-1 flex-col @[400px]:mt-0">
           <h2
-            className={`line-clamp-2 text-base font-semibold leading-snug ${titleColor} ${titleStrike}`}
+            className={`line-clamp-2 text-lg font-semibold leading-snug @[400px]:text-base ${titleColor} ${titleStrike}`}
           >
             {moment.title}
           </h2>
-          <div className={`mt-4 space-y-2 text-xs ${palette.date}`}>
+          <div className={`mt-3 space-y-2 text-sm @[400px]:mt-4 @[400px]:text-xs ${palette.date}`}>
             <p className="flex items-center gap-2">
-              <Calendar className={`size-3.5 shrink-0 ${palette.icon}`} aria-hidden="true" />
+              <Calendar className={`size-4 shrink-0 @[400px]:size-3.5 ${palette.icon}`} aria-hidden="true" />
               <span>{dateLine}</span>
             </p>
             <p className="flex items-center gap-2">
-              <MapPin className={`size-3.5 shrink-0 ${palette.icon}`} aria-hidden="true" />
+              <MapPin className={`size-4 shrink-0 @[400px]:size-3.5 ${palette.icon}`} aria-hidden="true" />
               <span className="truncate">{locationLine}</span>
             </p>
           </div>
           {isCancelled ? (
-            <p className="mt-4 text-xs italic text-red-300/80">
+            <p className="mt-4 text-sm italic text-red-300/80 @[400px]:text-xs">
               {t("cancelledExplanation")}
             </p>
           ) : (
@@ -149,12 +149,12 @@ export async function EmbedEventCard({
             className={ctaClassName(isPassive, isDark)}
           >
             <span>{ctaLabel}</span>
-            <ArrowRight className="size-3.5" aria-hidden="true" />
+            <ArrowRight className="size-4 @[400px]:size-3.5" aria-hidden="true" />
           </a>
         </div>
       </div>
       <p
-        className={`mt-3 text-center text-[9px] tracking-wide ${palette.footer}`}
+        className={`mt-4 text-center text-[10px] tracking-wide @[400px]:mt-3 @[400px]:text-[9px] ${palette.footer}`}
       >
         {t("poweredBy")}{" "}
         <a
@@ -172,7 +172,7 @@ export async function EmbedEventCard({
 
 function ctaClassName(passive: boolean, dark: boolean): string {
   const base =
-    "mt-auto inline-flex w-full items-center justify-center gap-1.5 rounded-lg py-2.5 text-center text-sm font-semibold transition-colors";
+    "mt-4 inline-flex w-full items-center justify-center gap-1.5 rounded-lg py-3 text-base font-semibold transition-colors @[400px]:mt-auto @[400px]:py-2.5 @[400px]:text-sm";
   if (!passive) {
     return `${base} bg-primary text-white hover:bg-primary/90`;
   }
@@ -211,7 +211,7 @@ function SocialProof({
           return (
             <div
               key={i}
-              className={`relative flex h-5 w-5 shrink-0 items-center justify-center overflow-hidden rounded-full text-[8px] font-semibold text-white ring-2 ${ringClass} ${avatarFilter}`}
+              className={`relative flex h-6 w-6 shrink-0 items-center justify-center overflow-hidden rounded-full text-[10px] font-semibold text-white ring-2 @[400px]:h-5 @[400px]:w-5 @[400px]:text-[8px] ${ringClass} ${avatarFilter}`}
               style={{ background: gradient }}
             >
               {a.user.image ? (
@@ -228,8 +228,7 @@ function SocialProof({
           );
         })}
       </div>
-      <span className={`text-xs ${labelColor}`}>{label}</span>
+      <span className={`text-sm @[400px]:text-xs ${labelColor}`}>{label}</span>
     </div>
   );
 }
-

--- a/src/components/embed/embed-event-card.tsx
+++ b/src/components/embed/embed-event-card.tsx
@@ -7,6 +7,7 @@ import { formatLongDate, formatLocalizedTime } from "@/lib/format-date";
 import { getMomentGradient } from "@/lib/gradient";
 import { getPublicUserInitials } from "@/lib/display-name";
 import { getAppUrl } from "@/lib/app-url";
+import { EMBED_MAX_WIDTH } from "@/components/embed/constants";
 import type { EmbedLocale, EmbedTheme } from "@/components/embed/types";
 
 type Props = {
@@ -84,7 +85,8 @@ export async function EmbedEventCard({
 
   return (
     <div
-      className={`@container mx-auto w-full max-w-[480px] rounded-2xl border ${palette.card} p-4 shadow-sm`}
+      className={`@container mx-auto w-full rounded-2xl border ${palette.card} p-4 shadow-sm`}
+      style={{ maxWidth: EMBED_MAX_WIDTH }}
     >
       <div className="flex flex-col @[400px]:flex-row @[400px]:gap-4">
         <div className="relative flex-shrink-0">

--- a/src/components/embed/embed-height-reporter.tsx
+++ b/src/components/embed/embed-height-reporter.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useEffect } from "react";
+import { EMBED_HEIGHT_MESSAGE_TYPE } from "@/components/embed/constants";
+
+export function EmbedHeightReporter() {
+  useEffect(() => {
+    if (typeof window === "undefined" || window.parent === window) return;
+
+    const send = () => {
+      window.parent.postMessage(
+        {
+          type: EMBED_HEIGHT_MESSAGE_TYPE,
+          height: document.documentElement.scrollHeight,
+        },
+        "*"
+      );
+    };
+
+    send();
+
+    const observer = new ResizeObserver(send);
+    observer.observe(document.documentElement);
+
+    return () => observer.disconnect();
+  }, []);
+
+  return null;
+}

--- a/src/components/embed/embed-height-reporter.tsx
+++ b/src/components/embed/embed-height-reporter.tsx
@@ -1,23 +1,23 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { EMBED_HEIGHT_MESSAGE_TYPE } from "@/components/embed/constants";
 
 export function EmbedHeightReporter() {
+  const lastSentHeight = useRef(0);
+
   useEffect(() => {
     if (typeof window === "undefined" || window.parent === window) return;
 
     const send = () => {
+      const height = Math.round(document.documentElement.scrollHeight);
+      if (height === lastSentHeight.current) return;
+      lastSentHeight.current = height;
       window.parent.postMessage(
-        {
-          type: EMBED_HEIGHT_MESSAGE_TYPE,
-          height: document.documentElement.scrollHeight,
-        },
+        { type: EMBED_HEIGHT_MESSAGE_TYPE, height },
         "*"
       );
     };
-
-    send();
 
     const observer = new ResizeObserver(send);
     observer.observe(document.documentElement);

--- a/src/components/embed/embed-snippet-dialog.tsx
+++ b/src/components/embed/embed-snippet-dialog.tsx
@@ -27,7 +27,11 @@ import {
   TabsTrigger,
 } from "@/components/ui/tabs";
 import { escapeHtml } from "@/lib/html";
-import { EMBED_HEIGHT_MESSAGE_TYPE } from "@/components/embed/constants";
+import {
+  EMBED_HEIGHT_MESSAGE_TYPE,
+  EMBED_INITIAL_HEIGHT,
+  EMBED_MAX_WIDTH,
+} from "@/components/embed/constants";
 import type { EmbedLocale, EmbedTheme } from "@/components/embed/types";
 
 type Props = {
@@ -35,9 +39,6 @@ type Props = {
   momentTitle: string;
   appUrl: string;
 };
-
-const EMBED_MAX_WIDTH = 480;
-const EMBED_INITIAL_HEIGHT = 230;
 
 export function EmbedSnippetDialog({ momentSlug, momentTitle, appUrl }: Props) {
   const t = useTranslations("EmbedWidget");
@@ -152,18 +153,14 @@ function buildSnippet({
 }): string {
   const elementId = `playground-embed-${momentSlug}`;
   const safeTitle = escapeHtml(titleAlt);
-  // L'iframe est responsive (width=100%, max-width=480px). Le script ajuste la hauteur
-  // au contenu réel via postMessage : layout horizontal (~230px) sur desktop, vertical
-  // (~640px) sur mobile contraint.
   return [
     `<iframe`,
     `  id="${elementId}"`,
     `  src="${embedUrl}"`,
-    `  width="100%"`,
     `  height="${EMBED_INITIAL_HEIGHT}"`,
     `  title="${safeTitle}"`,
     `  loading="lazy"`,
-    `  style="border:0;max-width:${EMBED_MAX_WIDTH}px;width:100%"`,
+    `  style="border:0;width:100%;max-width:${EMBED_MAX_WIDTH}px"`,
     `></iframe>`,
     `<script>`,
     `(function(){`,
@@ -174,7 +171,7 @@ function buildSnippet({
     `    if(e.origin!=="${appOrigin}") return;`,
     `    if(!e.data||e.data.type!=="${EMBED_HEIGHT_MESSAGE_TYPE}") return;`,
     `    var h=Number(e.data.height);`,
-    `    if(h>0) f.style.height=h+"px";`,
+    `    if(h>0&&h!==f.offsetHeight) f.style.height=h+"px";`,
     `  });`,
     `})();`,
     `</script>`,
@@ -192,10 +189,6 @@ function PreviewIframe({
 }) {
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const [height, setHeight] = useState(EMBED_INITIAL_HEIGHT);
-
-  useEffect(() => {
-    setHeight(EMBED_INITIAL_HEIGHT);
-  }, [embedUrl]);
 
   useEffect(() => {
     function onMessage(e: MessageEvent) {

--- a/src/components/embed/embed-snippet-dialog.tsx
+++ b/src/components/embed/embed-snippet-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Code, Globe, Moon, Sun } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useTheme } from "next-themes";
@@ -27,6 +27,7 @@ import {
   TabsTrigger,
 } from "@/components/ui/tabs";
 import { escapeHtml } from "@/lib/html";
+import { EMBED_HEIGHT_MESSAGE_TYPE } from "@/components/embed/constants";
 import type { EmbedLocale, EmbedTheme } from "@/components/embed/types";
 
 type Props = {
@@ -35,8 +36,8 @@ type Props = {
   appUrl: string;
 };
 
-const EMBED_WIDTH = 480;
-const EMBED_HEIGHT = 250;
+const EMBED_MAX_WIDTH = 480;
+const EMBED_INITIAL_HEIGHT = 230;
 
 export function EmbedSnippetDialog({ momentSlug, momentTitle, appUrl }: Props) {
   const t = useTranslations("EmbedWidget");
@@ -53,11 +54,17 @@ export function EmbedSnippetDialog({ momentSlug, momentTitle, appUrl }: Props) {
   }
 
   const embedUrl = `${appUrl}/embed/m/${momentSlug}?locale=${locale}&theme=${theme}`;
+  const titleAlt = t("titleAlt", { title: momentTitle });
 
   const snippet = useMemo(
     () =>
-      `<iframe\n  src="${embedUrl}"\n  width="${EMBED_WIDTH}"\n  height="${EMBED_HEIGHT}"\n  frameborder="0"\n  title="${escapeHtml(t("titleAlt", { title: momentTitle }))}"\n  loading="lazy"\n></iframe>`,
-    [embedUrl, momentTitle, t]
+      buildSnippet({
+        embedUrl,
+        appOrigin: appUrl,
+        momentSlug,
+        titleAlt,
+      }),
+    [embedUrl, appUrl, momentSlug, titleAlt]
   );
 
   return (
@@ -111,27 +118,17 @@ export function EmbedSnippetDialog({ momentSlug, momentTitle, appUrl }: Props) {
           </TabsList>
 
           <TabsContent value="preview" className="mt-2 min-w-0">
-            <div
-              className="flex items-center justify-center"
-              style={{ height: 260 }}
-            >
-              <iframe
-                key={embedUrl}
-                src={embedUrl}
-                width={EMBED_WIDTH}
-                height={EMBED_HEIGHT}
-                frameBorder={0}
-                title={t("titleAlt", { title: momentTitle })}
-                className="block max-w-full rounded-2xl"
-                style={{ maxHeight: "100%" }}
-              />
-            </div>
+            <PreviewIframe
+              embedUrl={embedUrl}
+              appOrigin={appUrl}
+              title={titleAlt}
+            />
           </TabsContent>
 
           <TabsContent value="code" className="mt-2 min-w-0">
             <pre
               className="bg-muted max-w-full overflow-scroll rounded-lg p-3 text-xs leading-relaxed [&::-webkit-scrollbar]:h-2 [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar]:appearance-none [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-slate-500/70 [&::-webkit-scrollbar-track]:rounded-full [&::-webkit-scrollbar-track]:bg-slate-700/30"
-              style={{ height: 260, scrollbarWidth: "thin", scrollbarColor: "rgba(100,116,139,0.7) rgba(51,65,85,0.3)" }}
+              style={{ height: 320, scrollbarWidth: "thin", scrollbarColor: "rgba(100,116,139,0.7) rgba(51,65,85,0.3)" }}
             >
               <code>{snippet}</code>
             </pre>
@@ -139,6 +136,94 @@ export function EmbedSnippetDialog({ momentSlug, momentTitle, appUrl }: Props) {
         </Tabs>
       </DialogContent>
     </Dialog>
+  );
+}
+
+function buildSnippet({
+  embedUrl,
+  appOrigin,
+  momentSlug,
+  titleAlt,
+}: {
+  embedUrl: string;
+  appOrigin: string;
+  momentSlug: string;
+  titleAlt: string;
+}): string {
+  const elementId = `playground-embed-${momentSlug}`;
+  const safeTitle = escapeHtml(titleAlt);
+  // L'iframe est responsive (width=100%, max-width=480px). Le script ajuste la hauteur
+  // au contenu réel via postMessage : layout horizontal (~230px) sur desktop, vertical
+  // (~640px) sur mobile contraint.
+  return [
+    `<iframe`,
+    `  id="${elementId}"`,
+    `  src="${embedUrl}"`,
+    `  width="100%"`,
+    `  height="${EMBED_INITIAL_HEIGHT}"`,
+    `  title="${safeTitle}"`,
+    `  loading="lazy"`,
+    `  style="border:0;max-width:${EMBED_MAX_WIDTH}px;width:100%"`,
+    `></iframe>`,
+    `<script>`,
+    `(function(){`,
+    `  var f=document.getElementById("${elementId}");`,
+    `  if(!f) return;`,
+    `  window.addEventListener("message",function(e){`,
+    `    if(e.source!==f.contentWindow) return;`,
+    `    if(e.origin!=="${appOrigin}") return;`,
+    `    if(!e.data||e.data.type!=="${EMBED_HEIGHT_MESSAGE_TYPE}") return;`,
+    `    var h=Number(e.data.height);`,
+    `    if(h>0) f.style.height=h+"px";`,
+    `  });`,
+    `})();`,
+    `</script>`,
+  ].join("\n");
+}
+
+function PreviewIframe({
+  embedUrl,
+  appOrigin,
+  title,
+}: {
+  embedUrl: string;
+  appOrigin: string;
+  title: string;
+}) {
+  const iframeRef = useRef<HTMLIFrameElement | null>(null);
+  const [height, setHeight] = useState(EMBED_INITIAL_HEIGHT);
+
+  useEffect(() => {
+    setHeight(EMBED_INITIAL_HEIGHT);
+  }, [embedUrl]);
+
+  useEffect(() => {
+    function onMessage(e: MessageEvent) {
+      const iframe = iframeRef.current;
+      if (!iframe || e.source !== iframe.contentWindow) return;
+      if (e.origin !== appOrigin) return;
+      const data = e.data as { type?: string; height?: number } | undefined;
+      if (!data || data.type !== EMBED_HEIGHT_MESSAGE_TYPE) return;
+      const h = Number(data.height);
+      if (Number.isFinite(h) && h > 0) setHeight(h);
+    }
+    window.addEventListener("message", onMessage);
+    return () => window.removeEventListener("message", onMessage);
+  }, [appOrigin]);
+
+  return (
+    <div className="flex justify-center" style={{ minHeight: EMBED_INITIAL_HEIGHT }}>
+      <iframe
+        ref={iframeRef}
+        key={embedUrl}
+        src={embedUrl}
+        width={EMBED_MAX_WIDTH}
+        height={height}
+        title={title}
+        className="block max-w-full rounded-2xl"
+        style={{ border: 0 }}
+      />
+    </div>
   );
 }
 
@@ -200,4 +285,3 @@ function ThemeToggleButton({
     </Button>
   );
 }
-


### PR DESCRIPTION
## Summary

Le widget d'embed rendait toujours en layout horizontal, même quand l'iframe était contraint sous 400px de largeur par le CSS du site hôte sur mobile (cas reproduit sur techspeakher.fr/tremplin). Le contenu apparaissait tassé et déformé.

- `EmbedEventCard` passe en container queries Tailwind 4 (`@container` + `@[400px]:`) : layout vertical par défaut (cover carré pleine largeur, contenu dessous), bascule en horizontal au-dessus de 400px de largeur du widget. Tailles polices, icônes et avatars adaptées.
- Nouveau composant `EmbedHeightReporter` (client) : mesure la hauteur du document via `ResizeObserver` et la `postMessage` au parent. Guard via `useRef` pour ignorer les hauteurs identiques.
- Snippet généré mis à jour : iframe responsive (`width: 100%; max-width: 480px`) accompagnée d'un petit script JS qui écoute le `postMessage` et ajuste la hauteur. Origin, source et type vérifiés côté listener.
- Preview iframe de la modale écoute aussi le message pour s'adapter en temps réel.

**Rétrocompat** : les iframes déjà intégrés avec l'ancien snippet (`width=480 height=250`) basculent en vertical sur mobile grâce aux container queries, mais resteront en hauteur fixe. Re-copier-coller le nouveau snippet pour bénéficier de la hauteur adaptative.

## Test plan

- [ ] Ouvrir `/embed/m/[slug]` à 360px de viewport → layout vertical
- [ ] Ouvrir `/embed/m/[slug]` à 480px de viewport → layout horizontal
- [ ] Vérifier les états passé / annulé sur les deux layouts
- [ ] Ouvrir le dialog Obtenir le code → copier le snippet → coller dans un fichier HTML servi en HTTP → vérifier que la hauteur s'adapte sur mobile
- [ ] Vérifier la preview de la modale qui s'adapte aussi
- [ ] Confirmer que l'ancien snippet (déjà déployé chez techspeakher) bascule bien en vertical sur mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)