### PR TITLE
fix(explorer): masquer aussi le skeleton À la une en vue mobile

### DIFF
--- a/src/app/[locale]/(routes)/explorer/loading.tsx
+++ b/src/app/[locale]/(routes)/explorer/loading.tsx
@@ -9,8 +9,8 @@ export default function ExplorerLoading() {
         <Skeleton className="h-5 w-80" />
       </div>
 
-      {/* À la une */}
-      <div className="rounded-[20px] border p-5 sm:p-6 space-y-5">
+      {/* À la une — masquée en mobile, comme le composant réel */}
+      <div className="hidden rounded-[20px] border p-5 sm:block sm:p-6 space-y-5">
         <div className="flex items-center justify-between">
           <div className="space-y-2">
             <Skeleton className="h-3 w-16" />


### PR DESCRIPTION
## Contexte

Suite à #506 (section « Communautés du jour » masquée en mobile), un flash subsistait : pendant le chargement, le **skeleton** de la page Découvrir affichait toujours son placeholder de la section À la une sur mobile, le temps de l'hydratation.

## Cause

Le `hidden sm:block` de #506 ne couvrait que le composant réel (`explorer-featured.tsx`). Le skeleton (`explorer/loading.tsx`) gardait son bloc placeholder visible sur tous les écrans.

## Changement

`src/app/[locale]/(routes)/explorer/loading.tsx` — conteneur du bloc skeleton À la une :
- ajout de `hidden … sm:block`, aligné sur le composant réel.

## Effet

- **Mobile** : plus de flash, le skeleton À la une ne s'affiche plus.
- **Desktop** : inchangé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)