### PR TITLE
fix(embed): naviguer le top frame au clic sur le CTA du widget

### DIFF
--- a/src/components/embed/embed-event-card.tsx
+++ b/src/components/embed/embed-event-card.tsx
@@ -146,7 +146,7 @@ export async function EmbedEventCard({
           )}
           <a
             href={ctaHref}
-            target="_blank"
+            target="_top"
             rel="noopener noreferrer"
             className={ctaClassName(isPassive, isDark)}
           >
@@ -161,7 +161,7 @@ export async function EmbedEventCard({
         {t("poweredBy")}{" "}
         <a
           href={platformUrl}
-          target="_blank"
+          target="_top"
           rel="noopener noreferrer"
           className={`transition-colors ${palette.footerLink}`}
         >

--- a/tests/e2e/embed-widget.spec.ts
+++ b/tests/e2e/embed-widget.spec.ts
@@ -46,10 +46,10 @@ test.describe("Embed widget — rendu public", () => {
     await expect(page.getByRole("link", { name: /s'inscrire/i })).toBeVisible();
   });
 
-  test("should open the public moment page in a new tab (target=_blank)", async ({ page }) => {
+  test("should navigate the top frame to the public moment page (target=_top)", async ({ page }) => {
     await page.goto(`/embed/m/${SLUGS.PUBLISHED_MOMENT}`);
     const cta = page.getByRole("link", { name: /s'inscrire/i });
-    await expect(cta).toHaveAttribute("target", "_blank");
+    await expect(cta).toHaveAttribute("target", "_top");
     await expect(cta).toHaveAttribute("rel", /noopener/);
   });
 });


### PR DESCRIPTION
## Summary
- Le CTA "S'inscrire" du widget iframe ne réagit pas dans les navigateurs in-app (LinkedIn mobile, Instagram, Facebook, etc.) : ils ne savent pas ouvrir un `target="_blank"` depuis une iframe.
- Bascule du CTA et du lien "Powered by" sur `target="_top"` — le clic remplace la fenêtre courante, pattern utilisé par Calendly/Eventbrite dans le même contexte.
- Aucune action côté sites intégrant le widget : l'iframe charge le contenu en live depuis nos serveurs (ISR 5 min).

## Test plan
- [ ] Test E2E `embed-widget.spec.ts` à jour (`target=_top`)
- [ ] Vérifier manuellement le clic dans un post LinkedIn mobile une fois en prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)