### PR TITLE
fix(comments): empêcher le débordement mobile d'une image attachée

### DIFF
--- a/src/components/moments/comment-thread.tsx
+++ b/src/components/moments/comment-thread.tsx
@@ -152,7 +152,7 @@ function CommentPhotos({
             onClick={() => handleClick(att.url, alt)}
             className={
               isSingle
-                ? "block max-w-xs cursor-pointer overflow-hidden rounded-lg ring-2 ring-transparent transition-all hover:opacity-90 hover:ring-primary/30"
+                ? "block w-full max-w-xs cursor-pointer overflow-hidden rounded-lg ring-2 ring-transparent transition-all hover:opacity-90 hover:ring-primary/30"
                 : "size-24 cursor-pointer overflow-hidden rounded-lg ring-2 ring-transparent transition-all hover:opacity-90 hover:ring-primary/30 sm:size-32"
             }
           >
@@ -161,7 +161,7 @@ function CommentPhotos({
               alt={alt}
               className={
                 isSingle
-                  ? "max-h-60 max-w-xs rounded-lg object-cover"
+                  ? "max-h-60 w-full rounded-lg object-cover"
                   : "size-full object-cover"
               }
             />


### PR DESCRIPTION
## Problème

Sur la vue mobile d'un commentaire, une image unique attachée et large (cf. carte Auchan Balma signalée) débordait hors de la zone du commentaire et hors de l'écran.

## Cause

Dans `CommentPhotos` (`comment-thread.tsx`), le cas image unique utilisait `max-w-xs` (320px **fixe**) sur le `<button>` et sur l'`<img>`, **sans `w-full`**. Sur un écran étroit, la zone disponible (carte `p-6` + indentation `border-l-2 pl-3`) est inférieure à 320px : le bloc ne se contractait pas et débordait.

## Fix

- bouton : `block max-w-xs` → `block w-full max-w-xs`
- image : `max-h-60 max-w-xs object-cover` → `max-h-60 w-full object-cover`

`w-full` borne la largeur au conteneur (contraction sur mobile), `max-w-xs` reste le plafond desktop. **Affichage desktop inchangé** (toujours 320px max). Le cas multi-images (`size-24 sm:size-32` en `flex-wrap`) n'est pas concerné.

🤖 Generated with [Claude Code](https://claude.com/claude-code)