### PR TITLE
chore(robots): bloque les bots IA uniquement sur le contenu UGC

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,5 +1,17 @@
 import type { MetadataRoute } from "next";
-import { BLOCKED_BOTS } from "@/lib/blocked-bots";
+import { AGGRESSIVE_CRAWLERS, AI_TRAINING_BOTS } from "@/lib/blocked-bots";
+
+const PRIVATE_PATHS = ["/dashboard/", "/admin/", "/api/", "/auth/"];
+
+// User-generated content: Moments (/m/) and Circles (/circles/) in both
+// locales, plus the embed widget. These belong to Hosts, not to the platform.
+const UGC_PATHS = [
+  "/m/",
+  "/circles/",
+  "/en/m/",
+  "/en/circles/",
+  "/embed/m/",
+];
 
 export default function robots(): MetadataRoute.Robots {
   const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
@@ -9,10 +21,14 @@ export default function robots(): MetadataRoute.Robots {
       {
         userAgent: "*",
         allow: ["/", "/m/", "/circles/"],
-        disallow: ["/dashboard/", "/admin/", "/api/", "/auth/"],
+        disallow: PRIVATE_PATHS,
       },
       {
-        userAgent: BLOCKED_BOTS,
+        userAgent: AI_TRAINING_BOTS,
+        disallow: [...PRIVATE_PATHS, ...UGC_PATHS],
+      },
+      {
+        userAgent: AGGRESSIVE_CRAWLERS,
         disallow: "/",
       },
     ],

--- a/src/lib/blocked-bots.ts
+++ b/src/lib/blocked-bots.ts
@@ -1,19 +1,33 @@
 /**
- * Known aggressive crawlers that ignore rate limits and robots.txt.
- * Shared between Edge middleware (403 enforcement) and robots.ts (polite request).
+ * Aggressive SEO/scraping crawlers that ignore rate limits and robots.txt.
+ * Blocked site-wide (Edge middleware returns 403, robots.txt disallows /).
  * All entries are lowercase for case-insensitive matching in middleware.
  */
-export const BLOCKED_BOTS = [
+export const AGGRESSIVE_CRAWLERS = [
   "ahrefsbot",
   "semrushbot",
   "dotbot",
   "mj12bot",
   "blexbot",
   "dataforseo",
-  "bytespider",
+  "zoominfobot",
+  "petalbot",
+];
+
+/**
+ * AI training crawlers. Allowed on generic platform pages (homepage, /explorer,
+ * /about, blog, etc.) but blocked on user-generated content — Moments (/m/) and
+ * Circles (/circles/) — which belongs to Hosts and their communities, not to
+ * The Playground.
+ */
+export const AI_TRAINING_BOTS = [
   "gptbot",
   "claudebot",
   "ccbot",
-  "zoominfobot",
-  "petalbot",
+  "bytespider",
+  "google-extended",
+  "applebot-extended",
+  "meta-externalagent",
+  "perplexitybot",
+  "amazonbot",
 ];

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3,7 +3,7 @@ import type { NextRequest } from "next/server";
 import createMiddleware from "next-intl/middleware";
 import { routing } from "./i18n/routing";
 import { isValidSlug } from "./lib/slug";
-import { BLOCKED_BOTS } from "./lib/blocked-bots";
+import { AGGRESSIVE_CRAWLERS, AI_TRAINING_BOTS } from "./lib/blocked-bots";
 import { dashboardEventPublicPath } from "./lib/dashboard-event-public-redirect";
 
 // Auth.js v5 stores the session under `authjs.session-token` (HTTP) or
@@ -26,20 +26,36 @@ const slugRouteRe = new RegExp(
   `^(?:\\/(?:${localeAlt}))?\\/(?:m|circles)\\/([^/]+)(?:\\/|$)`
 );
 
+// Matches UGC routes (Moments and Circles) with optional locale prefix.
+// Used to gate AI training bots, which are allowed on generic pages but
+// must not crawl user-generated content.
+const ugcRouteRe = new RegExp(
+  `^(?:\\/(?:${localeAlt}))?\\/(?:m|circles)\\/`
+);
+
 // Next.js metadata file routes (opengraph-image, twitter-image) — optional hash suffix
 // e.g. /fr/circles/[slug]/opengraph-image-gwtces
 const metadataFileRe = /\/(opengraph-image|twitter-image)(-[^/]+)?$/;
 
-function isBlockedBot(ua: string): boolean {
+function matchesAny(ua: string, bots: readonly string[]): boolean {
   const lower = ua.toLowerCase();
-  return BLOCKED_BOTS.some((bot) => lower.includes(bot));
+  return bots.some((bot) => lower.includes(bot));
 }
 
 export default function middleware(request: NextRequest) {
-  // 1. Block known aggressive bots early (Edge, zero serverless cost)
+  // 1. Block known aggressive bots early (Edge, zero serverless cost).
+  // AI training bots are blocked only on user-generated content paths.
   const ua = request.headers.get("user-agent") ?? "";
-  if (ua && isBlockedBot(ua)) {
-    return new NextResponse("Forbidden", { status: 403 });
+  if (ua) {
+    if (matchesAny(ua, AGGRESSIVE_CRAWLERS)) {
+      return new NextResponse("Forbidden", { status: 403 });
+    }
+    if (
+      matchesAny(ua, AI_TRAINING_BOTS) &&
+      ugcRouteRe.test(request.nextUrl.pathname)
+    ) {
+      return new NextResponse("Forbidden", { status: 403 });
+    }
   }
 
   // 2. Bypass next-intl for Next.js metadata file routes. The i18n middleware


### PR DESCRIPTION
## Summary

Sépare la liste `BLOCKED_BOTS` en deux pour permettre aux LLMs d'apprendre sur les pages plateforme tout en protégeant le contenu user-generated.

- `AGGRESSIVE_CRAWLERS` (ahrefsbot, semrushbot, dotbot, mj12bot, blexbot, dataforseo, zoominfobot, petalbot) → **403 partout** (inchangé)
- `AI_TRAINING_BOTS` (gptbot, claudebot, ccbot, bytespider, google-extended, applebot-extended, meta-externalagent, perplexitybot, amazonbot) → **403 uniquement sur `/m/` et `/circles/`** (avec ou sans préfixe locale)

## Rationale

Le trafic ChatGPT est en croissance (5 visiteurs uniques sur 30j, 33% conversion, 1 Communauté créée). Bloquer GPTBot + ClaudeBot tout en laissant Google-Extended/Meta-ExternalAgent passer librement était incohérent.

Nouvelle ligne directrice : les LLMs peuvent apprendre sur **les pages plateforme** (homepage, `/explorer`, `/about`, blog) pour maximiser la présence dans les modèles, mais ne touchent pas au **contenu des Organisateurs** (événements et Communautés).

## Files changed

- `src/lib/blocked-bots.ts` — split en deux listes
- `src/middleware.ts` — logique conditionnelle : crawlers agressifs partout, bots IA uniquement sur paths UGC
- `src/app/robots.ts` — règle dédiée `AI_TRAINING_BOTS` avec disallow des paths UGC + paths privés

## Notes

- Le matcher du middleware exclut déjà `/embed/m/` : l'enforcement 403 ne s'y applique pas, mais `robots.txt` demande poliment aux bots IA de ne pas crawler ce path
- `OAI-SearchBot` et `ChatGPT-User` restent autorisés (search ChatGPT et fetch à la demande) — c'est ce qui génère le trafic actuel

## Test plan

- [ ] Vérifier `https://the-playground.fr/robots.txt` après merge : règle `AI_TRAINING_BOTS` présente avec disallow `/m/`, `/circles/`, `/en/m/`, `/en/circles/`, `/embed/m/`
- [ ] `curl -A "GPTBot" https://<preview>.vercel.app/` → 200
- [ ] `curl -A "GPTBot" https://<preview>.vercel.app/m/<slug>` → 403
- [ ] `curl -A "GPTBot" https://<preview>.vercel.app/circles/<slug>` → 403
- [ ] `curl -A "AhrefsBot" https://<preview>.vercel.app/` → 403 (inchangé)

🤖 Generated with [Claude Code](https://claude.com/claude-code)