### PR TITLE
chore(slack): router les alertes Sentry vers le canal #sentry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -141,6 +141,9 @@ E2E_SECRET=""
 ADMIN_NOTIFICATIONS_EMAIL=""
 DAILY_REPORT_RECIPIENT=""
 SLACK_ADMIN_WEBHOOK_URL=""
+# Webhook Slack dédié au canal #sentry (alertes d'erreurs Sentry).
+# Si vide, les alertes Sentry retombent sur SLACK_ADMIN_WEBHOOK_URL (#admin).
+SLACK_SENTRY_WEBHOOK_URL=""
 
 
 # ── [INTERNE] Ne PAS renseigner sauf si tu es maintainer ─────────────────────

--- a/src/infrastructure/services/slack/slack-notification-service.ts
+++ b/src/infrastructure/services/slack/slack-notification-service.ts
@@ -1,6 +1,9 @@
 import { URGENCY_META, USER_IMPACT_META, type AnalysisResult } from "../sentry/analysis-meta";
 
-const WEBHOOK_URL = process.env.SLACK_ADMIN_WEBHOOK_URL;
+const ADMIN_WEBHOOK_URL = process.env.SLACK_ADMIN_WEBHOOK_URL;
+// Canal dédié aux erreurs Sentry (#sentry). Si non configuré, les notifs Sentry
+// retombent sur le webhook admin (#admin) — fallback pour ne rien perdre.
+const SENTRY_WEBHOOK_URL = process.env.SLACK_SENTRY_WEBHOOK_URL;
 
 export function isAdminEmailEnabled(): boolean {
   return process.env.ADMIN_NOTIFICATIONS_EMAIL !== "false";
@@ -14,8 +17,11 @@ type SlackBlock =
   | { type: "context"; elements: { type: "mrkdwn"; text: string }[] }
   | { type: "actions"; elements: { type: "button"; text: { type: "plain_text"; text: string }; url: string; style?: "primary" | "danger" }[] };
 
-async function sendSlack(payload: { text: string; blocks?: SlackBlock[] }): Promise<void> {
-  if (!WEBHOOK_URL) return;
+async function sendSlack(
+  payload: { text: string; blocks?: SlackBlock[] },
+  webhookUrl: string | undefined = ADMIN_WEBHOOK_URL,
+): Promise<void> {
+  if (!webhookUrl) return;
 
   // Guard symétrique avec safe-resend : seul VERCEL_ENV=production laisse
   // passer. Tout le reste (preview, staging, local, CI) bloque — fail-closed.
@@ -25,7 +31,7 @@ async function sendSlack(payload: { text: string; blocks?: SlackBlock[] }): Prom
   }
 
   try {
-    await fetch(WEBHOOK_URL, {
+    await fetch(webhookUrl, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(payload),
@@ -194,18 +200,24 @@ export async function notifySlackSentryIssue(params: {
   const { issue, analysis, sentryUrl } = params;
   const urgencyLabel = URGENCY_META[analysis.urgency].label;
   const impactMeta = USER_IMPACT_META[analysis.userImpact.level];
-  await sendSlack({
-    text: `🚨 [Sentry ${urgencyLabel}] ${issue.issueShortId} — ${issue.issueTitle}`,
-    blocks: [
-      { type: "header", text: { type: "plain_text", text: `🚨 Sentry — Urgence ${urgencyLabel}`, emoji: true } },
-      { type: "section", text: { type: "mrkdwn", text: `*${issue.issueShortId}*\n${issue.issueTitle}` } },
-      { type: "divider" },
-      { type: "section", text: { type: "mrkdwn", text: `*Déclencheur*\n${analysis.trigger}` } },
-      { type: "section", text: { type: "mrkdwn", text: `*Conséquence fonctionnelle*\n${analysis.functionalConsequence}` } },
-      { type: "section", text: { type: "mrkdwn", text: `${impactMeta.emoji} *${impactMeta.label}*\n${analysis.userImpact.description}` } },
-      { type: "divider" },
-      { type: "context", elements: [{ type: "mrkdwn", text: `_Détails techniques_\n\`\`\`${analysis.technical}\`\`\`` }] },
-      { type: "actions", elements: [{ type: "button", text: { type: "plain_text", text: "Voir dans Sentry" }, url: sentryUrl, style: "danger" }] },
-    ],
-  });
+  // Les erreurs Sentry vont dans #sentry. Fallback sur #admin si le webhook
+  // dédié n'est pas configuré (|| et non ?? : une variable d'env vide "" doit
+  // aussi retomber sur le webhook admin).
+  await sendSlack(
+    {
+      text: `🚨 [Sentry ${urgencyLabel}] ${issue.issueShortId} — ${issue.issueTitle}`,
+      blocks: [
+        { type: "header", text: { type: "plain_text", text: `🚨 Sentry — Urgence ${urgencyLabel}`, emoji: true } },
+        { type: "section", text: { type: "mrkdwn", text: `*${issue.issueShortId}*\n${issue.issueTitle}` } },
+        { type: "divider" },
+        { type: "section", text: { type: "mrkdwn", text: `*Déclencheur*\n${analysis.trigger}` } },
+        { type: "section", text: { type: "mrkdwn", text: `*Conséquence fonctionnelle*\n${analysis.functionalConsequence}` } },
+        { type: "section", text: { type: "mrkdwn", text: `${impactMeta.emoji} *${impactMeta.label}*\n${analysis.userImpact.description}` } },
+        { type: "divider" },
+        { type: "context", elements: [{ type: "mrkdwn", text: `_Détails techniques_\n\`\`\`${analysis.technical}\`\`\`` }] },
+        { type: "actions", elements: [{ type: "button", text: { type: "plain_text", text: "Voir dans Sentry" }, url: sentryUrl, style: "danger" }] },
+      ],
+    },
+    SENTRY_WEBHOOK_URL || ADMIN_WEBHOOK_URL,
+  );
 }


### PR DESCRIPTION
## Objectif

Les notifications d'**erreurs Sentry** (`notifySlackSentryIssue`) partaient dans `#admin`, mêlées à toutes les autres notifs (nouveaux users, inscriptions, etc.). Elles vont désormais dans un canal dédié **`#sentry`**.

## Changement

- `sendSlack(payload)` accepte un 2ᵉ paramètre webhook optionnel (défaut = webhook admin). Toutes les notifs existantes restent sur `#admin` sans changement.
- `notifySlackSentryIssue` route vers `SLACK_SENTRY_WEBHOOK_URL` (canal `#sentry`).
- **Fallback** : si `SLACK_SENTRY_WEBHOOK_URL` est absent **ou vide**, les alertes Sentry retombent sur `#admin` (rien n'est perdu pendant la transition).
- `.env.example` documente la nouvelle variable.

## ⚙️ Config requise (prod)

Pour activer le routage vers `#sentry`, ajouter sur Vercel (scope Production) :
`SLACK_SENTRY_WEBHOOK_URL` = webhook entrant Slack pointant sur `#sentry` (créé sur l'app « The Playground Admin »). Tant que ce n'est pas fait, le fallback maintient les alertes dans `#admin`.

## Vérification

- ✅ `pnpm typecheck`
- ✅ `/code-review` passé — a détecté et corrigé un bug : le fallback utilisait `??` (qui ne retombe pas sur chaîne vide `""`), corrigé en `||` pour que `SLACK_SENTRY_WEBHOOK_URL=""` retombe bien sur `#admin`.
- ✅ Périmètre vérifié : `notifySlackSentryIssue` est la seule notif Sentry→Slack ; toutes les autres restent sur `#admin`.
- Pas de changement de schema Prisma.

🤖 Generated with [Claude Code](https://claude.com/claude-code)