### PR TITLE
fix(circles): garde organisateur sur l'édition de Communauté et la création d'événement

### DIFF
--- a/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/edit/page.tsx
+++ b/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/edit/page.tsx
@@ -1,6 +1,5 @@
 import { notFound } from "next/navigation";
 import { getTranslations } from "next-intl/server";
-import { auth } from "@/infrastructure/auth/auth.config";
 import { prismaCircleRepository } from "@/infrastructure/repositories";
 import { createStripePaymentService } from "@/infrastructure/services";
 import { getCircleBySlug } from "@/domain/usecases/get-circle";
@@ -8,8 +7,10 @@ import { getStripeConnectStatus } from "@/domain/usecases/onboard-stripe-connect
 import { CircleNotFoundError } from "@/domain/errors";
 import { CircleForm } from "@/components/circles/circle-form";
 import { updateCircleAction } from "@/app/actions/circle";
+import { getCachedSession } from "@/lib/auth-cache";
 import { resolveCircleRepository } from "@/lib/admin-host-mode";
-import { isActivePrimaryHost } from "@/domain/models/circle";
+import { isActiveOrganizer, isActivePrimaryHost } from "@/domain/models/circle";
+import { redirectToPublicCircle } from "@/lib/dashboard-circle-public-redirect";
 import { Link } from "@/i18n/navigation";
 import { ChevronRight } from "lucide-react";
 
@@ -32,14 +33,20 @@ export default async function EditCirclePage({
     throw error;
   }
 
+  // Garde d'autorisation : seul un organisateur actif de la Communauté peut
+  // éditer. Un non-membre (ou un membre Participant) est renvoyé vers la page
+  // publique, comme sur les pages de gestion sœurs.
+  const session = await getCachedSession();
+  if (!session?.user?.id) redirectToPublicCircle(slug);
+
+  const circleRepo = await resolveCircleRepository(session, prismaCircleRepository);
+  const membership = await circleRepo.findMembership(circle.id, session.user.id);
+
+  if (!isActiveOrganizer(membership)) redirectToPublicCircle(slug);
+
   const boundAction = updateCircleAction.bind(null, circle.id);
 
   // Load Stripe Connect status for the HOST (supports admin host mode)
-  const session = await auth();
-  const circleRepo = await resolveCircleRepository(session, prismaCircleRepository);
-  const membership = session?.user?.id
-    ? await circleRepo.findMembership(circle.id, session.user.id)
-    : null;
   const canManageStripe = isActivePrimaryHost(membership);
 
   let stripeConnect;
@@ -49,7 +56,7 @@ export default async function EditCirclePage({
     let status = null as import("@/domain/ports/services/payment-service").ConnectAccountStatus | null;
 
     // If circle already has a Stripe account, fetch its status
-    if (circle.stripeConnectAccountId && session?.user?.id) {
+    if (circle.stripeConnectAccountId) {
       try {
         const stripeStatus = await getStripeConnectStatus(
           { circleId: circle.id, userId: session.user.id },

--- a/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/moments/new/page.tsx
+++ b/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/moments/new/page.tsx
@@ -5,6 +5,10 @@ import { getCircleBySlug } from "@/domain/usecases/get-circle";
 import { CircleNotFoundError } from "@/domain/errors";
 import { MomentForm } from "@/components/moments/moment-form";
 import { createMomentAction } from "@/app/actions/moment";
+import { getCachedSession } from "@/lib/auth-cache";
+import { resolveCircleRepository } from "@/lib/admin-host-mode";
+import { isActiveOrganizer } from "@/domain/models/circle";
+import { redirectToPublicCircle } from "@/lib/dashboard-circle-public-redirect";
 import { Link } from "@/i18n/navigation";
 import { ChevronRight } from "lucide-react";
 
@@ -26,6 +30,17 @@ export default async function NewMomentPage({
     }
     throw error;
   }
+
+  // Garde d'autorisation : seul un organisateur actif de la Communauté peut
+  // créer un événement. Un non-membre (ou un membre Participant) est renvoyé
+  // vers la page publique, comme sur les pages de gestion sœurs.
+  const session = await getCachedSession();
+  if (!session?.user?.id) redirectToPublicCircle(slug);
+
+  const circleRepo = await resolveCircleRepository(session, prismaCircleRepository);
+  const membership = await circleRepo.findMembership(circle.id, session.user.id);
+
+  if (!isActiveOrganizer(membership)) redirectToPublicCircle(slug);
 
   const boundAction = createMomentAction.bind(null, circle.id);
 

--- a/tests/e2e/circle-edit-authz.spec.ts
+++ b/tests/e2e/circle-edit-authz.spec.ts
@@ -16,8 +16,16 @@ import { SLUGS, AUTH } from "./fixtures";
  * par ses propres tests d'autorisation. Ici on verrouille la garde de page.
  */
 
-// Page publique de la Communauté seed (sans préfixe /dashboard/).
+// Page publique de la Communauté seed. Le `$` ancre la fin (tolère le préfixe
+// de locale présent ou non, "as-needed"). On vérifie EN PLUS l'absence de
+// `/dashboard/` pour exclure un faux positif si la redirection pointait par
+// erreur vers la page de gestion `/dashboard/circles/[slug]`.
 const PUBLIC_CIRCLE_URL = new RegExp(`/circles/${SLUGS.CIRCLE}/?$`);
+
+async function expectRedirectedToPublicCircle(page: import("@playwright/test").Page) {
+  await expect(page).toHaveURL(PUBLIC_CIRCLE_URL);
+  await expect(page).not.toHaveURL(/\/dashboard\//);
+}
 
 test.describe("Garde organisateur — Participant (non-organisateur)", () => {
   test.use({ storageState: AUTH.PLAYER });
@@ -25,13 +33,13 @@ test.describe("Garde organisateur — Participant (non-organisateur)", () => {
   test("redirige l'édition de Communauté vers la page publique", async ({ page }) => {
     await page.goto(`/fr/dashboard/circles/${SLUGS.CIRCLE}/edit`);
 
-    await expect(page).toHaveURL(PUBLIC_CIRCLE_URL);
+    await expectRedirectedToPublicCircle(page);
   });
 
   test("redirige la création d'événement vers la page publique", async ({ page }) => {
     await page.goto(`/fr/dashboard/circles/${SLUGS.CIRCLE}/moments/new`);
 
-    await expect(page).toHaveURL(PUBLIC_CIRCLE_URL);
+    await expectRedirectedToPublicCircle(page);
   });
 });
 

--- a/tests/e2e/circle-edit-authz.spec.ts
+++ b/tests/e2e/circle-edit-authz.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from "@playwright/test";
+import { SLUGS, AUTH } from "./fixtures";
+
+/**
+ * Tests E2E — Garde d'autorisation des pages de gestion d'une Communauté
+ *
+ * Régression : les pages `dashboard/circles/[slug]/edit` et
+ * `dashboard/circles/[slug]/moments/new` rendaient leur formulaire à TOUT
+ * utilisateur connecté qui devinait l'URL, sans vérifier qu'il est organisateur
+ * actif de la Communauté. Le layout parent ne contrôle que l'authentification.
+ *
+ * Le contrôle attendu (aligné sur les pages de gestion sœurs) : un non-membre
+ * ou un simple Participant est renvoyé vers la page publique `/circles/[slug]`.
+ *
+ * La couche écriture (usecases updateCircle / createMoment) est déjà couverte
+ * par ses propres tests d'autorisation. Ici on verrouille la garde de page.
+ */
+
+// Page publique de la Communauté seed (sans préfixe /dashboard/).
+const PUBLIC_CIRCLE_URL = new RegExp(`/circles/${SLUGS.CIRCLE}/?$`);
+
+test.describe("Garde organisateur — Participant (non-organisateur)", () => {
+  test.use({ storageState: AUTH.PLAYER });
+
+  test("redirige l'édition de Communauté vers la page publique", async ({ page }) => {
+    await page.goto(`/fr/dashboard/circles/${SLUGS.CIRCLE}/edit`);
+
+    await expect(page).toHaveURL(PUBLIC_CIRCLE_URL);
+  });
+
+  test("redirige la création d'événement vers la page publique", async ({ page }) => {
+    await page.goto(`/fr/dashboard/circles/${SLUGS.CIRCLE}/moments/new`);
+
+    await expect(page).toHaveURL(PUBLIC_CIRCLE_URL);
+  });
+});
+
+test.describe("Garde organisateur — Host (organisateur actif)", () => {
+  test.use({ storageState: AUTH.HOST });
+
+  test("autorise l'édition de Communauté pour l'organisateur", async ({ page }) => {
+    await page.goto(`/fr/dashboard/circles/${SLUGS.CIRCLE}/edit`);
+
+    // L'organisateur reste sur la page d'édition (aucune redirection).
+    await expect(page).toHaveURL(/\/dashboard\/circles\/.+\/edit$/);
+  });
+
+  test("autorise la création d'événement pour l'organisateur", async ({ page }) => {
+    await page.goto(`/fr/dashboard/circles/${SLUGS.CIRCLE}/moments/new`);
+
+    await expect(page).toHaveURL(/\/dashboard\/circles\/.+\/moments\/new$/);
+  });
+});


### PR DESCRIPTION
## Problème

Les pages dashboard `circles/[slug]/edit` et `circles/[slug]/moments/new` rendaient leur formulaire à **tout utilisateur connecté** qui devinait l'URL, sans vérifier qu'il est organisateur actif de la Communauté. Le layout parent ne contrôle que l'authentification.

L'écriture restait protégée (les usecases `updateCircle` / `createMoment` vérifient `isActiveOrganizer`), mais le **rendu exposait les métadonnées** de la Communauté, dont `stripeConnectAccountId` sérialisé dans les props du composant client `CircleForm` (et `stripeConnectActive` sur `MomentForm`). Gravité : divulgation d'information (IDOR en lecture), pas d'écriture.

## Correction

Ajout du contrôle d'autorisation manquant sur les 2 pages, **aligné sur les pages de gestion sœurs** (`circles/[slug]/page.tsx`, `moments/[momentSlug]/edit/page.tsx`) :

```ts
const session = await getCachedSession();
if (!session?.user?.id) redirectToPublicCircle(slug);
const circleRepo = await resolveCircleRepository(session, prismaCircleRepository);
const membership = await circleRepo.findMembership(circle.id, session.user.id);
if (!isActiveOrganizer(membership)) redirectToPublicCircle(slug);
```

Un non-membre ou un simple Participant est renvoyé vers la page publique `/circles/[slug]`. L'admin host mode reste autorisé (proxy `findMembership`), comme sur les pages sœurs.

## Périmètre vérifié

Audit transverse de toutes les `page.tsx` sous `dashboard/**` : ces 2 pages étaient les **seules** sans garde. Les autres pages de gestion appliquaient déjà le contrôle.

## Tests

Nouveau spec E2E `tests/e2e/circle-edit-authz.spec.ts` : un Participant est redirigé vers la page publique sur les 2 URLs, un Host y reste autorisé. La couche écriture a déjà ses tests d'autorisation unitaires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)