### PR TITLE
fix(admin): afficher "En attente" pour les memberships PENDING

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -261,7 +261,8 @@
     "role": {
       "host": "Organizer",
       "coHost": "Co-organizer",
-      "player": "Member"
+      "player": "Member",
+      "pending": "Pending"
     },
     "pendingRequests": {
       "membershipsTitle": "Pending membership requests",
@@ -843,7 +844,6 @@
       "memberSince": "Member since",
       "circles": "Communities",
       "noCircles": "No communities.",
-      "pendingMembership": "Pending",
       "moments": "Events",
       "noMoments": "No Events.",
       "auth": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -843,6 +843,7 @@
       "memberSince": "Member since",
       "circles": "Communities",
       "noCircles": "No communities.",
+      "pendingMembership": "Pending",
       "moments": "Events",
       "noMoments": "No Events.",
       "auth": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -843,6 +843,7 @@
       "memberSince": "Membre depuis",
       "circles": "Communautés",
       "noCircles": "Aucune communauté.",
+      "pendingMembership": "En attente",
       "moments": "Événements",
       "noMoments": "Aucun événement.",
       "auth": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -261,7 +261,8 @@
     "role": {
       "host": "Organisateur",
       "coHost": "Co-organisateur",
-      "player": "Participant"
+      "player": "Participant",
+      "pending": "En attente"
     },
     "pendingRequests": {
       "membershipsTitle": "Demandes d'adhésion en attente",
@@ -843,7 +844,6 @@
       "memberSince": "Membre depuis",
       "circles": "Communautés",
       "noCircles": "Aucune communauté.",
-      "pendingMembership": "En attente",
       "moments": "Événements",
       "noMoments": "Aucun événement.",
       "auth": {

--- a/src/app/[locale]/(routes)/admin/users/[id]/page.tsx
+++ b/src/app/[locale]/(routes)/admin/users/[id]/page.tsx
@@ -169,7 +169,9 @@ export default async function AdminUserDetailPage({ params }: Props) {
                     {circle.name}
                   </Link>
                   <Badge variant="outline" className="text-xs">
-                    {tRole(circle.role.toLowerCase() as "host" | "player")}
+                    {circle.status === "PENDING"
+                      ? t("userDetail.pendingMembership")
+                      : tRole(circle.role.toLowerCase() as "host" | "player")}
                   </Badge>
                 </div>
               ))}

--- a/src/app/[locale]/(routes)/admin/users/[id]/page.tsx
+++ b/src/app/[locale]/(routes)/admin/users/[id]/page.tsx
@@ -10,7 +10,14 @@ import { CopyButton } from "@/components/ui/copy-button";
 import { formatLongDate } from "@/lib/format-date";
 import { buildSentryIssuesSearchUrl } from "@/lib/sentry-url";
 import { buildPostHogPersonUrl } from "@/lib/posthog-url";
+import type { CircleMemberRole } from "@/domain/models/circle";
 import { AdminUserDeleteButton } from "./delete-button";
+
+const ROLE_I18N_KEY: Record<CircleMemberRole, "host" | "coHost" | "player"> = {
+  HOST: "host",
+  CO_HOST: "coHost",
+  PLAYER: "player",
+};
 
 type Props = {
   params: Promise<{ id: string }>;
@@ -169,9 +176,7 @@ export default async function AdminUserDetailPage({ params }: Props) {
                     {circle.name}
                   </Link>
                   <Badge variant="outline" className="text-xs">
-                    {circle.status === "PENDING"
-                      ? t("userDetail.pendingMembership")
-                      : tRole(circle.role.toLowerCase() as "host" | "player")}
+                    {tRole(circle.status === "PENDING" ? "pending" : ROLE_I18N_KEY[circle.role])}
                   </Badge>
                 </div>
               ))}

--- a/src/domain/ports/repositories/admin-repository.ts
+++ b/src/domain/ports/repositories/admin-repository.ts
@@ -1,5 +1,5 @@
 import type { UserRole } from "@/domain/models/user";
-import type { CircleVisibility, CircleCategory } from "@/domain/models/circle";
+import type { CircleVisibility, CircleCategory, MembershipStatus } from "@/domain/models/circle";
 import type { MomentStatus } from "@/domain/models/moment";
 
 // ─────────────────────────────────────────────
@@ -56,6 +56,7 @@ export type AdminUserDetail = AdminUserRow & {
     name: string;
     slug: string;
     role: string;
+    status: MembershipStatus;
   }>;
   moments: Array<{
     id: string;

--- a/src/domain/ports/repositories/admin-repository.ts
+++ b/src/domain/ports/repositories/admin-repository.ts
@@ -1,5 +1,10 @@
 import type { UserRole } from "@/domain/models/user";
-import type { CircleVisibility, CircleCategory, MembershipStatus } from "@/domain/models/circle";
+import type {
+  CircleVisibility,
+  CircleCategory,
+  CircleMemberRole,
+  MembershipStatus,
+} from "@/domain/models/circle";
 import type { MomentStatus } from "@/domain/models/moment";
 
 // ─────────────────────────────────────────────
@@ -55,7 +60,7 @@ export type AdminUserDetail = AdminUserRow & {
     id: string;
     name: string;
     slug: string;
-    role: string;
+    role: CircleMemberRole;
     status: MembershipStatus;
   }>;
   moments: Array<{

--- a/src/domain/usecases/__tests__/admin/get-admin-user.test.ts
+++ b/src/domain/usecases/__tests__/admin/get-admin-user.test.ts
@@ -75,4 +75,22 @@ describe("GetAdminUser", () => {
       expect(result?.circles[1].role).toBe("PLAYER");
     });
   });
+
+  describe("given a user with a PENDING membership", () => {
+    it("should expose the PENDING status on the membership entry", async () => {
+      const userDetail = makeAdminUserDetail({
+        circles: [
+          { id: "circle-1", name: "Tech Paris", slug: "tech-paris", role: "PLAYER", status: "PENDING" },
+        ],
+      });
+      const adminRepository = createMockAdminRepository({
+        findUserById: vi.fn().mockResolvedValue(userDetail),
+      });
+
+      const result = await getAdminUser("ADMIN", "user-1", { adminRepository });
+
+      expect(result?.circles[0].status).toBe("PENDING");
+      expect(result?.circles[0].role).toBe("PLAYER");
+    });
+  });
 });

--- a/src/domain/usecases/__tests__/admin/get-admin-user.test.ts
+++ b/src/domain/usecases/__tests__/admin/get-admin-user.test.ts
@@ -60,8 +60,8 @@ describe("GetAdminUser", () => {
     it("should return all circle memberships in the detail", async () => {
       const userDetail = makeAdminUserDetail({
         circles: [
-          { id: "circle-1", name: "Tech Paris", slug: "tech-paris", role: "HOST" },
-          { id: "circle-2", name: "Design Lyon", slug: "design-lyon", role: "PLAYER" },
+          { id: "circle-1", name: "Tech Paris", slug: "tech-paris", role: "HOST", status: "ACTIVE" },
+          { id: "circle-2", name: "Design Lyon", slug: "design-lyon", role: "PLAYER", status: "ACTIVE" },
         ],
       });
       const adminRepository = createMockAdminRepository({

--- a/src/domain/usecases/__tests__/admin/mock-admin-repository.ts
+++ b/src/domain/usecases/__tests__/admin/mock-admin-repository.ts
@@ -123,7 +123,7 @@ export function makeAdminUserDetail(
       welcomeEmailSentAt: new Date("2026-01-01"),
     },
     circles: [
-      { id: "circle-1", name: "Tech Paris", slug: "tech-paris", role: "HOST" },
+      { id: "circle-1", name: "Tech Paris", slug: "tech-paris", role: "HOST", status: "ACTIVE" },
     ],
     moments: [
       { id: "moment-1", title: "Meetup JS", slug: "meetup-js", startsAt: new Date("2099-06-01T18:00:00Z"), status: "PUBLISHED", circleName: "Tech Paris" },

--- a/src/infrastructure/repositories/prisma-admin-repository.ts
+++ b/src/infrastructure/repositories/prisma-admin-repository.ts
@@ -506,6 +506,7 @@ export const prismaAdminRepository: AdminRepository = {
         name: m.circle.name,
         slug: m.circle.slug,
         role: m.role,
+        status: m.status,
       })),
       moments: record.registrations.map((r) => ({
         id: r.moment.id,


### PR DESCRIPTION
## Contexte

Repéré pendant l'investigation d'un spike d'inscriptions (création de la Communauté "Cloud Pi Native" + 5 demandes en attente d'approbation) : sur `/admin/users/[id]`, les memberships en `PENDING` étaient affichés avec le badge **"Participant"**, masquant qu'elles n'étaient pas encore validées par l'organisateur.

## Summary

- Expose le champ `status: MembershipStatus` sur `AdminUserDetail.circles[]` (port + adapter Prisma)
- Affiche un badge **"En attente"** quand `status === "PENDING"`, sinon badge rôle inchangé
- **Post code-review** :
  - `role` retypé `CircleMemberRole` au port (suppression du cast `as "host" | "player"` qui ignorait `CO_HOST`)
  - Libellé centralisé sous `Dashboard.role.pending` (au lieu d'une clé dédiée `Admin.userDetail.pendingMembership`)
  - Test unitaire ajouté pour la branche PENDING (figer le contrat repo → usecase)

## Scope

Limité à `/admin/users/[id]` (la surface où le bug a été vu). Le compteur `memberCount` de `/admin/circles/[id]` qui mélange PENDING + ACTIVE est une incohérence connue, à traiter dans un fix séparé.

## Test plan

- [x] `pnpm typecheck` ✅
- [x] `pnpm test:unit src/domain/usecases/__tests__/admin/get-admin-user.test.ts` ✅ (5/5)
- [x] Vérif visuelle locale (DB dev = snapshot prod) :
  - `/admin/users/<Kevin>` → Cloud Pi Native = **"En attente"**
  - `/admin/users/<Akram>` → Cloud Pi Native = **"Organisateur"** (inchangé)
- [ ] Vérif Vercel preview une fois CI vert

🤖 Generated with [Claude Code](https://claude.com/claude-code)