### PR TITLE
fix(auth): guider les utilisateurs WebView vers un vrai navigateur pour OAuth

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -144,8 +144,7 @@
       "linkedin": "Continue with LinkedIn",
       "invalidEmail": "Invalid email address. Please check your input.",
       "sendFailed": "Couldn't send the email right now. Please try again in a moment.",
-      "webviewNotice": "You're using an in-app browser (LinkedIn, Instagram...). Use the email sign-in below, it works everywhere. To sign in with Google or GitHub, open the site in your browser (Safari, Chrome...).",
-      "webviewTooltip": "Not available from an in-app browser. Use the email sign-in, or open the site in your browser."
+      "webviewNotice": "You're using an in-app browser (LinkedIn, Instagram...). Use the email sign-in below, it works everywhere. To sign in with Google or GitHub, open the site in your browser (Safari, Chrome...)."
     },
     "verifyRequest": {
       "title": "Check your email",

--- a/messages/en.json
+++ b/messages/en.json
@@ -144,8 +144,8 @@
       "linkedin": "Continue with LinkedIn",
       "invalidEmail": "Invalid email address. Please check your input.",
       "sendFailed": "Couldn't send the email right now. Please try again in a moment.",
-      "webviewNotice": "You're using an in-app browser (LinkedIn, Instagram...). Use the email sign-in below — it works everywhere.",
-      "webviewTooltip": "Not available from an in-app browser. Use the email sign-in."
+      "webviewNotice": "You're using an in-app browser (LinkedIn, Instagram...). Use the email sign-in below, it works everywhere. To sign in with Google or GitHub, open the site in your browser (Safari, Chrome...).",
+      "webviewTooltip": "Not available from an in-app browser. Use the email sign-in, or open the site in your browser."
     },
     "verifyRequest": {
       "title": "Check your email",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -144,8 +144,8 @@
       "linkedin": "Continuer avec LinkedIn",
       "invalidEmail": "Adresse email invalide. Vérifiez votre saisie.",
       "sendFailed": "Impossible d'envoyer l'email pour le moment. Réessayez dans un instant.",
-      "webviewNotice": "Vous utilisez un navigateur intégré (LinkedIn, Instagram...). Utilisez la connexion par email ci-dessous — elle fonctionne partout.",
-      "webviewTooltip": "Non disponible depuis un navigateur intégré. Utilisez la connexion par email."
+      "webviewNotice": "Vous utilisez un navigateur intégré (LinkedIn, Instagram...). Utilisez la connexion par email ci-dessous, elle fonctionne partout. Pour vous connecter avec Google ou GitHub, ouvrez le site dans votre navigateur (Safari, Chrome...).",
+      "webviewTooltip": "Non disponible depuis un navigateur intégré. Utilisez la connexion par email, ou ouvrez le site dans votre navigateur."
     },
     "verifyRequest": {
       "title": "Vérifiez votre email",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -144,8 +144,7 @@
       "linkedin": "Continuer avec LinkedIn",
       "invalidEmail": "Adresse email invalide. Vérifiez votre saisie.",
       "sendFailed": "Impossible d'envoyer l'email pour le moment. Réessayez dans un instant.",
-      "webviewNotice": "Vous utilisez un navigateur intégré (LinkedIn, Instagram...). Utilisez la connexion par email ci-dessous, elle fonctionne partout. Pour vous connecter avec Google ou GitHub, ouvrez le site dans votre navigateur (Safari, Chrome...).",
-      "webviewTooltip": "Non disponible depuis un navigateur intégré. Utilisez la connexion par email, ou ouvrez le site dans votre navigateur."
+      "webviewNotice": "Vous utilisez un navigateur intégré (LinkedIn, Instagram...). Utilisez la connexion par email ci-dessous, elle fonctionne partout. Pour vous connecter avec Google ou GitHub, ouvrez le site dans votre navigateur (Safari, Chrome...)."
     },
     "verifyRequest": {
       "title": "Vérifiez votre email",

--- a/src/components/auth/sign-in-form.tsx
+++ b/src/components/auth/sign-in-form.tsx
@@ -6,12 +6,6 @@ import { useFormStatus } from "react-dom";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 import { Github, Loader2, Mail } from "lucide-react";
 import {
   signInWithGitHub,
@@ -50,27 +44,12 @@ function SubmitButton({
   );
 }
 
-function DisabledOAuthButton({
-  label,
-  icon,
-  tooltip,
-}: {
-  label: string;
-  icon: ReactNode;
-  tooltip: string;
-}) {
+function DisabledOAuthButton({ label, icon }: { label: string; icon: ReactNode }) {
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <Button variant="outline" className="w-full opacity-50 cursor-not-allowed" type="button" disabled>
-          {icon}
-          {label}
-        </Button>
-      </TooltipTrigger>
-      <TooltipContent side="bottom" className="max-w-64 text-center">
-        <p>{tooltip}</p>
-      </TooltipContent>
-    </Tooltip>
+    <Button variant="outline" className="w-full opacity-50 cursor-not-allowed" type="button" disabled>
+      {icon}
+      {label}
+    </Button>
   );
 }
 
@@ -92,8 +71,7 @@ export function SignInForm({ callbackUrl, error }: SignInFormProps) {
   }, []);
 
   return (
-    <TooltipProvider>
-      <div className="space-y-4">
+    <div className="space-y-4">
         {error && (
           <div
             role="alert"
@@ -114,16 +92,8 @@ export function SignInForm({ callbackUrl, error }: SignInFormProps) {
 
         {webview ? (
           <>
-            <DisabledOAuthButton
-              label={t("signIn.google")}
-              icon={<GoogleIcon />}
-              tooltip={t("signIn.webviewTooltip")}
-            />
-            <DisabledOAuthButton
-              label={t("signIn.github")}
-              icon={<Github className="size-4" />}
-              tooltip={t("signIn.webviewTooltip")}
-            />
+            <DisabledOAuthButton label={t("signIn.google")} icon={<GoogleIcon />} />
+            <DisabledOAuthButton label={t("signIn.github")} icon={<Github className="size-4" />} />
           </>
         ) : (
           <>
@@ -163,7 +133,6 @@ export function SignInForm({ callbackUrl, error }: SignInFormProps) {
           )}
           <SubmitButton label={t("signIn.magicLink")} />
         </form>
-      </div>
-    </TooltipProvider>
+    </div>
   );
 }


### PR DESCRIPTION
## Contexte

Dans les navigateurs intégrés (LinkedIn, Instagram, WhatsApp...), Google bloque OAuth (`Error 403: disallowed_useragent`). La détection WebView et le fallback magic link existent déjà, mais le bandeau n'expliquait pas comment profiter quand même de Google/GitHub.

## Changements

- **Bandeau WebView enrichi** (FR/EN) : indique qu'ouvrir le site dans un vrai navigateur (Safari, Chrome...) permet de se connecter avec Google ou GitHub. Supprime aussi le tiret long du copy d'origine.
- **Suppression du tooltip mort** sur les boutons OAuth désactivés : le tooltip Radix ne s'affichait jamais (déclencheur sur un bouton `disabled`, audience quasi exclusivement tactile). `DisabledOAuthButton` est simplifié, la clé i18n `webviewTooltip` est supprimée.

## Vérifications

- /code-review passé (2 findings traités : tooltip mort supprimé, duplication de copy résolue par la suppression de la clé)
- `pnpm typecheck` vert, Prettier passé, aucune référence résiduelle à `webviewTooltip`
- Aucun test n'assertait les anciens textes

Closes #436

🤖 Generated with [Claude Code](https://claude.com/claude-code)