### PR TITLE
fix(circle): rediriger les non-membres du dashboard Communauté vers la page publique

### DIFF
--- a/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/page.tsx
+++ b/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/page.tsx
@@ -32,6 +32,7 @@ import { getMomentGradient } from "@/lib/gradient";
 import { CollapsibleDescription } from "@/components/moments/collapsible-description";
 import { HostLink } from "@/components/circles/host-link";
 import { resolveCircleRepository } from "@/lib/admin-host-mode";
+import { redirectToPublicCircle } from "@/lib/dashboard-circle-public-redirect";
 import { isActiveOrganizer } from "@/domain/models/circle";
 import {
   Globe,
@@ -86,8 +87,12 @@ export default async function CircleDetailPage({
 
   const circleRepo = await resolveCircleRepository(session, prismaCircleRepository);
 
+  // Bounce visitors without a membership to the public circle page instead of a
+  // 404 — typically someone who was handed the `/dashboard/circles/[slug]`
+  // management link rather than the public `/circles/[slug]` one. PENDING members
+  // keep their current access (the membership is non-null), so they are unaffected.
   const membership = await circleRepo.findMembership(circle.id, session.user.id);
-  if (!membership) notFound();
+  if (!membership) redirectToPublicCircle(slug);
 
   const isOrganizer = isActiveOrganizer(membership);
   const callerRole = membership.role;

--- a/src/lib/dashboard-circle-public-redirect.ts
+++ b/src/lib/dashboard-circle-public-redirect.ts
@@ -1,0 +1,16 @@
+import { redirect } from "next/navigation";
+
+/**
+ * Server-side redirect to the public circle page (throws NEXT_REDIRECT).
+ *
+ * Used when a visitor reaches a circle's dashboard page without a membership
+ * (e.g. an organizer shared the `/dashboard/circles/[slug]` management link
+ * instead of the public `/circles/[slug]` one). Bouncing to the public page
+ * keeps them in the funnel, with the "Rejoindre" CTA, rather than hitting a 404.
+ *
+ * No locale prefix: next-intl ("as-needed") resolves it from the NEXT_LOCALE
+ * cookie, same as the sibling `redirectToPublicMoment`.
+ */
+export function redirectToPublicCircle(slug: string): never {
+  redirect(`/circles/${slug}`);
+}


### PR DESCRIPTION
## Problème

La page de gestion `/dashboard/circles/[slug]` renvoyait un **404** (`notFound()`) à tout visiteur connecté sans membership.

Tracé sur un cas réel (PostHog) : un nouvel utilisateur a ouvert `/dashboard/circles/cloud-pi-native` (`prev_pageview = None` → ouverture directe d'un lien externe), obtenu un 404, puis trouvé la page publique et rejoint la Communauté. Cause : le lien de **gestion** (copié depuis la barre d'adresse de l'organisateur) avait été partagé au lieu du lien **public** `/circles/[slug]`.

## Correctif

`notFound()` → **redirection 307** vers `/circles/[slug]` (page publique avec le CTA « Rejoindre »), pour garder le visiteur dans le funnel.

Aligne le comportement sur celui déjà en place pour les pages Moment (`redirectToPublicMoment`).

## Périmètre

- ✅ Page dashboard de la Communauté (la base) **uniquement**
- ❌ Pas `/edit` ni `/moments/new` (hors périmètre, décidé)
- ❌ Pas de couche middleware pour les visiteurs déconnectés (hors périmètre)

## Comportement

- **Non-membre** (aucune membership) → redirigé vers la page publique.
- **Membre PENDING** → inchangé (membership non-null, garde son accès actuel).
- **Circle inexistant** → `notFound()` conservé. Pas de boucle de redirection.
- **Mode admin-host** → fausse membership ACTIVE, accès préservé.

## Tests / vérifs

- `pnpm typecheck` ✅
- `/code-review` (high effort) : 0 bug de correctness, 1 nettoyage appliqué (helper inliné). Locale préservée via `localePrefix: as-needed` + cookie `NEXT_LOCALE` ; pas d'open-redirect (`isValidSlug` + Circle déjà résolu en base).
- Pas de migration Prisma.

🤖 Generated with [Claude Code](https://claude.com/claude-code)