### PR TITLE
fix(layout): désactive l'auto-traduction navigateur

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -87,8 +87,13 @@ export default async function LocaleLayout({
   };
 
   return (
-    <html lang={locale} suppressHydrationWarning>
+    <html lang={locale} translate="no" suppressHydrationWarning>
       <head>
+        {/* L'app est nativement bilingue FR/EN via next-intl. Google
+            Translate auto manipule le DOM hors-React et casse la
+            réconciliation (cf. NotFoundError insertBefore/removeChild
+            sur la page sign-in). On désactive donc l'auto-traduction. */}
+        <meta name="google" content="notranslate" />
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteJsonLd) }}

--- a/src/app/embed/layout.tsx
+++ b/src/app/embed/layout.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
 
 export default function EmbedLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html suppressHydrationWarning>
+    <html translate="no" suppressHydrationWarning>
       <body className={`${inter.variable} bg-transparent font-sans antialiased`}>
         {children}
       </body>

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -15,7 +15,12 @@ export default function GlobalError({
   }, [error]);
 
   return (
-    <html>
+    // lang="fr" + translate="no" : le contenu de cette page d'erreur est
+    // en français en dur. Sans translate="no", Google Translate auto
+    // wrappe les noeuds texte hors-React et déclenche exactement le bug
+    // NotFoundError insertBefore/removeChild qu'on évite ailleurs — sur
+    // la page la moins capable de l'absorber (déjà en état d'erreur).
+    <html lang="fr" translate="no">
       <body>
         <div className="flex min-h-screen flex-col items-center justify-center gap-6 p-8 text-center">
           <div className="space-y-2">


### PR DESCRIPTION
## Contexte

Issues Sentry **THE-PLAYGROUND-1H** (`NotFoundError: insertBefore`) et **THE-PLAYGROUND-10** (`removeChild`) sur `/auth/sign-in` : stack 100% React DOM, aucune frame applicative. Symptôme classique d'un script tiers manipulant le DOM hors-React, cause quasi certaine : Google Translate auto wrappant les noeuds texte dans des `<font>`, ce qui casse la réconciliation React au prochain rendu.

## Summary

- **`<html translate=\"no\">`** sur les deux layouts root (`[locale]/layout.tsx` + `embed/layout.tsx`)
- **`<meta name=\"google\" content=\"notranslate\" />`** dans le `<head>` du layout principal (belt-and-braces)
- **`global-error.tsx`** durci de la même façon (finding du code-review : c'est précisément la page la moins capable d'absorber le bug puisqu'on y arrive déjà en état d'erreur)

L'app est nativement bilingue FR/EN via next-intl, Google Translate auto n'apporte rien et casse React. Pattern adopté par Stripe, Linear, Notion.

## Pas de filtre Sentry `beforeSend`

Choix conscient : un filtre qui matche `Failed to execute 'insertBefore'/'removeChild' on 'Node'` risquerait de masquer une vraie régression React qui produirait le même symptôme depuis du code applicatif. On préfère que ces erreurs réapparaissent dans Sentry si elles surviennent, plutôt qu'un faux silence.

## Trade-off accepté

Le contenu utilisateur (descriptions Circle/Moment, commentaires, blog) n'est plus traduisible par le navigateur. Pour une Communauté FR avec visiteurs anglophones via la chrome EN, le contenu reste en français sans recours Google Translate. C'est cohérent avec l'objectif i18n native FR/EN, et préférable au bug React DOM. Si besoin futur, on pourra réactiver de façon ciblée via `translate=\"yes\"` sur des conteneurs spécifiques.

## Test plan

- [ ] CI vert (typecheck + tests unitaires + E2E)
- [ ] Smoke local : `<html>` a bien l'attribut `translate=\"no\"` (View Source sur sign-in)
- [ ] Chrome FR sur page `/en/auth/sign-in` (locale différente du navigateur) : la barre de proposition de traduction n'apparaît plus
- [ ] Monitoring Sentry post-deploy : 1H et 10 ne réapparaissent plus sous 7 jours → marquer résolu

🤖 Generated with [Claude Code](https://claude.com/claude-code)