### PR TITLE
fix(auth): refonte du wording de la page magic link /auth/confirm

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -152,10 +152,9 @@
       "description": "A sign-in link has been sent to your email address. Click it to sign in."
     },
     "confirm": {
-      "title": "Confirm your sign-in",
-      "description": "Click the button below to finish signing in to The Playground.",
-      "submit": "Confirm sign-in",
-      "hint": "This step keeps your link safe from anti-phishing scanners that automatically follow email links.",
+      "title": "One last click to sign in",
+      "reason": "Security check: one last click to make sure it's really you, and not an anti-spam bot.",
+      "submit": "Sign me in",
       "invalid": {
         "title": "Invalid link",
         "description": "This sign-in link is incomplete. Request a new one to continue.",
@@ -166,7 +165,7 @@
       "title": "Authentication error",
       "backToSignIn": "Back to sign in",
       "requestNewLink": "Send me a new link",
-      "verificationExplanation": "If you use a corporate inbox (Outlook, Gmail Workspace), your anti-phishing may have visited the link automatically and invalidated it.",
+      "verificationExplanation": "If you use a corporate inbox (Outlook, Gmail Workspace), an anti-spam bot may have visited the link automatically and invalidated it.",
       "verificationAction": "Request a new link and click it quickly, or sign in with Google/GitHub.",
       "webviewExplanation": "Google and GitHub block sign-in from in-app browsers (LinkedIn, Instagram, Facebook...).",
       "webviewAction": "Use the email sign-in, or open the site in your browser.",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -152,10 +152,9 @@
       "description": "Un lien de connexion a été envoyé à votre adresse email. Cliquez dessus pour vous connecter."
     },
     "confirm": {
-      "title": "Confirmer votre connexion",
-      "description": "Cliquez sur le bouton ci-dessous pour finaliser votre connexion à The Playground.",
-      "submit": "Confirmer ma connexion",
-      "hint": "Cette étape protège votre lien des anti-phishing qui parcourent automatiquement les emails.",
+      "title": "Un dernier clic pour vous connecter",
+      "reason": "Sécurité oblige : un dernier clic pour s'assurer que c'est bien vous, et pas un robot anti-spam.",
+      "submit": "Me connecter",
       "invalid": {
         "title": "Lien invalide",
         "description": "Ce lien de connexion est incomplet. Demandez-en un nouveau pour continuer.",
@@ -166,7 +165,7 @@
       "title": "Erreur d'authentification",
       "backToSignIn": "Retour à la connexion",
       "requestNewLink": "Recevoir un nouveau lien",
-      "verificationExplanation": "Si vous utilisez une boîte mail professionnelle (Outlook, Gmail Workspace), il est possible que votre anti-phishing ait visité le lien automatiquement et l'ait invalidé.",
+      "verificationExplanation": "Si vous utilisez une boîte mail professionnelle (Outlook, Gmail Workspace), il est possible qu'un robot anti-spam ait visité le lien automatiquement et l'ait invalidé.",
       "verificationAction": "Demandez un nouveau lien et cliquez-le rapidement, ou utilisez la connexion Google/GitHub.",
       "webviewExplanation": "Google et GitHub bloquent la connexion depuis les navigateurs intégrés (LinkedIn, Instagram, Facebook...).",
       "webviewAction": "Utilisez la connexion par email, ou ouvrez le site dans votre navigateur.",

--- a/src/app/[locale]/auth/confirm/page.tsx
+++ b/src/app/[locale]/auth/confirm/page.tsx
@@ -42,9 +42,9 @@ export default async function AuthConfirmPage({
   return (
     <div className="flex min-h-screen items-center justify-center px-4">
       <div className="w-full max-w-sm space-y-6 text-center">
-        <div className="space-y-2">
+        <div className="space-y-3">
           <h1 className="text-2xl font-bold tracking-tight">{t("title")}</h1>
-          <p className="text-muted-foreground text-sm">{t("description")}</p>
+          <p className="text-muted-foreground text-sm">{t("reason")}</p>
         </div>
 
         <form action={action} method="POST">
@@ -52,8 +52,6 @@ export default async function AuthConfirmPage({
             {t("submit")}
           </Button>
         </form>
-
-        <p className="text-muted-foreground text-xs">{t("hint")}</p>
       </div>
     </div>
   );

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -137,7 +137,7 @@ test.describe("Magic link — protection contre les scanners email", () => {
     page,
   }) => {
     await page.goto("/fr/auth/error?error=Verification");
-    await expect(page.getByText(/anti-phishing/i)).toBeVisible();
+    await expect(page.getByText(/anti-spam/i)).toBeVisible();
     await expect(page.getByRole("link", { name: /nouveau lien/i })).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary

- Cible la cause principale du drop-off observé sur `/auth/confirm` : un wording confus qui suggère que l'utilisateur valide une action déjà faite alors qu'il reste un clic à faire.
- Refonte purement contenu (4 fichiers, +11/-15) : nouveaux textes FR/EN, explication remontée sous le titre, alignement terminologique avec `/auth/error`.
- Aucune logique modifiée, aucune signature de fonction touchée, aucun test unitaire à refaire.

## Contexte

Le 2026-05-27, on a tracé une utilisatrice (Julie, BPCE, environnement Microsoft 365) qui a cliqué son magic link, atterri sur `/auth/confirm`, est restée 31 secondes puis a fermé l'onglet sans cliquer le bouton. Diagnostic via PostHog : aucune erreur technique, drop-off purement UX.

Le bouton actuel "Confirmer ma connexion" suggère "valider une action déjà faite" alors qu'il reste un clic obligatoire (volontaire, pour échapper aux scanners email type Defender Safe Links qui prefetchent les liens corporate).

## Changements

| Élément | Avant | Après |
|---|---|---|
| Titre | Confirmer votre connexion | Un dernier clic pour vous connecter |
| Bouton | Confirmer ma connexion | Me connecter |
| Explication | Texte gris minuscule en bas | Texte visible sous le titre |
| Vocabulaire | anti-phishing | robot anti-spam (plus accessible) |
| Description redondante | "Cliquez sur le bouton ci-dessous..." | Supprimée |

Alignement parallèle : `Auth.error.verificationExplanation` parle aussi de "robot anti-spam" (au lieu de "anti-phishing") pour rester cohérent.

## Scope strict (et ce que cette PR ne fait PAS)

Cette PR a été délibérément réduite après un code-review qui a identifié 4 bugs bloquants dans une version plus ambitieuse (détection de locale callbackUrl-first + allowlist de fournisseurs grand public). Ces deux sujets sont reportés car ils demandent un redesign de fond :

- **Locale callbackUrl-first** : ne pouvait pas fonctionner en prod car `signInWithEmail` hardcode `redirectTo: "/dashboard/profile/setup"` (pas de préfixe locale). À redessiner via propagation par cookie.
- **Allowlist consumer** : Outlook.com/Hotmail font des prefetchs via SmartScreen, et Resend tracking peut brûler les tokens. À redessiner avec désactivation explicite du tracking et recherche externe par domaine.

Aucun de ces problèmes ne touche le présent diff (pure modification de strings + rendu).

## Test plan

- [ ] Le typecheck passe localement (`pnpm typecheck` ✅)
- [ ] La page `/fr/auth/confirm?token=...&email=...` affiche le nouveau titre et le bouton "Me connecter"
- [ ] La page `/en/auth/confirm?token=...&email=...` affiche "One last click to sign in" / "Sign me in"
- [ ] La page `/fr/auth/error?error=Verification` mentionne "robot anti-spam"
- [ ] Le test E2E `tests/e2e/auth.spec.ts` continue de passer (matche désormais `/anti-spam/i`)
- [ ] Vérifier le rendu Vercel Preview sur les 2 langues

🤖 Generated with [Claude Code](https://claude.com/claude-code)