### PR TITLE
chore: mises à jour pré-release 2.14.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Le modèle communautaire de Meetup + l'expérience de Luma + 100% gratuit. Pas d
 - [Explorer](https://the-playground.fr/explorer) — répertoire public de communautés avec tri, filtres et section À la une
 - **Widget intégrable** — encart événement embarquable sur n'importe quel site externe (thème clair/sombre, copie du snippet HTML en un clic)
 - **Réseaux** — regrouper plusieurs communautés sous une vitrine commune (fédérations, collectifs, marques)
-- **Blog** — articles de fond sur la philosophie et les choix du produit
+- **Blog** — articles de fond et guides pratiques (philosophie produit, migration depuis Meetup, etc.)
 - Bilingue FR / EN avec URLs propres
 - 100% gratuit — seuls les frais Stripe (~2,9% + 0,30€) sur les événements payants
 
@@ -97,6 +97,11 @@ src/
   infrastructure/  → Adapters (Prisma, Resend, Stripe, Claude)
   app/             → Next.js App Router (routes, server actions)
   components/      → Composants React réutilisables
+  lib/             → Utilitaires partagés (helpers purs)
+  hooks/           → React hooks personnalisés
+  i18n/            → Configuration next-intl (routing, request)
+  content/         → Contenu statique (articles de blog en Markdown)
+  assets/          → Assets statiques (images, SVG)
 ```
 
 Voir `CLAUDE.md` pour le contrat strict d'architecture et les règles de dépendance.

--- a/messages/en.json
+++ b/messages/en.json
@@ -1730,7 +1730,8 @@
         "item1": "New registration for one of your events (for organizers)",
         "item2": "New comment on an event",
         "item3": "New event published in a community you belong to",
-        "item4": "Some emails are sent automatically and cannot be disabled: registration confirmation, event reminders, event update or cancellation notifications."
+        "item4": "Some emails are sent automatically and cannot be disabled: registration confirmation, event reminders, event update or cancellation notifications.",
+        "item5": "From comment notification emails, a \"Manage my preferences\" link takes you directly to the settings page, without going through Dashboard."
       },
       "leave": {
         "title": "Leave a community",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1730,7 +1730,8 @@
         "item1": "Nouvelle inscription à l'un de vos événements (pour les organisateurs)",
         "item2": "Nouveau commentaire sur un événement",
         "item3": "Nouvel événement publié dans une communauté dont vous êtes membre",
-        "item4": "D'autres emails sont envoyés automatiquement et ne peuvent pas être désactivés : confirmation d'inscription, rappels avant l'événement, notifications de modification ou d'annulation."
+        "item4": "D'autres emails sont envoyés automatiquement et ne peuvent pas être désactivés : confirmation d'inscription, rappels avant l'événement, notifications de modification ou d'annulation.",
+        "item5": "Depuis les emails de notification de commentaire, un lien « Gérer mes préférences » vous amène directement à la page de réglages, sans passer par Mon espace."
       },
       "leave": {
         "title": "Quitter une communauté",

--- a/src/app/[locale]/(routes)/(static)/about/page.tsx
+++ b/src/app/[locale]/(routes)/(static)/about/page.tsx
@@ -369,9 +369,9 @@ export default async function AboutPage() {
         <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
           {[
             { value: "2 100+", label: isFr ? "commits" : "commits" },
-            { value: "420+", label: isFr ? "pull requests" : "pull requests" },
+            { value: "450+", label: isFr ? "pull requests" : "pull requests" },
             { value: "81", label: isFr ? "cas d'usage" : "use cases" },
-            { value: "1 140+", label: isFr ? "tests" : "tests" },
+            { value: "1 170+", label: isFr ? "tests" : "tests" },
           ].map(({ value, label }) => (
             <div key={label} className="text-center">
               <p className="text-2xl font-extrabold tracking-tight bg-gradient-to-r from-pink-500 to-violet-500 bg-clip-text text-transparent">

--- a/src/app/[locale]/(routes)/(static)/help/page.tsx
+++ b/src/app/[locale]/(routes)/(static)/help/page.tsx
@@ -348,7 +348,7 @@ export default async function HelpPage() {
                 {t.rich("participant.notifications.intro", rich)}
               </p>
               <ul className="space-y-2">
-                {(["item1", "item2", "item3", "item4"] as const).map((item) => (
+                {(["item1", "item2", "item3", "item4", "item5"] as const).map((item) => (
                   <li key={item} className="flex items-start gap-2 text-sm text-muted-foreground">
                     <span className="mt-1.5 size-1.5 shrink-0 rounded-full bg-primary" />
                     {t(`participant.notifications.${item}`)}


### PR DESCRIPTION
Mises à jour des pages statiques avant la release 2.14.0.

## Changements
- **Page À propos** — stats actualisées : PRs 420+ → 450+, tests 1 140+ → 1 170+ (commits et usecases inchangés)
- **Page Aide** — nouvel item documentant le lien « Gérer mes préférences » direct depuis les emails de notification de commentaire (fr.json + en.json synchronisés)
- **README** — arbre `src/` complété (hooks, lib, i18n, content, assets), description du blog élargie aux guides pratiques

🤖 Generated with [Claude Code](https://claude.com/claude-code)