### PR TITLE
fix(comments): notifications email batch + after() pour éviter la perte d'emails

### DIFF
--- a/spec/follow-ups/email-batch-hardening.md
+++ b/spec/follow-ups/email-batch-hardening.md
@@ -1,0 +1,49 @@
+# Follow-ups : durcissement des batches email
+
+Suite à l'incident 2026-05-31 (5/39 emails de notification de commentaire partis sur l'événement « Soirée Tremplin »), le fix immédiat a corrigé la racine du bug pour le flow commentaire (`sendCommentNotifications` dans `comment.ts`). Trois familles de bugs préexistants restent à traiter dans des PRs dédiées.
+
+## 1. Visibilité Sentry sur les erreurs métier Resend (transverse)
+
+**Symptôme** : `sendBatch` privé (`src/infrastructure/services/email/resend-email-service.ts`) appelle `resend.batch.send` qui peut renvoyer `{ data: null, error }` sur erreur métier (rate-limit, quota, validation). Aujourd'hui le retour est ignoré. Les 7 callers (`sendNewMomentToMembers`, `sendMomentUpdateBatch`, `sendMomentCancelledBatch`, `sendBroadcastMoments`, `sendCircleInvitations`, `sendRegistrationReminderBatch`, `sendNewCommentBatch`) ne savent jamais qu'un envoi a échoué côté Resend.
+
+**Difficulté** : modifier `sendBatch` pour throw sur error casse des comportements en cascade chez les callers (cf. boucle `for(moments)` du cron `send-reminders` qui s'arrête au throw → doublons). Il faut soit :
+- propager les erreurs par valeur de retour (`{ sent, failed, errors }`) plutôt que throw, puis adapter chaque caller pour décider de son comportement
+- ou laisser `sendBatch` silencieux et faire la vérification dans CHAQUE caller individuellement
+
+**Priorité** : moyenne. La visibilité ops est dégradée mais la solution actuelle (`Promise.all` de singles) avait le même angle mort.
+
+## 2. `after()` manquant sur d'autres fire-and-forget
+
+**Symptôme** : plusieurs Server Actions dispatchent un envoi email/notif sans `after()` :
+- `src/app/actions/registration.ts` — commentaire explicite « Pas de after() » à corriger
+- `src/app/actions/broadcast-moment.ts` — dispatche `sendBroadcastMoments` en `.catch(Sentry)`
+- `src/app/actions/notify-host-new-circle-member.ts`
+- `src/app/actions/circle.ts` (certains usages)
+
+**Impact** : sur Vercel Fluid Compute, l'instance peut suspendre la fonction avant la fin du dispatch → même incident que `comment.ts` 2026-05-31 mais pour d'autres types de notif.
+
+**Priorité** : moyenne à haute selon le volume (broadcast = potentiellement des centaines de destinataires).
+
+## 3. Couplage entre deux batches successifs
+
+**Symptôme** : `src/app/actions/moment.ts` enchaîne `sendMomentUpdateBatch(participants)` puis `sendMomentUpdateBatch(hosts)` en `await` séquentiel. Si le premier rejette, le second n'est jamais appelé. Si on ajoute un throw sur erreur Resend (cf. point 1), l'asymétrie devient plus visible.
+
+**Fix** : `Promise.allSettled` au lieu de séquentiel, ou try/catch indépendant.
+
+**Priorité** : faible (dépendant du point 1).
+
+## 4. Slack inconsistency dans `sendCommentNotifications`
+
+**Symptôme** : `notifySlackNewComment` est skippé quand `recipientMap.size === 0` (early return) mais envoyé quand `recipients.length === 0` après filtre prefs. Slack est un canal interne — devrait être notifié dans les deux cas.
+
+**Fix** : déplacer `notifySlackNewComment` AVANT l'early return, ou retirer l'early return.
+
+**Priorité** : faible (cas rare : event sans aucun autre membre que le commenter).
+
+## 5. broadcast-moment cooldown 24h potentiellement locké sans envoi
+
+**Symptôme** : `markBroadcastSent` est appelé AVANT `sendBroadcastMoments`. Si l'envoi échoue silencieusement (aujourd'hui) ou throw (futur si point 1 est traité), le Host est bloqué 24h sans aucun email envoyé et sans recours UI.
+
+**Fix** : marker APRÈS l'envoi réussi, ou ajouter une voie de recours explicite.
+
+**Priorité** : moyenne (impact UX direct sur les Organisateurs).

--- a/src/app/actions/comment.ts
+++ b/src/app/actions/comment.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import * as Sentry from "@sentry/nextjs";
+import { after } from "next/server";
 import { fileTypeFromBuffer } from "file-type";
 import { auth } from "@/infrastructure/auth/auth.config";
 import {
@@ -128,15 +129,22 @@ export async function addCommentAction(
       }
     );
 
-    // Resolve i18n in the request context (before fire-and-forget)
+    // `buildEmailLocaleResolver` lit `getLocale()` (dépend de `headers()`) :
+    // doit s'exécuter dans le request context, avant `after()`.
     const resolver = await buildEmailLocaleResolver(userId);
 
-    sendCommentNotifications(momentId, userId, content, resolver).catch(
-      (err) => {
+    // `after()` garantit la complétion sur Vercel Fluid Compute après le retour
+    // de la Server Action. La callback DOIT être async et await la promise —
+    // une callback synchrone qui n'attend pas la Promise reproduirait le bug
+    // d'origine (5/39 emails partis, incident 2026-05-31).
+    after(async () => {
+      try {
+        await sendCommentNotifications(momentId, userId, content, resolver);
+      } catch (err) {
         console.error(err);
         Sentry.captureException(err);
       }
-    );
+    });
 
     return result.comment;
   });
@@ -228,37 +236,41 @@ async function sendCommentNotifications(
   const prefsMap =
     await prismaUserRepository.findNotificationPreferencesByIds(recipientIds);
 
-  await Promise.all(
-    [...recipientMap.values()].map(async (recipient) => {
-      const prefs = prefsMap.get(recipient.userId);
-      if (!prefs?.notifyNewComment) return;
+  // Filtre opt-in AVANT le batch — n'envoie qu'aux destinataires qui ont
+  // activé `notifyNewComment`.
+  const recipients = [...recipientMap.values()]
+    .filter((r) => prefsMap.get(r.userId)?.notifyNewComment)
+    .map((r) => ({ to: r.email, recipientName: r.name }));
 
-      const t = await resolver.translationsFor(recipient.userId);
+  if (recipients.length > 0) {
+    // Le commenter (=trigger) est exclu du recipientMap (cf. delete ci-dessus),
+    // donc tous les destinataires sont ≠ trigger → buildEmailLocaleResolver
+    // retourne toujours DEFAULT_RECIPIENT_LOCALE pour eux. Les strings sont
+    // donc identiques pour tous → précalcul une seule fois.
+    const t = await resolver.defaultTranslations();
 
-      return emailService.sendNewComment({
-        to: recipient.email,
-        recipientName: recipient.name,
-        playerName,
-        momentTitle: moment.title,
-        momentSlug: moment.slug,
-        commentPreview,
-        strings: {
-          subject: t("commentNotification.subject", {
-            playerName,
-            momentTitle: moment.title,
-          }),
-          heading: t("commentNotification.heading"),
-          message: t("commentNotification.message", {
-            playerName,
-            momentTitle: moment.title,
-          }),
-          commentPreviewLabel: t("commentNotification.commentPreviewLabel"),
-          viewCommentCta: t("commentNotification.viewCommentCta"),
-          footer: t("common.footer"),
-        },
-      });
-    })
-  );
+    await emailService.sendNewCommentBatch({
+      recipients,
+      playerName,
+      momentTitle: moment.title,
+      momentSlug: moment.slug,
+      commentPreview,
+      strings: {
+        subject: t("commentNotification.subject", {
+          playerName,
+          momentTitle: moment.title,
+        }),
+        heading: t("commentNotification.heading"),
+        message: t("commentNotification.message", {
+          playerName,
+          momentTitle: moment.title,
+        }),
+        commentPreviewLabel: t("commentNotification.commentPreviewLabel"),
+        viewCommentCta: t("commentNotification.viewCommentCta"),
+        footer: t("common.footer"),
+      },
+    });
+  }
 
   const baseUrl = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
   await notifySlackNewComment({

--- a/src/components/moments/comment-thread.tsx
+++ b/src/components/moments/comment-thread.tsx
@@ -291,7 +291,10 @@ export function CommentThread({
   }
 
   return (
-    <div className="border-border bg-card rounded-2xl border p-6">
+    <div
+      id="comments"
+      className="border-border bg-card scroll-mt-24 rounded-2xl border p-6"
+    >
       <div className="space-y-4">
         {/* Header */}
         <h2 className="text-muted-foreground text-xs font-semibold uppercase tracking-wider">

--- a/src/domain/ports/services/email-service.ts
+++ b/src/domain/ports/services/email-service.ts
@@ -264,6 +264,10 @@ export type MomentCancelledBatchEmailData = Omit<MomentCancelledEmailData, "to" 
   recipients: Array<{ to: string; recipientName: string }>;
 };
 
+export type NewCommentBatchEmailData = Omit<NewCommentEmailData, "to" | "recipientName"> & {
+  recipients: Array<{ to: string; recipientName: string }>;
+};
+
 export type AdminEntityCreatedEmailData = {
   to: string;
   entityType: "circle" | "moment";
@@ -498,7 +502,7 @@ export interface EmailService {
   ): Promise<void>;
   sendWaitlistPromotion(data: WaitlistPromotionEmailData): Promise<void>;
   sendHostNewRegistration(data: HostNewRegistrationEmailData): Promise<void>;
-  sendNewComment(data: NewCommentEmailData): Promise<void>;
+  sendNewCommentBatch(data: NewCommentBatchEmailData): Promise<void>;
   sendNewMomentToMember(data: NewMomentMemberEmailData): Promise<void>;
   sendNewMomentToMembers(data: NewMomentMembersEmailData): Promise<void>;
   sendMomentUpdate(data: MomentUpdateEmailData): Promise<void>;

--- a/src/domain/usecases/__tests__/helpers/mock-email-service.ts
+++ b/src/domain/usecases/__tests__/helpers/mock-email-service.ts
@@ -8,7 +8,7 @@ export function createMockEmailService(
     sendRegistrationConfirmation: vi.fn().mockResolvedValue(undefined),
     sendWaitlistPromotion: vi.fn().mockResolvedValue(undefined),
     sendHostNewRegistration: vi.fn().mockResolvedValue(undefined),
-    sendNewComment: vi.fn().mockResolvedValue(undefined),
+    sendNewCommentBatch: vi.fn().mockResolvedValue(undefined),
     sendNewMomentToMember: vi.fn().mockResolvedValue(undefined),
     sendNewMomentToMembers: vi.fn().mockResolvedValue(undefined),
     sendMomentUpdate: vi.fn().mockResolvedValue(undefined),

--- a/src/infrastructure/services/email/resend-email-service.ts
+++ b/src/infrastructure/services/email/resend-email-service.ts
@@ -5,7 +5,7 @@ import type {
   RegistrationReminderEmailData,
   WaitlistPromotionEmailData,
   HostNewRegistrationEmailData,
-  NewCommentEmailData,
+  NewCommentBatchEmailData,
   NewMomentMemberEmailData,
   NewMomentMembersEmailData,
   MomentUpdateEmailData,
@@ -172,13 +172,23 @@ export function createResendEmailService(): EmailService {
       });
     },
 
-    async sendNewComment(data: NewCommentEmailData): Promise<void> {
-      await send({
-        from,
-        to: data.to,
-        subject: data.strings.subject,
-        react: NewCommentEmail({ ...data, baseUrl }),
-      });
+    async sendNewCommentBatch(
+      data: NewCommentBatchEmailData
+    ): Promise<void> {
+      const { recipients, ...common } = data;
+      await sendBatch(
+        recipients.map(({ to, recipientName }) => ({
+          from,
+          to,
+          subject: common.strings.subject,
+          react: NewCommentEmail({
+            ...common,
+            to,
+            recipientName,
+            baseUrl,
+          }),
+        }))
+      );
     },
 
     async sendNewMomentToMember(

--- a/src/infrastructure/services/email/templates/new-comment.tsx
+++ b/src/infrastructure/services/email/templates/new-comment.tsx
@@ -20,7 +20,7 @@ export function NewCommentEmail({
   baseUrl,
   strings,
 }: Props) {
-  const viewUrl = `${baseUrl}/m/${momentSlug}`;
+  const viewUrl = `${baseUrl}/m/${momentSlug}#comments`;
 
   return (
     <EmailLayout preview={strings.subject} footer={strings.footer}>


### PR DESCRIPTION
## Summary

Fix de l'incident 2026-05-31 sur l'événement « Soirée Tremplin » : sur 39 inscrits éligibles, seuls **5 ont reçu l'email** de notification quand l'organisateur a posté un commentaire. Les 34 autres ont été silencieusement perdus.

### Causes racines

1. **Rate-limit Resend** : `sendCommentNotifications` faisait `Promise.all` de 39 appels `resend.emails.send` (single) en parallèle. Resend limite à 5 req/s par défaut → 34 envois rejetés en 429.
2. **Suspension Vercel** : le dispatch était fire-and-forget (`.catch(Sentry)`) **sans `after()`**, donc Vercel Fluid Compute pouvait tuer l'instance avant la fin des envois.

### Fix appliqué

- Nouvelle méthode `sendNewCommentBatch` qui appelle `resend.batch.send` (1 appel HTTP pour tous les destinataires, contourne le rate-limit).
- Dispatch enveloppé dans `after(async () => { try { await ... } catch ... })` (pattern aligné sur `circle.ts` et `profile.ts`).
- Précalcul du subject + strings une fois en FR (le commenter est exclu du recipientMap, donc tous les destinataires reçoivent `DEFAULT_RECIPIENT_LOCALE`).
- Filtre `notifyNewComment` déplacé avant le batch.

### Bonus UX

Le CTA « Voir le commentaire » dans l'email pointe maintenant directement vers la section commentaires de la page événement (`#comments` + `id="comments"` + `scroll-mt-24`).

### Périmètre

- **Aucune modification du helper `sendBatch` privé** : les 6 autres méthodes batch (broadcast, momentUpdate, momentCancelled, etc.) ont strictement le même comportement qu'avant.
- **Pas de scope creep** : les bugs latents transverses (visibilité Sentry sur erreurs Resend, `after()` manquant sur `registration.ts` / `broadcast-moment.ts`, Slack inconsistency, broadcast cooldown) sont documentés dans `spec/follow-ups/email-batch-hardening.md` pour des PRs dédiées.

### Renvoi manuel des 34 emails perdus

Effectué en parallèle via un script one-off ad-hoc le 2026-05-31 à 21:07 UTC : 34 destinataires ont reçu la notification rétroactivement (vérifié sur dashboard Resend).

## Test plan

- [x] `pnpm typecheck` pass
- [x] `pnpm vitest` : 626 tests pass (72 fichiers)
- [x] Aucun orphan caller de `sendNewComment\b` (grep)
- [x] Pattern `after()` vérifié conforme à `circle.ts` et `profile.ts` + source Next.js (`after-context.js:83`)
- [x] `sendBatch` privé strictement intact (diff vide sur cette fonction)
- [ ] Vérifier le rendu de l'email + scroll vers `#comments` sur preview Vercel
- [ ] Surveiller la prochaine notif commentaire en prod (Resend + Sentry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)