### PR TITLE
docs(help): documenter le widget d'intégration d'événement

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1642,6 +1642,7 @@
       "editCancel": "Edit or cancel",
       "radar": "The Radar",
       "share": "Share your event",
+      "embed": "Embed on your site",
       "members": "Manage members",
       "coHosts": "Co-organizers",
       "inviteMembers": "Invite members",
@@ -1826,6 +1827,15 @@
       "share": {
         "title": "Share your event",
         "intro": "Every event has a <strong>unique URL</strong> (format <code>the-playground.fr/m/your-event</code>). Copy this link from the event dashboard and share it directly — via WhatsApp, Instagram, email, or newsletter. No installation or prior account is required for attendees."
+      },
+      "embed": {
+        "title": "Embed an event on your site",
+        "intro": "You can display any event directly on your website, blog or newsletter using an embeddable <strong>widget</strong>. It shows the essentials of the event page (title, date, location, attendees) with a registration button, and always stays up to date automatically.",
+        "stepsLabel": "To get the embed code:",
+        "step1": "From your event dashboard, find the <strong>Event widget</strong> block and click <strong>Get the code</strong>",
+        "step2": "Choose the <strong>language</strong> (French or English) and the <strong>theme</strong> (light or dark). A live preview is shown",
+        "step3": "Click <strong>Copy code</strong>, then paste the HTML snippet into your site, blog post or newsletter editor",
+        "callout": "The widget updates automatically (date, remaining capacity, event status) and adapts to the width of its container. No maintenance on your end: if you edit the event, the widget reflects the change instantly."
       },
       "members": {
         "title": "Manage community members",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1642,6 +1642,7 @@
       "editCancel": "Modifier ou annuler",
       "radar": "Le Radar",
       "share": "Partager l'événement",
+      "embed": "Intégrer sur votre site",
       "members": "Gérer les membres",
       "coHosts": "Co-organisateurs",
       "inviteMembers": "Inviter des membres",
@@ -1826,6 +1827,15 @@
       "share": {
         "title": "Partager votre événement",
         "intro": "Chaque événement dispose d'une <strong>URL unique</strong> (format <code>the-playground.fr/m/votre-evenement</code>). Copiez ce lien depuis le tableau de bord de l'événement et partagez-le directement — via WhatsApp, Instagram, email, ou newsletter. Aucune installation ni compte préalable n'est requis pour les participants."
+      },
+      "embed": {
+        "title": "Intégrer un événement sur votre site",
+        "intro": "Vous pouvez afficher n'importe quel événement directement sur votre site, votre blog ou votre newsletter grâce à un <strong>widget</strong> à intégrer. Le widget reprend l'essentiel de la page de l'événement (titre, date, lieu, inscrits) avec un bouton d'inscription, et reste toujours à jour automatiquement.",
+        "stepsLabel": "Pour obtenir le code d'intégration :",
+        "step1": "Depuis le tableau de bord de votre événement, repérez le bloc <strong>Widget événement</strong> et cliquez sur <strong>Obtenir le code</strong>",
+        "step2": "Choisissez la <strong>langue</strong> (français ou anglais) et le <strong>thème</strong> (clair ou sombre). Un aperçu en direct s'affiche",
+        "step3": "Cliquez sur <strong>Copier le code</strong>, puis collez l'extrait HTML dans votre site, votre article de blog ou votre éditeur de newsletter",
+        "callout": "Le widget se met à jour automatiquement (date, places restantes, statut de l'événement) et s'adapte à la largeur de son emplacement. Aucune maintenance de votre côté : si vous modifiez l'événement, le widget reflète le changement instantanément."
       },
       "members": {
         "title": "Gérer les membres de votre communauté",

--- a/src/app/[locale]/(routes)/(static)/help/page.tsx
+++ b/src/app/[locale]/(routes)/(static)/help/page.tsx
@@ -100,6 +100,7 @@ export default async function HelpPage() {
         { id: "editCancel", label: t("sidebar.editCancel") },
         { id: "radar", label: t("sidebar.radar") },
         { id: "share", label: t("sidebar.share") },
+        { id: "embed", label: t("sidebar.embed") },
         { id: "members", label: t("sidebar.members") },
         { id: "coHosts", label: t("sidebar.coHosts") },
         { id: "inviteMembers", label: t("sidebar.inviteMembers") },
@@ -561,6 +562,30 @@ export default async function HelpPage() {
               <p className="text-sm leading-relaxed text-muted-foreground">
                 {t.rich("organizer.share.intro", rich)}
               </p>
+            </div>
+
+            <hr className="border-border" />
+
+            {/* Intégrer (widget) */}
+            <div className="space-y-4">
+              <SectionH3 id="embed">{t("organizer.embed.title")}</SectionH3>
+              <p className="text-sm leading-relaxed text-muted-foreground">
+                {t.rich("organizer.embed.intro", rich)}
+              </p>
+              <p className="text-sm font-medium text-foreground">
+                {t("organizer.embed.stepsLabel")}
+              </p>
+              <ol className="space-y-3">
+                {(["step1", "step2", "step3"] as const).map((step, i) => (
+                  <li key={step} className="flex items-start gap-3">
+                    <StepNumber n={i + 1} />
+                    <span className="text-sm leading-relaxed text-muted-foreground">
+                      {t.rich(`organizer.embed.${step}`, rich)}
+                    </span>
+                  </li>
+                ))}
+              </ol>
+              <Callout>{t("organizer.embed.callout")}</Callout>
             </div>
 
             <hr className="border-border" />


### PR DESCRIPTION
## Contexte

La feature widget/iframe (bouton « Obtenir le code » dans le tableau de bord d'un événement) n'était pas documentée sur la page Aide. Les organisateurs n'avaient aucun moyen de savoir comment l'utiliser.

## Changements

Ajout d'un article **« Intégrer un événement sur votre site »** dans la section Organisateur de la page Aide, juste après « Partager votre événement » (même registre : diffusion de l'événement).

- `messages/fr.json` + `messages/en.json` : nouveau bloc `organizer.embed` (titre, intro, 3 étapes, callout) + entrée sidebar `embed`
- `help/page.tsx` : bloc de rendu + entrée dans la navigation latérale

L'article explique où récupérer le code du widget, le choix langue/thème, le copier-coller, et la mise à jour automatique.

## Vérifications

- JSON valide (fr + en, clés synchronisées)
- `pnpm typecheck` au vert

🤖 Generated with [Claude Code](https://claude.com/claude-code)