### PR TITLE
docs(blog): guide de migration Meetup vers The Playground (FR+EN)

### DIFF
--- a/src/content/blog/en/migrer-meetup-vers-the-playground.md
+++ b/src/content/blog/en/migrer-meetup-vers-the-playground.md
@@ -1,0 +1,171 @@
+---
+title: "How to migrate your Meetup community to The Playground: step-by-step guide"
+description: "How to leave Meetup without breaking your community. The full method to transfer members, events and visibility to The Playground, in 4 to 8 weeks."
+date: "2026-05-25"
+keywords:
+  - migrate from meetup
+  - leave meetup
+  - meetup migration
+  - export meetup members
+  - meetup alternative
+---
+
+Since Bending Spoons acquired Meetup in January 2024, many organisers have seen their subscription rise sharply, the public API turn paid in February 2025, and their members hit with Meetup+ or per-RSVP fees. The question is no longer "should I leave Meetup", but "how do I do it without breaking what I've built". This guide lays out the method in two parts: first the strategy, then six tactical steps.
+
+## Part 1: the migration strategy
+
+### What you can (and can't) recover from Meetup
+
+Before any technical action, you need to understand what Meetup actually lets you export. This constraint shapes the whole migration.
+
+|  | Recoverable | Not recoverable |
+| --- | --- | --- |
+| Member list | Yes (names, photos, in `.xls`) | Not the emails (unless Meetup Pro, with conditions) |
+| Attendees per event | Yes (CSV per event) | No overall history |
+| Photos, discussions, past events | No | Everything |
+| API access | Paid, GraphQL only since February 2025 | Restricted member fields |
+
+The critical point: **on the Standard plan ($16.49 to $47/month), you have no access to your members' email addresses**. It's stated explicitly in the Meetup help docs ("The Contact Members tool doesn't give you access to your members' contact details or their email addresses"). The only plan that grants email access is Meetup Pro, starting at $55 per group per month, and even then under strict conditions: the member must have RSVP'd to an event after your upgrade to Pro (no retroactive access to existing members), and must have explicitly consented to share their email.
+
+In other words, to retrieve your own members' emails, you have to pay for the most expensive plan and accept that you'll only recover a fraction of your base anyway. It's a lock-in choice: without the emails, you can't reach your members outside Meetup, so you can't leave without rebuilding from scratch. This won't change. That's exactly what keeps organisers on the platform. Practical consequence for your migration: you cannot "export your list and email everyone to announce the change".
+
+### The principle: run both platforms in parallel
+
+As long as your Meetup subscription is active, you can post on your group and notify members through the built-in tools. Once you cancel, that channel disappears. This mechanic forces a precise sequence: don't close Meetup before you've transferred your base to the new platform.
+
+Migrating a community isn't an instant switch. It's a transition period where Meetup and The Playground coexist, the time it takes for members to develop the habit of using the new place. Most organisers who failed their migration tried to move too fast: announcement without a concrete event, Meetup closed before the critical mass had moved.
+
+### A realistic timeline
+
+| Phase | Duration | Goal |
+| --- | --- | --- |
+| Phase 1 | Week 1 | Set up the Playground Community and the first events |
+| Phase 2 | Weeks 2 to 6 | Announce, run the first events, keep both platforms active |
+| Phase 3 | Weeks 7 to 8 | Close the Meetup group |
+
+Four to eight weeks depending on how often you run events. The more frequent your events, the faster the migration: each event is a chance to announce the change and bring more members across.
+
+### What to accept upfront
+
+You won't recover 100% of your members. A realistic transition rate sits between 40 and 60% in the first three months, then climbs back up if you stay active. Members inactive for a long time won't come back regardless of the platform: they weren't attending your events anyway. The migration acts as a filter. Those who follow are your real members.
+
+## Part 2: the six tactical steps
+
+### Step 1: create your Community on The Playground (day 1)
+
+Take exactly what defines your Meetup group, without reinventing:
+
+- **Name**: keep it identical if possible, it helps member recognition.
+- **Description**: copy from Meetup, refresh if outdated.
+- **Cover image**: in square (1:1) format, the standard on The Playground.
+- **Public or private**: match what you had.
+
+Note the URL of your new Community. You'll paste it everywhere over the coming weeks.
+
+### Step 2: recreate your upcoming events (day 2)
+
+Migrate only the next two or three events. No need to recreate the history: Meetup doesn't really surface it anymore, and no one will dig through your new Community for a past event.
+
+For each upcoming event:
+- Title, date, time, location, description
+- Cover image (square)
+- Capacity if you set one
+- Price if the event is paid
+
+Create them as Drafts. You'll publish them at the official announcement, not before. A published event without an announcement sends a confused signal to the community.
+
+### Step 3: download your Meetup data (day 2 or 3)
+
+**Member list**. Log in to Meetup, then open the URL `https://www.meetup.com/[group-name]/members/?op=csv`. The downloaded file is an `.xls`. Open it in Excel or Google Sheets and export to CSV if needed.
+
+**Attendees for the next event**. From the event page on Meetup: Organizer Tools → Manage Attendees → Tools → Download attendees.
+
+What's it actually for? Not to contact people directly (you don't have emails on the Standard plan), but to:
+- Keep a record of who was a member before the migration.
+- Identify your most active members so you can reach out individually (via Meetup messages) at the switch.
+- Measure your transition rate later.
+
+### Step 4: announce the migration to your members (start of week 2)
+
+The most important moment. One rule: be transparent, short, with a concrete next step.
+
+**Announcement template** (post on the Meetup group + message to members through Meetup's tools):
+
+> Hi everyone,
+>
+> We're moving to a new platform: The Playground.
+>
+> Why: [your reason, in one sentence. Example: "Meetup has become paid for both organisers and members. We want a free, smoother platform."]
+>
+> Our Community lives here: [Playground URL]
+>
+> Our next event, [title + date], is already open for registration: [event URL]
+>
+> We're keeping this Meetup group active for a few more weeks while everyone makes the switch. See you on the other side.
+
+Multiply the channels: Meetup group, WhatsApp if you have one, LinkedIn as a personal post (not a company page), your email signature. The more the message travels, the smoother the transition.
+
+The trap to avoid: announcing the migration without a published Playground event ready. Without a concrete next step, members don't move. They vaguely note "I should sign up over there one day" and never come back.
+
+### Step 5: nail the first Playground events (weeks 2 to 6)
+
+The first event on The Playground is critical. It proves the community is still alive and installs the reflex "I sign up via Playground" for the future.
+
+A few tactics that help:
+
+- **Prime the social proof.** Ask two or three regulars to sign up first. The visible avatars on the event page trigger more registrations.
+- **Share the link multiple times**, at different moments (Monday morning, Thursday evening, weekend). One post isn't enough.
+- **Remind on Meetup 48 hours before the event**, with the direct link to the Playground page. That's the legitimate use of your Meetup subscription during the transition.
+
+On The Playground, joining an event automatically adds the Member to the Community. That's different from Meetup, where you first join the group, then RSVP. Less friction, better conversion.
+
+After the event, repeat: announce the next one within the week, on both platforms. Regularity creates the habit.
+
+### Step 6: close the Meetup group properly (weeks 7 to 8)
+
+When to close: after two or three successful events on The Playground, when you can see the new member base is rotating and new members come directly through the Playground channel. Not before.
+
+How to close:
+
+1. **Post a final message** at the top of the Meetup group:
+
+> This group will close on [date]. Our community continues here: [Playground URL]. All upcoming events are posted there. Thanks to everyone who made this group come alive for [X] years.
+
+2. **Keep that message pinned for two weeks**, so the least active members see it.
+3. **Cancel your Meetup subscription** before the renewal date (otherwise you pay for one more cycle).
+4. **Delete the group or leave it inactive**. Deleting is cleaner but irreversible. Leaving it inactive keeps a public trace, which can help old members find their way to your new Community.
+
+## Migration FAQ
+
+### Will I lose members?
+
+Yes, it's inevitable. Expect 40 to 60% transition in the first three months, then a gradual rise if you stay active. Members inactive for six months or more won't follow, but they weren't participating anyway.
+
+### How long should I plan for?
+
+Four to eight weeks depending on your event cadence. With one event per month, count two full months. With one event per week, it's faster: less risk that members forget the change between two announcements.
+
+### Should I keep both platforms running for long?
+
+No. The longer the parallel period lasts, the more it dilutes your members' attention, and the more you pay Meetup for a channel you're abandoning. Four to six weeks is a healthy balance.
+
+### How do I make up for losing Meetup's directory visibility?
+
+That's a real loss if you relied on organic discovery to recruit new members. Three levers partially compensate:
+- The Explore page on The Playground (directory of public Communities).
+- A personal LinkedIn post for every new event (the best channel for professional meetups).
+- Word of mouth from existing members, which is actually the most effective recruitment channel.
+
+### I have paid events still selling on Meetup, how do I handle the transition?
+
+Honour the events already sold on Meetup until their date. For new events, switch to The Playground with Stripe Connect: the organiser receives the payment directly, no platform commission. Only standard Stripe fees (around 2.9% + €0.30) apply.
+
+### What if some members refuse to leave Meetup?
+
+That's their call. Don't force, don't remove anyone. The announcement and the regular reminders are enough. Most holdouts migrate after the second or third announced event. Those who never migrate were probably already disconnected from the community.
+
+## In summary
+
+Migrating away from Meetup isn't a risk, it's a filter. The members who follow are the ones who actually keep your community alive. The others were already gone, even if they remained technically registered.
+
+Leaving Meetup also means taking back control: your Community, your members, your data, no fees or paywall for anyone. The work takes 4 to 8 weeks. The benefit lasts years.

--- a/src/content/blog/fr/migrer-meetup-vers-the-playground.md
+++ b/src/content/blog/fr/migrer-meetup-vers-the-playground.md
@@ -1,0 +1,173 @@
+---
+title: "Migrer votre communauté Meetup vers The Playground : guide pas à pas"
+description: "Comment quitter Meetup sans casser votre communauté. La méthode complète pour transférer membres, événements et notoriété vers The Playground, en 4 à 8 semaines."
+date: "2026-05-25"
+keywords:
+  - migrer meetup
+  - quitter meetup
+  - migration communauté meetup
+  - exporter membres meetup
+  - alternative meetup
+---
+
+Depuis le rachat par Bending Spoons en janvier 2024, beaucoup d'organisateurs ont vu leur abonnement Meetup augmenter fortement, l'API publique passer en payant en février 2025, et leurs membres être sollicités via Meetup+ ou des frais d'inscription. La question n'est plus tellement "faut-il quitter Meetup", mais "comment le faire sans casser ce qu'on a construit". Ce guide explique la méthode, en deux temps : d'abord la stratégie, ensuite les six étapes tactiques.
+
+## Partie 1 : la stratégie de migration
+
+### Ce que vous pouvez (et ne pouvez pas) récupérer de Meetup
+
+Avant toute action technique, il faut comprendre ce que Meetup permet réellement d'exporter. C'est cette contrainte qui structure toute la migration.
+
+|  | Récupérable | Non récupérable |
+| --- | --- | --- |
+| Liste des membres | Oui (noms, photos, en `.xls`) | Pas les emails (sauf Meetup Pro, sous conditions) |
+| Attendees par événement | Oui (CSV par événement) | Pas l'historique global |
+| Photos, discussions, événements passés | Non | Tout |
+| Accès via API | Payant, restreint à GraphQL depuis février 2025 | Champs membres limités |
+
+Le point critique : **sur le plan Standard ($16.49 à $47/mois), vous n'avez pas accès aux emails de vos membres**. C'est documenté noir sur blanc dans l'aide Meetup ("The Contact Members tool doesn't give you access to your members' contact details or their email addresses"). Le seul plan qui donne accès aux emails est Meetup Pro, à partir de $55 par groupe et par mois, et même là sous conditions strictes : le membre doit avoir fait un RSVP après votre passage en Pro (pas rétroactif sur vos membres existants), et avoir consenti explicitement à partager son email.
+
+Autrement dit, pour récupérer les emails de vos propres membres, il faut payer le plan le plus cher, et accepter que vous ne récupérerez de toute façon qu'une fraction de votre base. C'est un choix de lock-in : sans les emails, vous ne pouvez pas contacter vos membres en dehors de Meetup, donc vous ne pouvez pas partir sans tout reconstruire. Cette mécanique ne va pas changer, c'est précisément ce qui retient les organisateurs sur la plateforme. Conséquence pratique pour votre migration : vous ne pourrez pas "exporter votre liste et envoyer un email à tout le monde pour annoncer le changement".
+
+### L'implication : votre seul canal d'annonce, c'est Meetup lui-même
+
+Tant que votre abonnement Meetup est actif, vous pouvez poster sur le groupe et envoyer des notifications aux membres via les outils intégrés. Une fois l'abonnement annulé, ce canal disparaît. Cette mécanique impose un séquencement très précis : on ne ferme pas Meetup avant d'avoir transféré sa base sur la nouvelle plateforme.
+
+### Le principe : faire tourner les deux plateformes en parallèle
+
+Migrer une communauté n'est pas une bascule instantanée. C'est une période de transition pendant laquelle vous faites cohabiter Meetup et The Playground, le temps que les membres prennent l'habitude du nouvel endroit. La plupart des organisateurs qui ont raté leur migration ont essayé d'aller trop vite : annonce sans rendez-vous concret, fermeture de Meetup avant que la masse critique ait bougé.
+
+### Le calendrier réaliste
+
+| Phase | Durée | Objectif |
+| --- | --- | --- |
+| Phase 1 | Semaine 1 | Préparer la Communauté Playground et les premiers événements |
+| Phase 2 | Semaines 2 à 6 | Annoncer, organiser les premiers événements, faire vivre les deux plateformes |
+| Phase 3 | Semaines 7 à 8 | Fermer le groupe Meetup |
+
+Quatre à huit semaines selon votre fréquence d'événements. Plus vos événements sont fréquents, plus la migration est rapide : chaque événement est une occasion d'annoncer le changement et d'embarquer de nouveaux membres.
+
+### Ce qu'il faut accepter à l'avance
+
+Vous ne récupérerez pas 100% de vos membres. Un taux de transition réaliste se situe entre 40 et 60% sur les trois premiers mois, puis remonte ensuite si vous restez actif. Les membres inactifs depuis longtemps ne reviendront pas, quelle que soit la plateforme : ils ne venaient déjà plus à vos événements. La migration agit comme un filtre. Ceux qui suivent sont vos vrais membres.
+
+## Partie 2 : les six étapes tactiques
+
+### Étape 1 : créer votre Communauté sur The Playground (jour 1)
+
+Reprenez exactement ce qui définit votre groupe Meetup, sans réinventer :
+
+- **Nom** : gardez-le identique si possible, ça facilite la reconnaissance par les membres.
+- **Description** : recopiez celle de Meetup, ajustez si elle date.
+- **Image de couverture** : en format carré (1:1), c'est le standard sur The Playground.
+- **Statut public ou privé** : alignez-vous sur ce que vous aviez.
+
+Notez l'URL de votre nouvelle Communauté. Vous allez la coller partout dans les semaines qui viennent.
+
+### Étape 2 : recréer vos prochains événements (jour 2)
+
+Migrez seulement les deux ou trois prochains événements. Inutile de recréer l'historique : Meetup ne le met plus vraiment en valeur de toute façon, et personne n'ira chercher un événement passé sur votre nouvelle Communauté.
+
+Pour chaque événement à venir :
+- Titre, date, heure, lieu, description
+- Image de couverture (carrée)
+- Capacité si vous en imposez une
+- Prix si l'événement est payant
+
+Créez-les en Brouillon. Vous les publierez au moment de l'annonce officielle, pas avant. Un événement publié sans annonce envoie un signal flou à la communauté.
+
+### Étape 3 : télécharger vos données Meetup (jour 2 ou 3)
+
+**Liste des membres**. Connectez-vous à Meetup, puis ouvrez l'URL `https://www.meetup.com/[nom-du-groupe]/members/?op=csv`. Le fichier téléchargé est un `.xls`. Ouvrez-le dans Excel ou Google Sheets et exportez-le en CSV si besoin.
+
+**Attendees du prochain événement**. Depuis la page de l'événement sur Meetup : Organizer Tools → Manage Attendees → Tools → Download attendees.
+
+À quoi ça sert vraiment ? Pas à contacter directement (vous n'avez pas les emails sur le plan Standard), mais à :
+- Garder une trace de qui était membre avant la migration.
+- Repérer vos membres les plus actifs pour les solliciter individuellement (via messages Meetup) au moment de la bascule.
+- Mesurer plus tard votre taux de transition.
+
+### Étape 4 : annoncer la migration à vos membres (début semaine 2)
+
+C'est le moment le plus important. Une seule règle : être transparent, court, avec un rendez-vous concret.
+
+**Template d'annonce** (à publier en post de groupe Meetup + à envoyer en message aux membres via les outils Meetup) :
+
+> Bonjour à tous,
+>
+> Nous déménageons sur une nouvelle plateforme : The Playground.
+>
+> Pourquoi : [votre raison, en une phrase. Exemple : "Meetup est devenu payant pour les organisateurs et pour les membres. Nous voulons une plateforme gratuite et plus fluide."]
+>
+> Notre Communauté est ici : [URL Playground]
+>
+> Notre prochain événement, [titre + date], est déjà ouvert aux inscriptions : [URL événement]
+>
+> Nous gardons ce groupe Meetup actif encore quelques semaines, le temps que tout le monde fasse la transition. Au plaisir de vous retrouver de l'autre côté.
+
+Multipliez les canaux : groupe Meetup, WhatsApp si vous en avez un, LinkedIn en post personnel (pas en page entreprise), votre signature email. Plus le message tourne, plus la transition s'enclenche.
+
+Le piège à éviter : annoncer la migration sans avoir un premier événement Playground publié. Sans rendez-vous concret, les membres ne bougent pas, ils notent vaguement "il faut que je m'inscrive là-bas un jour", et n'y reviennent jamais.
+
+### Étape 5 : réussir les premiers événements Playground (semaines 2 à 6)
+
+Le premier événement sur The Playground est critique. Il prouve que la communauté existe encore et installe le réflexe "je m'inscris sur Playground" pour la suite.
+
+Quelques tactiques qui aident :
+
+- **Amorcer la preuve sociale**. Demandez à deux ou trois habitués de s'inscrire en premier. Les avatars visibles sur la page événement déclenchent les inscriptions des autres.
+- **Partager le lien plusieurs fois**, à des moments différents (lundi matin, jeudi soir, week-end). Un seul post ne suffit pas.
+- **Rappeler sur Meetup 48 heures avant l'événement**, avec le lien direct vers la page Playground. C'est l'utilisation légitime de votre abonnement Meetup pendant la transition.
+
+Sur The Playground, l'inscription à un événement inscrit automatiquement le Participant à la Communauté. C'est différent de Meetup où il faut d'abord rejoindre le groupe, puis faire un RSVP. Moins de friction, meilleure conversion.
+
+Après l'événement, recommencez : annoncez le prochain dans la semaine, sur les deux plateformes. La régularité crée l'habitude.
+
+### Étape 6 : fermer le groupe Meetup proprement (semaines 7 à 8)
+
+Quand fermer : après deux ou trois événements réussis sur The Playground, quand vous constatez que la base d'inscrits tourne et que les nouveaux membres viennent directement par le canal Playground. Pas avant.
+
+Comment fermer :
+
+1. **Publier un dernier message** en haut du groupe Meetup :
+
+> Ce groupe sera fermé le [date]. Notre communauté continue ici : [URL Playground]. Tous nos prochains événements y sont publiés. Merci à tous ceux qui ont fait vivre ce groupe pendant [X] années.
+
+2. **Laisser ce message visible deux semaines**, le temps que les membres les moins actifs le voient passer.
+3. **Annuler l'abonnement Meetup** avant la date de renouvellement (sinon vous payez un cycle pour rien).
+4. **Supprimer le groupe ou le laisser inactif**. Le supprimer est plus propre, mais c'est irréversible. Le laisser inactif garde une trace publique, ce qui peut aider les anciens membres à retrouver le chemin de votre nouvelle Communauté.
+
+## FAQ migration
+
+### Vais-je perdre des membres ?
+
+Oui, c'est inévitable. Comptez 40 à 60% de transition sur les trois premiers mois, puis une remontée progressive si vous restez actif. Les membres inactifs depuis six mois ou plus ne suivront pas, mais ils ne participaient déjà plus.
+
+### Combien de temps faut-il prévoir ?
+
+Quatre à huit semaines selon votre rythme d'événements. Avec un événement par mois, comptez deux mois pleins. Avec un événement par semaine, c'est plus rapide : moins de risque que les membres oublient le changement entre deux annonces.
+
+### Faut-il garder les deux plateformes en parallèle longtemps ?
+
+Non. Plus la période parallèle dure, plus elle dilue l'attention des membres, et plus vous payez Meetup pour un canal que vous êtes en train d'abandonner. Quatre à six semaines est un bon équilibre.
+
+### Comment compenser la perte de visibilité de l'annuaire Meetup ?
+
+C'est une vraie perte si vous comptiez sur la découverte organique pour recruter de nouveaux membres. Trois leviers compensent partiellement :
+- La page Découvrir de The Playground (annuaire des Communautés publiques).
+- Un post LinkedIn personnel à chaque nouvel événement (le canal le plus performant pour les meetups professionnels).
+- Le bouche à oreille des membres existants, qui reste le meilleur canal de recrutement en réalité.
+
+### J'ai des événements payants en cours sur Meetup, comment gérer ?
+
+Honorez les événements déjà vendus sur Meetup jusqu'à leur date. Pour les nouveaux événements, basculez sur The Playground avec Stripe Connect : l'organisateur reçoit le paiement directement, sans commission plateforme. Seuls les frais Stripe standards (environ 2.9% + 0.30€) s'appliquent.
+
+### Et si certains membres refusent de quitter Meetup ?
+
+C'est leur choix. Ne forcez pas, ne supprimez personne. Le message d'annonce et les rappels réguliers suffisent. La majorité des réfractaires finit par migrer après le deuxième ou troisième événement annoncé. Ceux qui ne migrent jamais étaient probablement déjà déconnectés de la communauté.
+
+## En résumé
+
+La migration depuis Meetup n'est pas un risque, c'est un filtre. Les membres qui suivent sont ceux qui font réellement vivre votre communauté. Les autres étaient déjà partis, même s'ils restaient techniquement inscrits.
+
+Quitter Meetup, c'est aussi reprendre le contrôle : votre Communauté, vos membres, vos données, sans frais ni paywall pour personne. Le travail tient en 4 à 8 semaines. Le bénéfice dure des années.


### PR DESCRIPTION
## Summary

Nouvel article de blog ciblant les organisateurs qui veulent quitter Meetup sans casser leur communauté. Structure en deux temps :

- **Partie 1 stratégie** : ce qui est récupérable de Meetup, lock-in des emails (Standard sans accès, Pro à 55$/groupe/mois sous conditions strictes), calendrier réaliste 4 à 8 semaines, taux de transition attendu 40 à 60%
- **Partie 2 tactique** : 6 étapes datées (jour 1 → semaine 8) avec actions concrètes, URL exacte d'export Meetup, templates d'annonce et de fermeture
- **FAQ** : 6 questions opérationnelles (perte de membres, durée, parallèle, annuaire, événements payants, réfractaires)

Versions FR et EN avec slug identique (convention du blog).

## Test plan

- [ ] Article FR visible sur `/blog/migrer-meetup-vers-the-playground`
- [ ] Article EN visible sur `/en/blog/migrer-meetup-vers-the-playground`
- [ ] Rendu Markdown correct (titres, tableaux, blockquotes, listes)
- [ ] Métadonnées OG/SEO (title, description, keywords) bien remontées
- [ ] Article listé dans la page `/blog` et dans `/en/blog`

🤖 Generated with [Claude Code](https://claude.com/claude-code)