### PR TITLE
fix(slack): notifie l'admin sur l'adhésion directe à une Communauté

### DIFF
--- a/src/app/actions/circle.ts
+++ b/src/app/actions/circle.ts
@@ -557,16 +557,12 @@ async function notifyHostCircleJoin(
   // sendSlack avale ses propres erreurs, l'envoi ne peut pas faire échouer les
   // notifications Host qui suivent.
   const baseUrl = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
-  const memberCount = await prismaCircleRepository.countMembers(circleId);
-  await notifySlackNewMember({
-    playerName,
-    circleName: circle.name,
-    memberInfo: `${memberCount} membre${memberCount > 1 ? "s" : ""}`,
-    circleUrl: `${baseUrl}/dashboard/circles/${circle.slug}`,
-    pendingApproval,
-  });
+  const circleUrl = `${baseUrl}/dashboard/circles/${circle.slug}`;
 
   if (pendingApproval) {
+    // Pas de compte de membres ici : le demandeur n'est pas encore membre.
+    await notifySlackNewMember({ playerName, circleName: circle.name, circleUrl, pendingApproval: true });
+
     // Demande d'adhésion en attente → notifier les HOSTs
     const hosts = await prismaCircleRepository.findOrganizers(circleId);
     const hostUserIds = hosts.map((h) => h.userId);
@@ -595,7 +591,17 @@ async function notifyHostCircleJoin(
       })
     );
   } else {
-    // Membre accepté directement → notification classique
+    // Membre accepté directement → notification classique.
+    // memberCount calculé une seule fois et partagé entre Slack et emails Host.
+    const memberCount = await prismaCircleRepository.countMembers(circleId);
+    await notifySlackNewMember({
+      playerName,
+      circleName: circle.name,
+      memberInfo: `${memberCount} membre${memberCount > 1 ? "s" : ""}`,
+      circleUrl,
+      pendingApproval: false,
+    });
+
     // Les Hosts ne sont pas le déclencheur ici → tous reçoivent en locale par défaut.
     const t = await resolver.defaultTranslations();
     await notifyHostNewCircleMember(
@@ -604,6 +610,7 @@ async function notifyHostCircleJoin(
       circle.name,
       userId,
       playerName,
+      memberCount,
       (count) => t("hostCircleMemberNotification.memberCountInfo", { count }),
       {
         subject: t("hostCircleMemberNotification.subject", { playerName, circleName: circle.name }),

--- a/src/app/actions/circle.ts
+++ b/src/app/actions/circle.ts
@@ -35,6 +35,7 @@ import { toActionResult } from "./helpers/to-action-result";
 import { processCoverImage } from "./cover-image";
 import { notifyAdminEntityCreated } from "./notify-admin-entity-created";
 import { notifyHostNewCircleMember } from "./notify-host-new-circle-member";
+import { notifySlackNewMember } from "@/infrastructure/services/slack/slack-notification-service";
 import {
   resolveCustomCategoryForCreate,
   resolveCustomCategoryForUpdate,
@@ -269,10 +270,19 @@ export async function joinCircleDirectlyAction(
     );
 
     if (!alreadyMember) {
+      // Resolver construit en request context (getLocale), avant after().
       const resolver = await buildEmailLocaleResolver(userId);
-      notifyHostCircleJoin(circleId, userId, pendingApproval, resolver).catch((err) => {
-        console.error("[joinCircleDirectlyAction] Erreur notification host :", err);
-        Sentry.captureException(err);
+      // after() garantit la complétion sur Vercel Fluid Compute après le retour de
+      // la Server Action (email Host + notif Slack admin). Une promesse fire-and-forget
+      // nue serait larguée au gel de l'instance (même incident qu'en 2026-06-04 sur
+      // registration.ts, ce chemin avait été oublié).
+      after(async () => {
+        try {
+          await notifyHostCircleJoin(circleId, userId, pendingApproval, resolver);
+        } catch (err) {
+          console.error("[joinCircleDirectlyAction] Erreur notification host :", err);
+          Sentry.captureException(err);
+        }
       });
       invalidateDashboardCache(userId);
     }
@@ -541,6 +551,20 @@ async function notifyHostCircleJoin(
 
   const playerName =
     [user.firstName, user.lastName].filter(Boolean).join(" ") || user.email;
+
+  // Notif Slack admin — câblée pour l'adhésion DIRECTE à une Communauté (le
+  // parcours par événement passe par notifySlackNewRegistration). Best-effort :
+  // sendSlack avale ses propres erreurs, l'envoi ne peut pas faire échouer les
+  // notifications Host qui suivent.
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
+  const memberCount = await prismaCircleRepository.countMembers(circleId);
+  await notifySlackNewMember({
+    playerName,
+    circleName: circle.name,
+    memberInfo: `${memberCount} membre${memberCount > 1 ? "s" : ""}`,
+    circleUrl: `${baseUrl}/dashboard/circles/${circle.slug}`,
+    pendingApproval,
+  });
 
   if (pendingApproval) {
     // Demande d'adhésion en attente → notifier les HOSTs

--- a/src/app/actions/notify-host-new-circle-member.ts
+++ b/src/app/actions/notify-host-new-circle-member.ts
@@ -11,6 +11,7 @@ export async function notifyHostNewCircleMember(
   circleName: string,
   newMemberUserId: string,
   newMemberName: string,
+  memberCount: number,
   formatMemberCount: (count: number) => string,
   strings: {
     subject: string;
@@ -20,10 +21,7 @@ export async function notifyHostNewCircleMember(
     footer: string;
   }
 ): Promise<void> {
-  const [hosts, memberCount] = await Promise.all([
-    prismaCircleRepository.findOrganizers(circleId),
-    prismaCircleRepository.countMembers(circleId),
-  ]);
+  const hosts = await prismaCircleRepository.findOrganizers(circleId);
 
   const filteredHosts = hosts.filter((host) => host.userId !== newMemberUserId);
   const hostUserIds = filteredHosts.map((h) => h.userId);

--- a/src/infrastructure/services/slack/slack-notification-service.ts
+++ b/src/infrastructure/services/slack/slack-notification-service.ts
@@ -161,6 +161,32 @@ export async function notifySlackNewRegistration(params: {
   });
 }
 
+export async function notifySlackNewMember(params: {
+  playerName: string;
+  circleName: string;
+  memberInfo: string;
+  circleUrl: string;
+  pendingApproval: boolean;
+}): Promise<void> {
+  const { pendingApproval } = params;
+  const icon = pendingApproval ? "⏳" : "🟢";
+  const label = pendingApproval ? "Demande d'adhésion" : "Nouveau membre";
+  const verb = pendingApproval ? "demande à rejoindre" : "a rejoint";
+
+  await sendSlack({
+    text: `${icon} ${label} — ${params.playerName} → ${params.circleName}`,
+    blocks: [
+      { type: "header", text: { type: "plain_text", text: `${icon} ${label}`, emoji: true } },
+      { type: "section", text: { type: "mrkdwn", text: `*${params.playerName}* ${verb} *${params.circleName}*` } },
+      { type: "section", fields: [
+        { type: "mrkdwn", text: `*Communauté*\n${params.circleName}` },
+        { type: "mrkdwn", text: `*Membres*\n${params.memberInfo}` },
+      ]},
+      { type: "actions", elements: [{ type: "button", text: { type: "plain_text", text: "Voir la Communauté" }, url: params.circleUrl }] },
+    ],
+  });
+}
+
 export async function notifySlackNewComment(params: {
   playerName: string;
   momentTitle: string;

--- a/src/infrastructure/services/slack/slack-notification-service.ts
+++ b/src/infrastructure/services/slack/slack-notification-service.ts
@@ -164,7 +164,9 @@ export async function notifySlackNewRegistration(params: {
 export async function notifySlackNewMember(params: {
   playerName: string;
   circleName: string;
-  memberInfo: string;
+  // Omis pour une demande en attente : le demandeur n'est pas encore membre,
+  // afficher le compte (ACTIVE only) serait trompeur.
+  memberInfo?: string;
   circleUrl: string;
   pendingApproval: boolean;
 }): Promise<void> {
@@ -173,17 +175,21 @@ export async function notifySlackNewMember(params: {
   const label = pendingApproval ? "Demande d'adhésion" : "Nouveau membre";
   const verb = pendingApproval ? "demande à rejoindre" : "a rejoint";
 
+  const blocks: SlackBlock[] = [
+    { type: "header", text: { type: "plain_text", text: `${icon} ${label}`, emoji: true } },
+    { type: "section", text: { type: "mrkdwn", text: `*${params.playerName}* ${verb} *${params.circleName}*` } },
+  ];
+  if (params.memberInfo) {
+    blocks.push({ type: "section", fields: [{ type: "mrkdwn", text: `*Membres*\n${params.memberInfo}` }] });
+  }
+  blocks.push({
+    type: "actions",
+    elements: [{ type: "button", text: { type: "plain_text", text: "Voir la Communauté" }, url: params.circleUrl }],
+  });
+
   await sendSlack({
     text: `${icon} ${label} — ${params.playerName} → ${params.circleName}`,
-    blocks: [
-      { type: "header", text: { type: "plain_text", text: `${icon} ${label}`, emoji: true } },
-      { type: "section", text: { type: "mrkdwn", text: `*${params.playerName}* ${verb} *${params.circleName}*` } },
-      { type: "section", fields: [
-        { type: "mrkdwn", text: `*Communauté*\n${params.circleName}` },
-        { type: "mrkdwn", text: `*Membres*\n${params.memberInfo}` },
-      ]},
-      { type: "actions", elements: [{ type: "button", text: { type: "plain_text", text: "Voir la Communauté" }, url: params.circleUrl }] },
-    ],
+    blocks,
   });
 }
 


### PR DESCRIPTION
## Contexte

Deux users ont rejoint la Communauté **Cloud Pi Native** le 2026-06-05 en **direct** (sans passer par un événement) et aucune notif Slack admin n'est arrivée. Le fix du 2026-06-04 (`after()` sur `registration.ts`) ne couvrait que l'inscription à un **événement** ; l'adhésion directe passe par `joinCircleDirectlyAction` (`circle.ts`), un chemin oublié.

Diagnostic : pour ce parcours, **aucune notif Slack admin n'existait dans le code**, et l'email Host était dispatché en fire-and-forget nu (`.catch()` sans `after()`), donc largué par intermittence au gel de l'instance Vercel Fluid Compute.

## Changements

- **`notifySlackNewMember`** : nouvelle notif admin (`🟢 Nouveau membre` / `⏳ Demande d'adhésion`), sur le modèle de `notifySlackNewRegistration`.
- **Câblage** dans `notifyHostCircleJoin` (couvre adhésion acceptée et en attente d'approbation).
- **`joinCircleDirectlyAction`** : dispatch basculé en `after()`, fiabilisant à la fois la nouvelle notif Slack **et** l'email Host existant.

Pas de double notif : le parcours par événement gère l'adhésion en interne (usecase `joinMoment`) et déclenche `🎟️ Nouvelle inscription`, sans passer par `joinCircleDirectlyAction`.

## Suite à /code-review (high effort)

- Champ « Membres » masqué sur une demande en attente (`countMembers` ne compte que les `ACTIVE`, le demandeur `PENDING` n'y figure pas → compteur trompeur).
- Champ « Communauté » redondant supprimé (le nom est déjà dans la phrase).
- Double `countMembers` éliminé sur le chemin accepté (calculé une fois, partagé avec `notifyHostNewCircleMember`).

## Vérification

Le guard `sendSlack` bloque hors `VERCEL_ENV=production`, donc impossible à tester en preview/staging. La vérif réelle se fera après merge en provoquant une adhésion directe à une Communauté de test en prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)