### PR TITLE
fix(seo): noindex sur les routes techniques et pages d'auth

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -130,6 +130,16 @@ const nextConfig: NextConfig = {
         source: "/((?!embed).*)",
         headers: securityHeaders,
       },
+      {
+        // Routes techniques jamais destinées à apparaître dans un index moteur.
+        // Doublé du `disallow` dans robots.ts car robots.txt n'empêche pas
+        // l'indexation d'URLs découvertes via lien externe — seul X-Robots-Tag
+        // bloque l'indexation côté Google/Bing.
+        source: "/:path(api|ingest|monitoring)/:rest*",
+        headers: [
+          { key: "X-Robots-Tag", value: "noindex, nofollow, noarchive" },
+        ],
+      },
     ];
   },
 };

--- a/src/app/[locale]/auth/layout.tsx
+++ b/src/app/[locale]/auth/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+// Pages de flow d'auth (sign-in, verify-request, confirm, error) :
+// jamais destinées à être indexées. Évite que Google retourne ces pages
+// transitoires comme résultat de recherche pour "the playground connexion".
+export const metadata: Metadata = {
+  robots: { index: false, follow: false, nocache: true },
+};
+
+export default function AuthLayout({ children }: { children: ReactNode }) {
+  return children;
+}


### PR DESCRIPTION
## Contexte

Un visiteur anonyme est arrivé sur `/api/auth/verify-request` via une recherche Google (event PostHog du 2026-05-27). Cette URL est une page d'état transitoire d'Auth.js qui ne devrait jamais apparaître en résultat de recherche.

Le `robots.txt` actuel applique bien un `disallow: /api/`, mais robots.txt **n'empêche pas l'indexation** d'URLs découvertes par lien externe : Google peut indexer sans crawler. Seul un header `X-Robots-Tag: noindex` ou une meta `robots noindex` bloque l'indexation.

## Changements

- **`next.config.ts`** : header `X-Robots-Tag: noindex, nofollow, noarchive` sur `/api/*`, `/ingest/*` (tunnel PostHog), `/monitoring/*` (tunnel Sentry).
- **`src/app/[locale]/auth/layout.tsx`** (nouveau) : `metadata.robots = { index: false, follow: false, nocache: true }`. Couvre `sign-in`, `verify-request`, `confirm`, `error` en FR et EN.

## Hors scope

- `/dashboard/*` et `/admin/*` : même risque potentiel, à traiter dans une issue séparée si besoin.

## Test plan

- [ ] Vérifier sur la preview que `curl -I https://<preview>/api/auth/verify-request` retourne bien `X-Robots-Tag: noindex, nofollow, noarchive`
- [ ] Vérifier que `curl -I https://<preview>/fr/auth/verify-request` renvoie une page contenant `<meta name="robots" content="noindex,nofollow,...">`
- [ ] Vérifier que `curl -I https://<preview>/` ne contient PAS de header X-Robots-Tag (les pages publiques restent indexables)
- [ ] Une fois mergé, soumettre une demande de suppression d'URL dans Google Search Console pour `/api/auth/verify-request`

🤖 Generated with [Claude Code](https://claude.com/claude-code)