### PR TITLE
fix(explorer): masquer la section À la une en vue mobile

### DIFF
--- a/src/components/explorer/explorer-featured.tsx
+++ b/src/components/explorer/explorer-featured.tsx
@@ -21,7 +21,7 @@ export function ExplorerFeatured({ circles }: Props) {
   if (circles.length === 0) return null;
 
   return (
-    <div className="relative mb-8 overflow-hidden rounded-[20px] border border-border">
+    <div className="relative mb-8 hidden overflow-hidden rounded-[20px] border border-border sm:block">
       {/* Backdrop cinématique — dark mode uniquement */}
       <div
         className="absolute inset-0 hidden scale-105 opacity-40 dark:block"


### PR DESCRIPTION
## Contexte

La section « Communautés du jour » (À la une) de la page Découvrir était affichée sur tous les écrans, y compris en mobile. On pensait l'avoir déjà masquée en vue mobile, mais l'investigation a confirmé que ce n'avait jamais été fait : aucune classe responsive ne la masquait.

## Changement

`src/components/explorer/explorer-featured.tsx` — conteneur racine :
- `relative mb-8 overflow-hidden …` → ajout de `hidden … sm:block`

La section est désormais masquée en dessous de `sm` (640px) et visible à partir de `sm`. Le breakpoint est aligné sur celui de la grille interne (1 colonne → 3 colonnes à `sm`).

## Effet

- **Mobile** : section masquée, les résultats de recherche remontent au-dessus de la ligne de flottaison.
- **Desktop** : inchangé.

## Note

Les 3 covers conservent `priority` ; même masquées en CSS, elles restent préchargées sur mobile (léger coût réseau). Un rendu conditionnel JS l'éviterait mais introduirait un risque de hydration mismatch. Le masquage CSS reste le pattern propre, déjà utilisé dans ce composant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)