### PR TITLE
fix(i18n): retirer la virgule des salutations "Bonjour, <prénom>"

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -187,7 +187,7 @@
       "cta": "Explore"
     },
     "modeChoice": {
-      "greetingPrefix": "Welcome,",
+      "greetingPrefix": "Welcome",
       "greetingSuffix": "What do you want to do?",
       "greetingAnonymous": "Welcome — what do you want to do?",
       "subtitle": "Where would you like to start?",
@@ -279,7 +279,7 @@
     "online": "Online",
     "hybrid": "Hybrid",
     "hostTools": "Host tools",
-    "greeting": "Hello, {name}",
+    "greeting": "Hello {name}",
     "greetingAnonymous": "Hello",
     "greetingSubtitle": "Your events and communities, at a glance.",
     "memberCount": "{count} members",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -187,7 +187,7 @@
       "cta": "Explorer"
     },
     "modeChoice": {
-      "greetingPrefix": "Bienvenue,",
+      "greetingPrefix": "Bienvenue",
       "greetingSuffix": "Que voulez-vous faire ?",
       "greetingAnonymous": "Bienvenue — que voulez-vous faire ?",
       "subtitle": "Par où voulez-vous commencer ?",
@@ -279,7 +279,7 @@
     "online": "En ligne",
     "hybrid": "Hybride",
     "hostTools": "Outils organisateur",
-    "greeting": "Bonjour, {name}",
+    "greeting": "Bonjour {name}",
     "greetingAnonymous": "Bonjour",
     "greetingSubtitle": "Vos événements et vos communautés, en un coup d'œil.",
     "memberCount": "{count} membres",


### PR DESCRIPTION
## Contexte

Le titre « Bonjour, <prénom> » affichait une virgule disgracieuse entre la salutation et le prénom, sur plusieurs pages.

## Changements

Suppression de la virgule dans les salutations (FR + EN) :

| Clé | Avant | Après |
|---|---|---|
| `Dashboard.greeting` (FR) | `Bonjour, {name}` | `Bonjour {name}` |
| `Dashboard.greeting` (EN) | `Hello, {name}` | `Hello {name}` |
| `Welcome.modeChoice.greetingPrefix` (FR) | `Bienvenue,` | `Bienvenue` |
| `Welcome.modeChoice.greetingPrefix` (EN) | `Welcome,` | `Welcome` |

Pages concernées : « Mon espace » (Dashboard) et l'onboarding (choix du mode).

## Notes

- Changement de contenu i18n uniquement, aucun composant touché.
- Pas d'harmonisation des mots (« Bonjour » et « Bienvenue » conservés tels quels), conformément à la demande.

🤖 Generated with [Claude Code](https://claude.com/claude-code)