### PR TITLE
feat(email): alerter sur Slack quand le quota Resend approche la limite

### DIFF
--- a/src/infrastructure/services/email/__tests__/resend-quota-monitor.test.ts
+++ b/src/infrastructure/services/email/__tests__/resend-quota-monitor.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const notifySlackQuotaWarningMock = vi.fn();
+
+vi.mock("../../slack/slack-notification-service", () => ({
+  notifySlackQuotaWarning: (used: number, tier: number) =>
+    notifySlackQuotaWarningMock(used, tier),
+}));
+
+import { checkResendQuota, __resetForTests } from "../resend-quota-monitor";
+
+function headers(used: number | string): Record<string, string> {
+  return { "x-resend-daily-quota": String(used) };
+}
+
+describe("checkResendQuota", () => {
+  beforeEach(() => {
+    __resetForTests();
+    notifySlackQuotaWarningMock.mockReset();
+  });
+
+  describe("given le quota est sous le premier seuil", () => {
+    it("should ne pas alerter", async () => {
+      await checkResendQuota(headers(42));
+      expect(notifySlackQuotaWarningMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("given le quota franchit 70", () => {
+    it("should alerter une fois au palier 70", async () => {
+      await checkResendQuota(headers(72));
+      expect(notifySlackQuotaWarningMock).toHaveBeenCalledExactlyOnceWith(72, 70);
+    });
+
+    it("should ne pas re-alerter tant qu'on reste dans le palier 70", async () => {
+      await checkResendQuota(headers(72));
+      await checkResendQuota(headers(80));
+      await checkResendQuota(headers(89));
+      expect(notifySlackQuotaWarningMock).toHaveBeenCalledExactlyOnceWith(72, 70);
+    });
+  });
+
+  describe("given le quota franchit 90", () => {
+    it("should alerter au palier 90 après le palier 70", async () => {
+      await checkResendQuota(headers(72));
+      await checkResendQuota(headers(91));
+      expect(notifySlackQuotaWarningMock).toHaveBeenCalledTimes(2);
+      expect(notifySlackQuotaWarningMock).toHaveBeenLastCalledWith(91, 90);
+    });
+
+    it("should alerter directement au palier 90 si on saute par-dessus 70", async () => {
+      await checkResendQuota(headers(95));
+      expect(notifySlackQuotaWarningMock).toHaveBeenCalledExactlyOnceWith(95, 90);
+    });
+  });
+
+  describe("given le header de quota est absent ou invalide", () => {
+    it.each([
+      ["headers null", null],
+      ["headers undefined", undefined],
+      ["header manquant", {} as Record<string, string>],
+      ["valeur non numérique", { "x-resend-daily-quota": "n/a" }],
+    ])("should ne rien faire (%s)", async (_label, h) => {
+      await checkResendQuota(h);
+      expect(notifySlackQuotaWarningMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("given le quota redescend (nouveau jour, reset Resend à minuit)", () => {
+    it("should se réarmer et ré-alerter au palier 70 le lendemain", async () => {
+      await checkResendQuota(headers(72)); // jour 1 : alerte 70
+      await checkResendQuota(headers(5)); // lendemain : quota remis à zéro puis 5 emails
+      await checkResendQuota(headers(75)); // jour 2 : franchit de nouveau 70
+
+      expect(notifySlackQuotaWarningMock).toHaveBeenCalledTimes(2);
+      expect(notifySlackQuotaWarningMock).toHaveBeenNthCalledWith(1, 72, 70);
+      expect(notifySlackQuotaWarningMock).toHaveBeenNthCalledWith(2, 75, 70);
+    });
+  });
+});

--- a/src/infrastructure/services/email/resend-email-service.ts
+++ b/src/infrastructure/services/email/resend-email-service.ts
@@ -1,4 +1,5 @@
 import { createSafeResend } from "@/lib/email/safe-resend";
+import { checkResendQuota } from "./resend-quota-monitor";
 import type {
   EmailService,
   RegistrationConfirmationEmailData,
@@ -99,7 +100,8 @@ export function createResendEmailService(): EmailService {
   ): Promise<void> {
     const to = Array.isArray(params.to) ? params.to : [params.to];
     if (to.every(isDemoEmail)) return;
-    await resend.emails.send(params);
+    const res = await resend.emails.send(params);
+    await checkResendQuota(res.headers);
   }
 
   // Envoie un batch en respectant la limite de 100 emails par appel Resend.
@@ -116,7 +118,8 @@ export function createResendEmailService(): EmailService {
     const CHUNK_SIZE = 100;
     for (let i = 0; i < real.length; i += CHUNK_SIZE) {
       if (i > 0) await new Promise((r) => setTimeout(r, 500));
-      await resend.batch.send(real.slice(i, i + CHUNK_SIZE));
+      const res = await resend.batch.send(real.slice(i, i + CHUNK_SIZE));
+      await checkResendQuota(res.headers);
     }
   }
 

--- a/src/infrastructure/services/email/resend-quota-monitor.ts
+++ b/src/infrastructure/services/email/resend-quota-monitor.ts
@@ -1,0 +1,55 @@
+/**
+ * Surveillance du quota d'envoi quotidien de Resend (plan gratuit : 100 emails/jour).
+ *
+ * Resend renvoie sur chaque réponse d'envoi un header `x-resend-daily-quota`
+ * contenant le nombre d'emails déjà envoyés aujourd'hui (cumulé, plan gratuit
+ * uniquement). On lit ce chiffre à chaque envoi et on alerte sur Slack quand on
+ * franchit un palier (70 puis 90), une seule fois par palier et par jour.
+ *
+ * Limites assumées :
+ * - L'état est en mémoire de l'instance serverless : plusieurs instances chaudes
+ *   peuvent émettre la même alerte (doublons tolérés, sans gravité).
+ * - Le header n'est présent que sur le plan gratuit : après un passage à un plan
+ *   payant, `used` vaut NaN et la surveillance se désactive d'elle-même.
+ * - Slack est prod-only (voir slack-notification-service) : aucune alerte hors prod.
+ */
+
+import { notifySlackQuotaWarning } from "../slack/slack-notification-service";
+
+const TIERS = [70, 90] as const;
+const QUOTA_HEADER = "x-resend-daily-quota";
+
+// État en mémoire — anti-spam (une alerte par palier) + détection du nouveau jour.
+let lastTierAlerted = 0;
+let lastSeenUsed = 0;
+
+/**
+ * À appeler après chaque envoi Resend, avec les headers de la réponse.
+ * Ne lève jamais d'exception : la surveillance ne doit jamais casser un envoi.
+ */
+export async function checkResendQuota(
+  headers: Record<string, string> | null | undefined,
+): Promise<void> {
+  try {
+    const used = Number(headers?.[QUOTA_HEADER]);
+    if (Number.isNaN(used)) return;
+
+    // Le quota a baissé → Resend l'a remis à zéro à minuit → nouveau jour, on réarme.
+    if (used < lastSeenUsed) lastTierAlerted = 0;
+    lastSeenUsed = used;
+
+    const highest = Math.max(0, ...TIERS.filter((tier) => used >= tier));
+    if (highest > lastTierAlerted) {
+      lastTierAlerted = highest;
+      await notifySlackQuotaWarning(used, highest);
+    }
+  } catch {
+    // Best-effort : un échec de surveillance ne doit jamais bloquer un envoi.
+  }
+}
+
+/** Réinitialise l'état mémoire — tests uniquement. */
+export function __resetForTests(): void {
+  lastTierAlerted = 0;
+  lastSeenUsed = 0;
+}

--- a/src/infrastructure/services/slack/slack-notification-service.ts
+++ b/src/infrastructure/services/slack/slack-notification-service.ts
@@ -180,8 +180,8 @@ export async function notifySlackQuotaWarning(
     text: `⚠️ Quota Resend à ${used}/100 aujourd'hui (seuil ${tier} franchi)`,
     blocks: [
       { type: "header", text: { type: "plain_text", text: "⚠️ Quota emails Resend", emoji: true } },
-      { type: "section", text: { type: "mrkdwn", text: `*${used}/100* emails envoyes aujourd'hui (plan gratuit).\nSeuil de *${tier}* franchi.` } },
-      { type: "context", elements: [{ type: "mrkdwn", text: "Au-dela de 100/jour, les envois sont bloques jusqu'au lendemain. Pense a passer sur un plan payant." }] },
+      { type: "section", text: { type: "mrkdwn", text: `*${used}/100* emails envoyés aujourd'hui (plan gratuit).\nSeuil de *${tier}* franchi.` } },
+      { type: "context", elements: [{ type: "mrkdwn", text: "Au-delà de 100/jour, les envois sont bloqués jusqu'au lendemain. Pense à passer sur un plan payant." }] },
     ],
   });
 }

--- a/src/infrastructure/services/slack/slack-notification-service.ts
+++ b/src/infrastructure/services/slack/slack-notification-service.ts
@@ -172,6 +172,20 @@ export async function notifySlackNewComment(params: {
   });
 }
 
+export async function notifySlackQuotaWarning(
+  used: number,
+  tier: number,
+): Promise<void> {
+  await sendSlack({
+    text: `⚠️ Quota Resend à ${used}/100 aujourd'hui (seuil ${tier} franchi)`,
+    blocks: [
+      { type: "header", text: { type: "plain_text", text: "⚠️ Quota emails Resend", emoji: true } },
+      { type: "section", text: { type: "mrkdwn", text: `*${used}/100* emails envoyes aujourd'hui (plan gratuit).\nSeuil de *${tier}* franchi.` } },
+      { type: "context", elements: [{ type: "mrkdwn", text: "Au-dela de 100/jour, les envois sont bloques jusqu'au lendemain. Pense a passer sur un plan payant." }] },
+    ],
+  });
+}
+
 export async function notifySlackSentryIssue(params: {
   issue: { issueShortId: string; issueTitle: string };
   analysis: AnalysisResult;

--- a/src/infrastructure/services/slack/slack-notification-service.ts
+++ b/src/infrastructure/services/slack/slack-notification-service.ts
@@ -50,10 +50,10 @@ export async function notifySlackNewEntity(params: {
 }): Promise<void> {
   const isCircle = params.entityType === "circle";
   const icon = isCircle ? "🟣" : "📅";
-  const label = isCircle ? "Nouvelle Communaute" : "Nouvel evenement";
+  const label = isCircle ? "Nouvelle Communauté" : "Nouvel événement";
 
   const bodyParts = [`*${params.entityName}*`, `Par ${params.creatorName} (${params.creatorEmail})`];
-  if (params.circleName) bodyParts.push(`Communaute : ${params.circleName}`);
+  if (params.circleName) bodyParts.push(`Communauté : ${params.circleName}`);
   if (params.momentDate) bodyParts.push(`Date : ${params.momentDate}`);
   if (params.locationText) bodyParts.push(`Lieu : ${params.locationText}`);
 
@@ -80,17 +80,17 @@ export async function notifySlackMomentUpdated(params: {
   const bodyParts = [
     `*${params.momentTitle}*`,
     `Par ${params.hostName} (${params.hostEmail})`,
-    `Communaute : ${params.circleName}`,
+    `Communauté : ${params.circleName}`,
     `Date : ${params.momentDate}`,
     `Lieu : ${params.locationText}`,
   ];
 
   await sendSlack({
-    text: `✏️ Evenement modifie — ${params.momentTitle}`,
+    text: `✏️ Événement modifié — ${params.momentTitle}`,
     blocks: [
-      { type: "header", text: { type: "plain_text", text: "✏️ Evenement modifie", emoji: true } },
+      { type: "header", text: { type: "plain_text", text: "✏️ Événement modifié", emoji: true } },
       { type: "section", text: { type: "mrkdwn", text: bodyParts.join("\n") } },
-      { type: "section", text: { type: "mrkdwn", text: `*Champs modifies*\n${params.changedFields.map((f) => `• ${f}`).join("\n")}` } },
+      { type: "section", text: { type: "mrkdwn", text: `*Champs modifiés*\n${params.changedFields.map((f) => `• ${f}`).join("\n")}` } },
       { type: "actions", elements: [{ type: "button", text: { type: "plain_text", text: "Voir dans le dashboard" }, url: params.momentUrl }] },
     ],
   });
@@ -145,12 +145,12 @@ export async function notifySlackNewRegistration(params: {
     text: `🎟️ Nouvelle inscription — ${params.playerName} → ${params.momentTitle}`,
     blocks: [
       { type: "header", text: { type: "plain_text", text: "🎟️ Nouvelle inscription", emoji: true } },
-      { type: "section", text: { type: "mrkdwn", text: `*${params.playerName}* s'est inscrit a *${params.momentTitle}*` } },
+      { type: "section", text: { type: "mrkdwn", text: `*${params.playerName}* s'est inscrit à *${params.momentTitle}*` } },
       { type: "section", fields: [
-        { type: "mrkdwn", text: `*Communaute*\n${params.circleName}` },
+        { type: "mrkdwn", text: `*Communauté*\n${params.circleName}` },
         { type: "mrkdwn", text: `*Inscriptions*\n${params.registrationInfo}` },
       ]},
-      { type: "actions", elements: [{ type: "button", text: { type: "plain_text", text: "Voir l'evenement" }, url: params.momentUrl }] },
+      { type: "actions", elements: [{ type: "button", text: { type: "plain_text", text: "Voir l'événement" }, url: params.momentUrl }] },
     ],
   });
 }
@@ -165,9 +165,9 @@ export async function notifySlackNewComment(params: {
     text: `💬 Nouveau commentaire — ${params.playerName} sur ${params.momentTitle}`,
     blocks: [
       { type: "header", text: { type: "plain_text", text: "💬 Nouveau commentaire", emoji: true } },
-      { type: "section", text: { type: "mrkdwn", text: `*${params.playerName}* a commente sur *${params.momentTitle}*` } },
+      { type: "section", text: { type: "mrkdwn", text: `*${params.playerName}* a commenté sur *${params.momentTitle}*` } },
       { type: "section", text: { type: "mrkdwn", text: `> ${params.commentPreview}` } },
-      { type: "actions", elements: [{ type: "button", text: { type: "plain_text", text: "Voir l'evenement" }, url: params.momentUrl }] },
+      { type: "actions", elements: [{ type: "button", text: { type: "plain_text", text: "Voir l'événement" }, url: params.momentUrl }] },
     ],
   });
 }


### PR DESCRIPTION
## Contexte

Le plan gratuit de Resend est limité à **100 emails/jour**. Au-delà, tous les envois (dont les magic links de connexion) sont bloqués jusqu'au lendemain, sans facturation mais sans alerte non plus. On veut être prévenu avant d'atteindre la limite.

## Solution

Resend renvoie sur chaque réponse d'envoi le header `x-resend-daily-quota` (nombre d'emails déjà envoyés aujourd'hui, cumulé sur le compte). On lit ce chiffre après chaque envoi et on émet une alerte Slack au franchissement des seuils **70** puis **90**, une seule fois par seuil et par jour.

- État en mémoire (anti-spam + réarmement quotidien automatique). Les doublons d'alerte entre instances serverless sont tolérés.
- Aucune base de données, aucun cron.
- La surveillance ne peut jamais casser un envoi (try/catch interne).
- Inerte hors production (Slack est déjà prod-only) et auto-désactivée sur un plan payant (le header disparaît).

## Périmètre

- Branché sur le service email (confirmations, rappels, notifications). Le header étant cumulé au niveau du compte, un seul envoi via le service révèle le total global.
- Choix assumé : les magic links ne sont pas instrumentés directement.

## Fichiers

- `resend-quota-monitor.ts` (nouveau) : lecture du quota, logique de seuils, état mémoire.
- `slack-notification-service.ts` : nouvelle alerte `notifySlackQuotaWarning` + correction des accents français manquants dans toutes les notifications existantes.
- `resend-email-service.ts` : appel du moniteur après chaque envoi.
- Tests unitaires du moniteur (seuils, pas de re-alerte, réarmement, header absent).

## Tests

- `pnpm typecheck` vert.
- 10 tests unitaires du moniteur verts.