### PR TITLE
fix: fiabiliser les notifications d'inscription via after()

### DIFF
--- a/src/app/actions/registration.ts
+++ b/src/app/actions/registration.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { after } from "next/server";
 import * as Sentry from "@sentry/nextjs";
 import { auth } from "@/infrastructure/auth/auth.config";
 import { isAdminUser, resolveCircleRepository } from "@/lib/admin-host-mode";
@@ -55,14 +56,21 @@ export async function joinMomentAction(
     );
 
     if (!isAdminUser(session)) {
-      // Pas de after() : Vercel serverless peut couper la lambda avant que l'after se déclenche.
+      // `buildEmailLocaleResolver` lit `getLocale()` (dépend de `headers()`) :
+      // doit s'exécuter dans le request context, avant `after()`.
       const resolver = await buildEmailLocaleResolver(userId);
-      const fireAndForget = result.pendingApproval
-        ? notifyHostsPendingApproval(momentId, userId, resolver)
-        : sendRegistrationEmails(momentId, userId, result.registration, resolver);
-      fireAndForget.catch((err) => {
-        console.error(err);
-        Sentry.captureException(err);
+      // `after()` garantit la complétion sur Vercel Fluid Compute après le retour
+      // de la Server Action. Une promesse fire-and-forget nue serait larguée au
+      // gel de l'instance (emails + Slack perdus par intermittence).
+      after(async () => {
+        try {
+          await (result.pendingApproval
+            ? notifyHostsPendingApproval(momentId, userId, resolver)
+            : sendRegistrationEmails(momentId, userId, result.registration, resolver));
+        } catch (err) {
+          console.error(err);
+          Sentry.captureException(err);
+        }
       });
     }
 
@@ -91,20 +99,31 @@ export async function cancelRegistrationAction(
       }
     );
 
+    // Resolver construit en request context (getLocale), avant les `after()`.
     const resolver = await buildEmailLocaleResolver(userId);
 
     if (result.promotedRegistration) {
-      sendPromotionEmail(result.promotedRegistration, resolver).catch((err) => {
-        console.error(err);
-        Sentry.captureException(err);
+      const promoted = result.promotedRegistration;
+      after(async () => {
+        try {
+          await sendPromotionEmail(promoted, resolver);
+        } catch (err) {
+          console.error(err);
+          Sentry.captureException(err);
+        }
       });
     }
 
     const cancelledReg = result.registration;
     if (cancelledReg.paymentStatus === "PAID" || cancelledReg.paymentStatus === "REFUNDED") {
-      sendHostPaidCancellationEmail(registrationId, userId, resolver).catch((err) =>
-        Sentry.captureException(err)
-      );
+      after(async () => {
+        try {
+          await sendHostPaidCancellationEmail(registrationId, userId, resolver);
+        } catch (err) {
+          console.error(err);
+          Sentry.captureException(err);
+        }
+      });
     }
 
     invalidateDashboardCache(userId);
@@ -114,7 +133,7 @@ export async function cancelRegistrationAction(
   });
 }
 
-// --- Fire-and-forget email helpers ---
+// --- Email helpers (dispatchés via after() par les actions) ---
 
 async function sendHostPaidCancellationEmail(
   registrationId: string,
@@ -388,18 +407,28 @@ export async function removeRegistrationByHostAction(
       }
     );
 
+    // Resolver construit en request context (getLocale), avant les `after()`.
     const resolver = await buildEmailLocaleResolver(hostUserId);
     const { momentId, userId } = result.cancelledRegistration;
 
-    sendRemovedByHostEmail(momentId, userId, resolver).catch((err) => {
-      console.error(err);
-      Sentry.captureException(err);
+    after(async () => {
+      try {
+        await sendRemovedByHostEmail(momentId, userId, resolver);
+      } catch (err) {
+        console.error(err);
+        Sentry.captureException(err);
+      }
     });
 
     if (result.promotedRegistration) {
-      sendPromotionEmail(result.promotedRegistration, resolver).catch((err) => {
-        console.error(err);
-        Sentry.captureException(err);
+      const promoted = result.promotedRegistration;
+      after(async () => {
+        try {
+          await sendPromotionEmail(promoted, resolver);
+        } catch (err) {
+          console.error(err);
+          Sentry.captureException(err);
+        }
       });
     }
 
@@ -470,10 +499,15 @@ export async function approveMomentRegistrationAction(
     );
 
     const reg = result.registration;
+    // Resolver construit en request context (getLocale), avant `after()`.
     const resolver = await buildEmailLocaleResolver(hostUserId);
-    sendRegistrationEmails(reg.momentId, reg.userId, reg, resolver).catch((err) => {
-      console.error(err);
-      Sentry.captureException(err);
+    after(async () => {
+      try {
+        await sendRegistrationEmails(reg.momentId, reg.userId, reg, resolver);
+      } catch (err) {
+        console.error(err);
+        Sentry.captureException(err);
+      }
     });
 
     invalidateDashboardCache(reg.userId);
@@ -501,10 +535,15 @@ export async function rejectMomentRegistrationAction(
       }
     );
 
+    // Resolver construit en request context (getLocale), avant `after()`.
     const resolver = await buildEmailLocaleResolver(hostUserId);
-    notifyPlayerRejection(result.userId, result.momentId, resolver).catch((err) => {
-      console.error("[rejection-notification] Error:", err);
-      Sentry.captureException(err);
+    after(async () => {
+      try {
+        await notifyPlayerRejection(result.userId, result.momentId, resolver);
+      } catch (err) {
+        console.error("[rejection-notification] Error:", err);
+        Sentry.captureException(err);
+      }
     });
 
     invalidateDashboardCache(result.userId);
@@ -512,7 +551,7 @@ export async function rejectMomentRegistrationAction(
   });
 }
 
-// ── Notification helpers (fire-and-forget, pas de after()) ────
+// ── Notification helpers (dispatchés via after() par les actions) ────
 
 async function notifyHostsPendingApproval(
   momentId: string,

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { NextResponse, after } from "next/server";
 import * as Sentry from "@sentry/nextjs";
 import {
   prismaCircleRepository,
@@ -36,20 +36,30 @@ export async function POST(request: Request) {
     );
 
     if (result.handled) {
+      const { registration } = result;
       // Webhook : pas de contexte i18n côté requête → resolver retombe sur la
       // locale par défaut FR pour tous les destinataires (comportement
       // historique préservé).
-      const resolver = await buildEmailLocaleResolver(result.registration.userId);
-      sendRegistrationEmails(
-        result.registration.momentId,
-        result.registration.userId,
-        result.registration,
-        resolver
-      ).catch((error) => Sentry.captureException(error));
+      const resolver = await buildEmailLocaleResolver(registration.userId);
+      // `after()` garantit la complétion sur Vercel Fluid Compute après le retour
+      // du route handler. Une promesse fire-and-forget nue serait larguée au gel
+      // de l'instance (emails + Slack perdus par intermittence).
+      after(async () => {
+        try {
+          await sendRegistrationEmails(
+            registration.momentId,
+            registration.userId,
+            registration,
+            resolver
+          );
+        } catch (error) {
+          Sentry.captureException(error);
+        }
+      });
 
       return NextResponse.json({
         received: true,
-        registrationId: result.registration.id,
+        registrationId: registration.id,
       });
     }
 


### PR DESCRIPTION
## Problème

Les notifications d'inscription à un événement (emails Participant/Host + notif Slack admin) **n'arrivaient que par intermittence** ("très souvent" la notif Slack manquait). Les emails de confirmation sautaient aussi parfois.

## Cause racine

Les dispatches de notifications étaient lancés en **promesse fire-and-forget nue** (`someEmailFn(...).catch(...)`, sans `after()`). Sur Vercel, une fois la Server Action (ou le route handler) retournée, l'instance est gelée et la promesse pendante est **larguée silencieusement** — sans lever d'erreur (rien dans Sentry). La notif Slack, en bout de chaîne, était la première sacrifiée.

C'est la **même classe de bug** déjà corrigée en prod pour les commentaires (`comment.ts`, incident 2026-05-31). `registration.ts` et le webhook Stripe n'avaient juste jamais été migrés.

## Correctif

Bascule de tous les dispatches de notif d'inscription vers `after()`, qui maintient l'instance Vercel vivante jusqu'à la complétion. Couvre **les deux chemins** :

- **`registration.ts`** (5 actions) — chemin des inscriptions gratuites : `joinMoment`, `cancel`, `removeByHost`, `approve`, `reject`.
- **`webhook/route.ts`** — chemin des inscriptions **payantes** (sinon le fix serait incomplet pour les events payants).

`buildEmailLocaleResolver` reste construit en request context (il lit `getLocale()`), seul l'envoi est différé. Pattern identique au précédent prouvé `comment.ts` / `profile.ts`.

## Vérification

- ✅ `pnpm typecheck` passe
- ✅ `/code-review` passé sur `registration.ts` (1 finding : le webhook, corrigé dans cette PR)
- ✅ `/verify` : fidèle à l'intention, complet (gratuit + payant)
- ⚠️ Validation E2E réelle (emails + Slack bloqués hors prod) → à confirmer en preview/prod après merge

## Hors scope (suivi possible)

Le même anti-pattern fire-and-forget existe pour d'**autres** notifs (non signalées) : `moment.ts` (notifs événement), `broadcast-moment.ts`, `circle.ts:273`. À fiabiliser dans une branche dédiée si souhaité.

🤖 Generated with [Claude Code](https://claude.com/claude-code)