### PR TITLE
fix(db): durcit la page Communauté face aux hoquets Neon

### DIFF
--- a/src/app/[locale]/(routes)/circles/[slug]/page.tsx
+++ b/src/app/[locale]/(routes)/circles/[slug]/page.tsx
@@ -1,8 +1,8 @@
 import { cache } from "react";
 import { notFound } from "next/navigation";
 import { getTranslations } from "next-intl/server";
-import * as Sentry from "@sentry/nextjs";
 import { measureTime } from "@/lib/perf-logger";
+import { degradedQuery } from "@/lib/degraded-query";
 import { stripProtocol } from "@/lib/url";
 import type { Metadata } from "next";
 import type { RegistrationWithUser } from "@/domain/models/registration";
@@ -55,24 +55,6 @@ import { MemberAvatarStack } from "@/components/circles/member-avatar-stack";
 import { CircleOrganizersList } from "@/components/circles/circle-organizers-list";
 
 export const revalidate = 60;
-
-// Décor de la page Communauté : si Neon hoquette sur ces queries, on rend
-// la page en mode dégradé (compteurs/avatars vides) plutôt que de tout
-// perdre. Le signal reste capturé par Sentry pour le monitoring.
-async function degradedQuery<T>(
-  promise: Promise<T>,
-  fallback: T,
-  tag: string,
-): Promise<T> {
-  try {
-    return await promise;
-  } catch (err) {
-    Sentry.captureException(err, {
-      tags: { context: "circle_page_degraded", query: tag },
-    });
-    return fallback;
-  }
-}
 
 // Deduplicate DB call between generateMetadata and the page (identique au pattern /m/[slug])
 const getCachedCircle = cache(async (slug: string) => {
@@ -217,17 +199,17 @@ export default async function PublicCirclePage({
     degradedQuery(
       prismaRegistrationRepository.findRegisteredCountsByMomentIds(allMomentIds),
       new Map<string, number>(),
-      "registration_counts",
+      "circle_page:registration_counts",
     ),
     degradedQuery(
       prismaRegistrationRepository.findTopRegistrantsByMomentIds(allMomentIds, 3),
       new Map<string, RegistrationWithUser[]>(),
-      "top_registrants",
+      "circle_page:top_registrants",
     ),
     degradedQuery(
       prismaCircleNetworkRepository.findNetworksByCircleId(circle.id),
       [] as CircleNetwork[],
-      "circle_networks",
+      "circle_page:circle_networks",
     ),
     canSeeMembers
       ? degradedQuery(
@@ -237,7 +219,7 @@ export default async function PublicCirclePage({
             priorityUserId: session?.user?.id ?? null,
           }),
           { members: [], total: 0, hasMore: false },
-          "members_first_page",
+          "circle_page:members_first_page",
         )
       : Promise.resolve({ members: [], total: 0, hasMore: false }),
   ]);

--- a/src/app/[locale]/(routes)/circles/[slug]/page.tsx
+++ b/src/app/[locale]/(routes)/circles/[slug]/page.tsx
@@ -1,9 +1,12 @@
 import { cache } from "react";
 import { notFound } from "next/navigation";
 import { getTranslations } from "next-intl/server";
+import * as Sentry from "@sentry/nextjs";
 import { measureTime } from "@/lib/perf-logger";
 import { stripProtocol } from "@/lib/url";
 import type { Metadata } from "next";
+import type { RegistrationWithUser } from "@/domain/models/registration";
+import type { CircleNetwork } from "@/domain/models/circle-network";
 import {
   prismaCircleRepository,
   prismaMomentRepository,
@@ -52,6 +55,24 @@ import { MemberAvatarStack } from "@/components/circles/member-avatar-stack";
 import { CircleOrganizersList } from "@/components/circles/circle-organizers-list";
 
 export const revalidate = 60;
+
+// Décor de la page Communauté : si Neon hoquette sur ces queries, on rend
+// la page en mode dégradé (compteurs/avatars vides) plutôt que de tout
+// perdre. Le signal reste capturé par Sentry pour le monitoring.
+async function degradedQuery<T>(
+  promise: Promise<T>,
+  fallback: T,
+  tag: string,
+): Promise<T> {
+  try {
+    return await promise;
+  } catch (err) {
+    Sentry.captureException(err, {
+      tags: { context: "circle_page_degraded", query: tag },
+    });
+    return fallback;
+  }
+}
 
 // Deduplicate DB call between generateMetadata and the page (identique au pattern /m/[slug])
 const getCachedCircle = cache(async (slug: string) => {
@@ -193,15 +214,31 @@ export default async function PublicCirclePage({
   // Fetch registration counts + top attendees (avatars) pour TOUS les moments (upcoming + past)
   const allMomentIds = allMoments.map((m) => m.id);
   const [countByMomentId, topAttendeesByMomentId, circleNetworks, membersFirstPage] = await Promise.all([
-    prismaRegistrationRepository.findRegisteredCountsByMomentIds(allMomentIds),
-    prismaRegistrationRepository.findTopRegistrantsByMomentIds(allMomentIds, 3),
-    prismaCircleNetworkRepository.findNetworksByCircleId(circle.id),
+    degradedQuery(
+      prismaRegistrationRepository.findRegisteredCountsByMomentIds(allMomentIds),
+      new Map<string, number>(),
+      "registration_counts",
+    ),
+    degradedQuery(
+      prismaRegistrationRepository.findTopRegistrantsByMomentIds(allMomentIds, 3),
+      new Map<string, RegistrationWithUser[]>(),
+      "top_registrants",
+    ),
+    degradedQuery(
+      prismaCircleNetworkRepository.findNetworksByCircleId(circle.id),
+      [] as CircleNetwork[],
+      "circle_networks",
+    ),
     canSeeMembers
-      ? prismaCircleRepository.findMembersPaginated(circle.id, {
-          offset: 0,
-          limit: 20,
-          priorityUserId: session?.user?.id ?? null,
-        })
+      ? degradedQuery(
+          prismaCircleRepository.findMembersPaginated(circle.id, {
+            offset: 0,
+            limit: 20,
+            priorityUserId: session?.user?.id ?? null,
+          }),
+          { members: [], total: 0, hasMore: false },
+          "members_first_page",
+        )
       : Promise.resolve({ members: [], total: 0, hasMore: false }),
   ]);
 

--- a/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/page.tsx
+++ b/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/page.tsx
@@ -1,7 +1,10 @@
 import { notFound } from "next/navigation";
 import { getLocale, getTranslations } from "next-intl/server";
 import { stripProtocol } from "@/lib/url";
+import { degradedQuery } from "@/lib/degraded-query";
 import { formatLongDate } from "@/lib/format-date";
+import type { Registration, RegistrationWithUser } from "@/domain/models/registration";
+import type { CircleNetwork } from "@/domain/models/circle-network";
 import {
   prismaCircleRepository,
   prismaMomentRepository,
@@ -98,13 +101,27 @@ export default async function CircleDetailPage({
       { momentRepository: prismaMomentRepository, circleRepository: prismaCircleRepository },
       { skipCircleCheck: true }
     ),
-    isOrganizer ? prismaCircleRepository.findPendingMemberships(circle.id) : Promise.resolve([]),
-    prismaCircleNetworkRepository.findNetworksByCircleId(circle.id),
-    prismaCircleRepository.findMembersPaginated(circle.id, {
-      offset: 0,
-      limit: 20,
-      priorityUserId: session.user.id,
-    }),
+    isOrganizer
+      ? degradedQuery(
+          prismaCircleRepository.findPendingMemberships(circle.id),
+          [],
+          "dashboard_circle_page:pending_memberships",
+        )
+      : Promise.resolve([]),
+    degradedQuery(
+      prismaCircleNetworkRepository.findNetworksByCircleId(circle.id),
+      [] as CircleNetwork[],
+      "dashboard_circle_page:circle_networks",
+    ),
+    degradedQuery(
+      prismaCircleRepository.findMembersPaginated(circle.id, {
+        offset: 0,
+        limit: 20,
+        priorityUserId: session.user.id,
+      }),
+      { members: [], total: 0, hasMore: false },
+      "dashboard_circle_page:members_first_page",
+    ),
   ]);
 
   const totalMembers = hosts.length + players.length;
@@ -119,9 +136,21 @@ export default async function CircleDetailPage({
   // Récupère compteurs + inscriptions utilisateur + top inscrits (avatars) pour TOUS les moments
   const allMomentIds = allMoments.map((m) => m.id);
   const [countByMomentId, userRegistrationsByMomentId, topAttendeesByMomentId] = await Promise.all([
-    prismaRegistrationRepository.findRegisteredCountsByMomentIds(allMomentIds),
-    prismaRegistrationRepository.findByMomentIdsAndUser(allMomentIds, session.user.id!),
-    prismaRegistrationRepository.findTopRegistrantsByMomentIds(allMomentIds, 3),
+    degradedQuery(
+      prismaRegistrationRepository.findRegisteredCountsByMomentIds(allMomentIds),
+      new Map<string, number>(),
+      "dashboard_circle_page:registration_counts",
+    ),
+    degradedQuery(
+      prismaRegistrationRepository.findByMomentIdsAndUser(allMomentIds, session.user.id!),
+      new Map<string, Registration | null>(),
+      "dashboard_circle_page:user_registrations",
+    ),
+    degradedQuery(
+      prismaRegistrationRepository.findTopRegistrantsByMomentIds(allMomentIds, 3),
+      new Map<string, RegistrationWithUser[]>(),
+      "dashboard_circle_page:top_registrants",
+    ),
   ]);
   const userStatusByMomentId = new Map(
     [...userRegistrationsByMomentId.entries()].map(([id, reg]) => [id, reg?.status ?? null])

--- a/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/page.tsx
+++ b/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/page.tsx
@@ -3,7 +3,7 @@ import { getLocale, getTranslations } from "next-intl/server";
 import { stripProtocol } from "@/lib/url";
 import { degradedQuery } from "@/lib/degraded-query";
 import { formatLongDate } from "@/lib/format-date";
-import type { Registration, RegistrationWithUser } from "@/domain/models/registration";
+import type { RegistrationWithUser } from "@/domain/models/registration";
 import type { CircleNetwork } from "@/domain/models/circle-network";
 import {
   prismaCircleRepository,
@@ -101,13 +101,10 @@ export default async function CircleDetailPage({
       { momentRepository: prismaMomentRepository, circleRepository: prismaCircleRepository },
       { skipCircleCheck: true }
     ),
-    isOrganizer
-      ? degradedQuery(
-          prismaCircleRepository.findPendingMemberships(circle.id),
-          [],
-          "dashboard_circle_page:pending_memberships",
-        )
-      : Promise.resolve([]),
+    // pendingMemberships volontairement NON dégradé : l'état "aucune
+    // demande" est indistinguable d'une dégradation et un Organisateur qui
+    // croit la queue vide peut laisser des demandes non approuvées.
+    isOrganizer ? prismaCircleRepository.findPendingMemberships(circle.id) : Promise.resolve([]),
     degradedQuery(
       prismaCircleNetworkRepository.findNetworksByCircleId(circle.id),
       [] as CircleNetwork[],
@@ -141,11 +138,11 @@ export default async function CircleDetailPage({
       new Map<string, number>(),
       "dashboard_circle_page:registration_counts",
     ),
-    degradedQuery(
-      prismaRegistrationRepository.findByMomentIdsAndUser(allMomentIds, session.user.id!),
-      new Map<string, Registration | null>(),
-      "dashboard_circle_page:user_registrations",
-    ),
+    // userRegistrations volontairement NON dégradé : si vide, chaque
+    // Moment s'affiche "non inscrit" alors que l'utilisateur l'est, ce
+    // qui le pousse à re-cliquer "S'inscrire" et déclencher une erreur
+    // de contrainte unique. Mieux vaut une vraie erreur de page.
+    prismaRegistrationRepository.findByMomentIdsAndUser(allMomentIds, session.user.id!),
     degradedQuery(
       prismaRegistrationRepository.findTopRegistrantsByMomentIds(allMomentIds, 3),
       new Map<string, RegistrationWithUser[]>(),

--- a/src/infrastructure/db/__tests__/retry-policy.test.ts
+++ b/src/infrastructure/db/__tests__/retry-policy.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { Prisma } from "@prisma/client";
-import { isTransientError } from "../retry-policy";
+import { describeDbError, isTransientError } from "../retry-policy";
 
 describe("isTransientError", () => {
   describe("given a Neon control plane error", () => {
@@ -38,6 +38,22 @@ describe("isTransientError", () => {
     );
   });
 
+  describe("given a Neon WebSocket ErrorEvent (driver-level)", () => {
+    it("should treat a DOM-style ErrorEvent (type=error, empty message) as transient", () => {
+      const errorEvent = { type: "error", message: "" };
+      expect(isTransientError(errorEvent)).toBe(true);
+    });
+
+    it("should treat a wrapped ErrorEvent (under .error) as transient", () => {
+      const wrapped = { error: { type: "error", message: "" } };
+      expect(isTransientError(wrapped)).toBe(true);
+    });
+
+    it("should treat an Error whose message mentions WebSocket as transient", () => {
+      expect(isTransientError(new Error("WebSocket closed"))).toBe(true);
+    });
+  });
+
   describe("given a non-transient error", () => {
     it("should not retry a unique constraint violation (P2002)", () => {
       const error = new Prisma.PrismaClientKnownRequestError(
@@ -56,5 +72,33 @@ describe("isTransientError", () => {
       expect(isTransientError(null)).toBe(false);
       expect(isTransientError(undefined)).toBe(false);
     });
+  });
+});
+
+describe("describeDbError", () => {
+  it("extracts the message from a standard Error", () => {
+    expect(describeDbError(new Error("boom"))).toBe("boom");
+  });
+
+  it("extracts a non-empty message field from a plain object", () => {
+    expect(describeDbError({ message: "pool closed" })).toBe("pool closed");
+  });
+
+  it("returns a sentinel for a DOM ErrorEvent (type=error, empty message)", () => {
+    expect(describeDbError({ type: "error", message: "" })).toBe(
+      "websocket_error_event",
+    );
+  });
+
+  it("unwraps nested errors via the .error field", () => {
+    expect(
+      describeDbError({ message: "", error: new Error("inner cause") }),
+    ).toBe("inner cause");
+  });
+
+  it("stringifies unknown shapes as a last resort", () => {
+    expect(describeDbError("oops")).toBe("oops");
+    expect(describeDbError(null)).toBe("null");
+    expect(describeDbError(42)).toBe("42");
   });
 });

--- a/src/infrastructure/db/prisma.ts
+++ b/src/infrastructure/db/prisma.ts
@@ -4,6 +4,7 @@ import {
   BASE_DELAY_MS,
   MAX_RETRIES,
   READ_OPERATIONS,
+  describeDbError,
   isTransientError,
   sleep,
 } from "./retry-policy";
@@ -18,7 +19,7 @@ function createClient(): PrismaClient {
   const adapter = new PrismaNeon(
     {
       connectionString: process.env.DATABASE_URL!,
-      max: 5,
+      max: 10,
       idleTimeoutMillis: 30_000,
       connectionTimeoutMillis: 15_000,
     },
@@ -28,7 +29,7 @@ function createClient(): PrismaClient {
           JSON.stringify({
             level: "error",
             type: "pool_error",
-            message: err.message,
+            message: describeDbError(err),
           })
         );
       },
@@ -84,7 +85,7 @@ export const prisma = _baseClient.$extends({
                   operation,
                   attempt: attempt + 1,
                   delay,
-                  error: error instanceof Error ? error.message : String(error),
+                  error: describeDbError(error),
                 })
               );
               await sleep(delay);
@@ -102,7 +103,7 @@ export const prisma = _baseClient.$extends({
                   operation,
                   duration,
                   ...(attempt > 0 && { retries: attempt }),
-                  error: error instanceof Error ? error.message : String(error),
+                  error: describeDbError(error),
                 })
               );
             }

--- a/src/infrastructure/db/retry-policy.ts
+++ b/src/infrastructure/db/retry-policy.ts
@@ -18,6 +18,11 @@ const TRANSIENT_PATTERNS = [
   // Neon control plane hiccup (cold start, rolling deploy, transient saturation).
   // Substring matches "Control plane request failed" and any future variant.
   "Control plane",
+  // @neondatabase/serverless balance des ErrorEvent DOM quand son WebSocket
+  // tombe — `.message` est vide, d'où la chaîne sentinelle produite par
+  // describeDbError pour les rendre détectables.
+  "websocket_error_event",
+  "WebSocket",
 ];
 
 const TRANSIENT_PRISMA_CODES = new Set([
@@ -39,11 +44,30 @@ export const READ_OPERATIONS = new Set([
   "groupBy",
 ]);
 
+export function describeDbError(error: unknown): string {
+  if (error && typeof error === "object") {
+    const obj = error as { message?: unknown; error?: unknown; type?: unknown };
+    if (typeof obj.message === "string" && obj.message.length > 0) {
+      return obj.message;
+    }
+    if (obj.error !== undefined && obj.error !== null) {
+      return describeDbError(obj.error);
+    }
+    // ErrorEvent DOM émis par @neondatabase/serverless quand le WebSocket
+    // tombe : `.message` vide, mais `.type === "error"`. On produit une
+    // chaîne sentinelle pour la rendre matchable par TRANSIENT_PATTERNS.
+    if (obj.type === "error") {
+      return "websocket_error_event";
+    }
+  }
+  return error instanceof Error ? error.message : String(error);
+}
+
 export function isTransientError(error: unknown): boolean {
   if (error instanceof Prisma.PrismaClientKnownRequestError) {
     return TRANSIENT_PRISMA_CODES.has(error.code);
   }
-  const message = error instanceof Error ? error.message : String(error);
+  const message = describeDbError(error);
   return TRANSIENT_PATTERNS.some((p) => message.includes(p));
 }
 

--- a/src/lib/degraded-query.ts
+++ b/src/lib/degraded-query.ts
@@ -1,0 +1,20 @@
+import * as Sentry from "@sentry/nextjs";
+
+// Pour les blocs décoratifs d'une page (compteurs, avatars, listes
+// secondaires) : si la query échoue, on rend la page en mode dégradé avec
+// un fallback plutôt que de tout perdre. L'erreur reste capturée par
+// Sentry pour le monitoring. À réserver aux blocs non structurants.
+export async function degradedQuery<T>(
+  promise: Promise<T>,
+  fallback: T,
+  tag: string,
+): Promise<T> {
+  try {
+    return await promise;
+  } catch (err) {
+    Sentry.captureException(err, {
+      tags: { context: "degraded_query", query: tag },
+    });
+    return fallback;
+  }
+}

--- a/src/lib/degraded-query.ts
+++ b/src/lib/degraded-query.ts
@@ -1,9 +1,15 @@
+import { unstable_noStore as noStore } from "next/cache";
 import * as Sentry from "@sentry/nextjs";
 
 // Pour les blocs décoratifs d'une page (compteurs, avatars, listes
 // secondaires) : si la query échoue, on rend la page en mode dégradé avec
 // un fallback plutôt que de tout perdre. L'erreur reste capturée par
 // Sentry pour le monitoring. À réserver aux blocs non structurants.
+//
+// Quand on dégrade, on opt-out du cache ISR pour cette regen : sinon le
+// HTML dégradé (compteurs à 0, avatars vides) serait servi à tous les
+// visiteurs pendant la durée du `revalidate`, transformant un hoquet de
+// quelques secondes en page morte pendant une minute.
 export async function degradedQuery<T>(
   promise: Promise<T>,
   fallback: T,
@@ -12,6 +18,7 @@ export async function degradedQuery<T>(
   try {
     return await promise;
   } catch (err) {
+    noStore();
     Sentry.captureException(err, {
       tags: { context: "degraded_query", query: tag },
     });


### PR DESCRIPTION
## Contexte

Issue Sentry **THE-PLAYGROUND-1F** : `Error: [object ErrorEvent]` non géré sur la page Communauté quand `@neondatabase/serverless` perd son WebSocket. Le driver émet un `ErrorEvent` DOM dont `.message` est vide, ce qui empêchait à la fois la reconnaissance comme erreur transitoire (pas de retry) et l'extraction d'un message utile dans les logs.

## Summary

- **`describeDbError`** extrait un message lisible des erreurs Neon, y compris les `ErrorEvent` DOM à `.message` vide (récurse via `.error`, produit un sentinel `websocket_error_event` quand `type === "error"`)
- **`TRANSIENT_PATTERNS`** reconnaît les variantes WebSocket → les retries se déclenchent désormais sur les drops
- **Pool Neon** `max: 5 → 10` pour absorber les bursts de queries en parallèle
- **`degradedQuery`** (`src/lib/degraded-query.ts`) : helper qui wrappe les queries décoratives. Si une query échoue, retourne un fallback, log l'erreur dans Sentry, **et opt-out du cache ISR** via `noStore()` pour éviter de propager le HTML dégradé pendant 60s
- Pages **Communauté publique + dashboard** durcies sur leurs queries décoratives (counts, top attendees, networks, members paginés)
- Pas wrapées volontairement : `pendingMemberships` et `userRegistrations` côté dashboard, car l'état vide est indistinguable d'une dégradation (faux signal critique pour l'Organisateur ou l'utilisateur)
- 5 nouveaux tests sur `describeDbError` et le matching `ErrorEvent`

## Test plan

- [ ] CI vert (typecheck + tests unitaires)
- [ ] Smoke local : la page `/circles/<slug>` rend correctement sans dégradation
- [ ] Smoke local : simuler une erreur sur une query décorative (throw forcé) → la page rend avec le fallback (compteurs à 0, avatars vides) + Sentry capture l'événement avec tag `circle_page:<query_name>`
- [ ] Monitoring Sentry post-deploy : surveiller que les retries `db_retry` apparaissent désormais avec un message exploitable (et non `[object ErrorEvent]`) si Neon hoquette
- [ ] Surveillance des `pool_error` Sentry : s'assurer qu'augmenter `max` à 10 ne déclenche pas de "too many connections" sur le plan Neon actuel

🤖 Generated with [Claude Code](https://claude.com/claude-code)