### PR TITLE
feat(observability): captures auth côté serveur avec user-agent

### DIFF
--- a/src/app/[locale]/auth/error/auth-error-view.tsx
+++ b/src/app/[locale]/auth/error/auth-error-view.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
+import { Button } from "@/components/ui/button";
+import { Link } from "@/i18n/navigation";
+import { ExternalLink } from "lucide-react";
+import { isInAppBrowser } from "@/lib/detect-webview";
+import { AUTH_ERROR_VERIFICATION } from "@/lib/auth/error-kinds";
+
+function AuthHint({ explanation, action }: { explanation: string; action: string }) {
+  return (
+    <div className="rounded-lg border border-primary/30 bg-primary/5 px-4 py-3 text-sm text-muted-foreground text-left space-y-2">
+      <p>{explanation}</p>
+      <p className="font-medium text-foreground">{action}</p>
+    </div>
+  );
+}
+
+export function AuthErrorView({ error }: { error: string | null }) {
+  const t = useTranslations("Auth");
+  const [webview, setWebview] = useState(false);
+
+  useEffect(() => {
+    setWebview(isInAppBrowser());
+  }, []);
+
+  const errorMessage = error
+    ? t(`errors.${error}`, { defaultValue: t("errors.Default") })
+    : t("errors.Default");
+
+  const isVerification = error === AUTH_ERROR_VERIFICATION;
+  const ctaLabel = isVerification ? t("error.requestNewLink") : t("error.backToSignIn");
+
+  return (
+    <div className="flex min-h-screen items-center justify-center px-4">
+      <div className="w-full max-w-sm space-y-4 text-center">
+        <h1 className="text-2xl font-bold tracking-tight">{t("error.title")}</h1>
+        <p className="text-muted-foreground text-sm">{errorMessage}</p>
+
+        {isVerification && (
+          <AuthHint
+            explanation={t("error.verificationExplanation")}
+            action={t("error.verificationAction")}
+          />
+        )}
+
+        {webview && (
+          <AuthHint
+            explanation={t("error.webviewExplanation")}
+            action={t("error.webviewAction")}
+          />
+        )}
+
+        <div className="flex flex-col gap-2">
+          <Button asChild>
+            <Link href="/auth/sign-in">{ctaLabel}</Link>
+          </Button>
+          {webview && (
+            <Button variant="outline" asChild>
+              <a
+                href={typeof window !== "undefined" ? window.location.origin : "https://the-playground.fr"}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <ExternalLink className="size-4" />
+                {t("error.openInBrowser")}
+              </a>
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/[locale]/auth/error/page.tsx
+++ b/src/app/[locale]/auth/error/page.tsx
@@ -1,94 +1,35 @@
-"use client";
-
-import { useEffect, useRef, useState } from "react";
-import { useSearchParams } from "next/navigation";
-import { useTranslations } from "next-intl";
 import * as Sentry from "@sentry/nextjs";
-import { Button } from "@/components/ui/button";
-import { Link } from "@/i18n/navigation";
-import { ExternalLink } from "lucide-react";
-import { isInAppBrowser } from "@/lib/detect-webview";
-import { classifyAuthError, AUTH_ERROR_VERIFICATION } from "@/lib/auth/error-kinds";
+import { headers } from "next/headers";
+import { classifyAuthError } from "@/lib/auth/error-kinds";
+import { AuthErrorView } from "./auth-error-view";
 
-function AuthHint({ explanation, action }: { explanation: string; action: string }) {
-  return (
-    <div className="rounded-lg border border-primary/30 bg-primary/5 px-4 py-3 text-sm text-muted-foreground text-left space-y-2">
-      <p>{explanation}</p>
-      <p className="font-medium text-foreground">{action}</p>
-    </div>
-  );
-}
+type Props = {
+  searchParams: Promise<{ error?: string }>;
+};
 
-export default function AuthErrorPage() {
-  const searchParams = useSearchParams();
-  const error = searchParams.get("error");
-  const t = useTranslations("Auth");
-  const [webview, setWebview] = useState(false);
-  const capturedRef = useRef<string | null>(null);
+// Capture côté serveur : les réseaux d'entreprise/administration qui bloquent
+// sentry.io (incident @interieur.gouv.fr) ne remontent jamais une capture
+// client. Le rendu serveur, lui, voit chaque visite de la page avec son
+// user-agent — ce qui permet de distinguer humains et scanners email.
+export default async function AuthErrorPage({ searchParams }: Props) {
+  const { error } = await searchParams;
 
-  useEffect(() => {
-    setWebview(isInAppBrowser());
-  }, []);
+  if (error) {
+    const headersList = await headers();
+    Sentry.captureMessage(`auth-error-page: ${error}`, {
+      level: "warning",
+      tags: {
+        context: "auth",
+        error_code: error,
+        auth_error_kind: classifyAuthError(error),
+        surface: "server",
+      },
+      extra: {
+        user_agent: headersList.get("user-agent") ?? "unknown",
+        referer: headersList.get("referer") ?? "unknown",
+      },
+    });
+  }
 
-  useEffect(() => {
-    if (error && capturedRef.current !== error) {
-      capturedRef.current = error;
-      Sentry.captureMessage(`auth-error-page: ${error}`, {
-        level: "warning",
-        tags: {
-          context: "auth",
-          error_code: error,
-          auth_error_kind: classifyAuthError(error),
-        },
-      });
-    }
-  }, [error]);
-
-  const errorMessage = error
-    ? t(`errors.${error}`, { defaultValue: t("errors.Default") })
-    : t("errors.Default");
-
-  const isVerification = error === AUTH_ERROR_VERIFICATION;
-  const ctaLabel = isVerification ? t("error.requestNewLink") : t("error.backToSignIn");
-
-  return (
-    <div className="flex min-h-screen items-center justify-center px-4">
-      <div className="w-full max-w-sm space-y-4 text-center">
-        <h1 className="text-2xl font-bold tracking-tight">{t("error.title")}</h1>
-        <p className="text-muted-foreground text-sm">{errorMessage}</p>
-
-        {isVerification && (
-          <AuthHint
-            explanation={t("error.verificationExplanation")}
-            action={t("error.verificationAction")}
-          />
-        )}
-
-        {webview && (
-          <AuthHint
-            explanation={t("error.webviewExplanation")}
-            action={t("error.webviewAction")}
-          />
-        )}
-
-        <div className="flex flex-col gap-2">
-          <Button asChild>
-            <Link href="/auth/sign-in">{ctaLabel}</Link>
-          </Button>
-          {webview && (
-            <Button variant="outline" asChild>
-              <a
-                href={typeof window !== "undefined" ? window.location.origin : "https://the-playground.fr"}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                <ExternalLink className="size-4" />
-                {t("error.openInBrowser")}
-              </a>
-            </Button>
-          )}
-        </div>
-      </div>
-    </div>
-  );
+  return <AuthErrorView error={error ?? null} />;
 }

--- a/src/app/[locale]/auth/error/page.tsx
+++ b/src/app/[locale]/auth/error/page.tsx
@@ -1,10 +1,13 @@
 import * as Sentry from "@sentry/nextjs";
-import { headers } from "next/headers";
-import { classifyAuthError } from "@/lib/auth/error-kinds";
+import {
+  classifyAuthError,
+  normalizeAuthErrorCode,
+} from "@/lib/auth/error-kinds";
+import { getRequestObservability } from "@/lib/auth/request-observability";
 import { AuthErrorView } from "./auth-error-view";
 
 type Props = {
-  searchParams: Promise<{ error?: string }>;
+  searchParams: Promise<{ error?: string | string[] }>;
 };
 
 // Capture côté serveur : les réseaux d'entreprise/administration qui bloquent
@@ -12,21 +15,27 @@ type Props = {
 // client. Le rendu serveur, lui, voit chaque visite de la page avec son
 // user-agent — ce qui permet de distinguer humains et scanners email.
 export default async function AuthErrorPage({ searchParams }: Props) {
-  const { error } = await searchParams;
+  const params = await searchParams;
+  // Un param répété (?error=a&error=b) arrive en string[] — on ne garde que
+  // la première valeur, comme le faisait useSearchParams().get().
+  const error = Array.isArray(params.error) ? params.error[0] : params.error;
 
   if (error) {
-    const headersList = await headers();
-    Sentry.captureMessage(`auth-error-page: ${error}`, {
+    // Le code normalisé borne la cardinalité des tags/messages Sentry
+    // (?error= est contrôlable par l'utilisateur) ; la valeur brute reste
+    // disponible en extra.
+    const code = normalizeAuthErrorCode(error);
+    Sentry.captureMessage(`auth-error-page: ${code}`, {
       level: "warning",
       tags: {
         context: "auth",
-        error_code: error,
-        auth_error_kind: classifyAuthError(error),
+        error_code: code,
+        auth_error_kind: classifyAuthError(code),
         surface: "server",
       },
       extra: {
-        user_agent: headersList.get("user-agent") ?? "unknown",
-        referer: headersList.get("referer") ?? "unknown",
+        raw_error: error,
+        ...(await getRequestObservability()),
       },
     });
   }

--- a/src/infrastructure/auth/auth.config.ts
+++ b/src/infrastructure/auth/auth.config.ts
@@ -1,4 +1,5 @@
 import * as Sentry from "@sentry/nextjs";
+import { headers } from "next/headers";
 import NextAuth from "next-auth";
 import GitHub from "next-auth/providers/github";
 import Google from "next-auth/providers/google";
@@ -135,6 +136,33 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
           auth_error_kind: classifyAuthError(code),
         },
       });
+    },
+  },
+  events: {
+    // Trace serveur de chaque sign-in réussi, avec user-agent : permet de
+    // distinguer un clic humain d'une détonation de scanner email (incident
+    // @interieur.gouv.fr — Users fantômes créés 6s après l'envoi du lien).
+    // Chaque clic sur un magic link réutilisable apparaît ici.
+    async signIn({ user, account, isNewUser }) {
+      try {
+        const headersList = await headers();
+        Sentry.captureMessage("auth:sign-in", {
+          level: "info",
+          tags: {
+            context: "auth",
+            provider: account?.provider ?? "unknown",
+            is_new_user: String(isNewUser ?? false),
+          },
+          extra: {
+            user_agent: headersList.get("user-agent") ?? "unknown",
+            referer: headersList.get("referer") ?? "unknown",
+            email_domain: user.email?.split("@")[1] ?? "unknown",
+          },
+        });
+      } catch {
+        // Observabilité uniquement — ne doit jamais bloquer le sign-in
+        // (headers() indisponible hors scope requête, Sentry down, etc.)
+      }
     },
   },
   callbacks: {

--- a/src/infrastructure/auth/auth.config.ts
+++ b/src/infrastructure/auth/auth.config.ts
@@ -1,5 +1,4 @@
 import * as Sentry from "@sentry/nextjs";
-import { headers } from "next/headers";
 import NextAuth from "next-auth";
 import GitHub from "next-auth/providers/github";
 import Google from "next-auth/providers/google";
@@ -13,6 +12,8 @@ import { isUploadedUrl } from "@/lib/blob";
 import { prismaUserRepository } from "@/infrastructure/repositories/prisma-user-repository";
 import { detectLocaleForMagicLink } from "@/lib/auth/magic-link-url";
 import { classifyAuthError } from "@/lib/auth/error-kinds";
+import { getRequestObservability } from "@/lib/auth/request-observability";
+import { captureServerEvent } from "@/lib/posthog-server";
 import { createReusableVerificationToken } from "@/infrastructure/auth/reusable-verification-token";
 
 // Validité du magic link. On le rend volontairement court (vs 24h par défaut
@@ -110,7 +111,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
     error: "/auth/error",
   },
   logger: {
-    error(error) {
+    async error(error) {
       console.error("[AUTH ERROR]", error);
       const code = error?.name ?? "Unknown";
       const kind = classifyAuthError(code);
@@ -124,9 +125,12 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
           error_code: code,
           auth_error_kind: kind,
         },
+        // Le user-agent distingue un token expiré détonné par un scanner
+        // email d'un vrai clic humain tardif (incident @interieur.gouv.fr).
+        extra: await getRequestObservability(),
       });
     },
-    warn(code) {
+    async warn(code) {
       console.warn("[AUTH WARN]", code);
       Sentry.captureMessage(`auth:${code}`, {
         level: "warning",
@@ -135,6 +139,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
           error_code: code,
           auth_error_kind: classifyAuthError(code),
         },
+        extra: await getRequestObservability(),
       });
     },
   },
@@ -142,27 +147,16 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
     // Trace serveur de chaque sign-in réussi, avec user-agent : permet de
     // distinguer un clic humain d'une détonation de scanner email (incident
     // @interieur.gouv.fr — Users fantômes créés 6s après l'envoi du lien).
-    // Chaque clic sur un magic link réutilisable apparaît ici.
+    // Chaque clic sur un magic link réutilisable apparaît ici. Canal PostHog
+    // (pas Sentry) : c'est de la télémétrie steady-state, pas une anomalie.
     async signIn({ user, account, isNewUser }) {
-      try {
-        const headersList = await headers();
-        Sentry.captureMessage("auth:sign-in", {
-          level: "info",
-          tags: {
-            context: "auth",
-            provider: account?.provider ?? "unknown",
-            is_new_user: String(isNewUser ?? false),
-          },
-          extra: {
-            user_agent: headersList.get("user-agent") ?? "unknown",
-            referer: headersList.get("referer") ?? "unknown",
-            email_domain: user.email?.split("@")[1] ?? "unknown",
-          },
-        });
-      } catch {
-        // Observabilité uniquement — ne doit jamais bloquer le sign-in
-        // (headers() indisponible hors scope requête, Sentry down, etc.)
-      }
+      const requestContext = await getRequestObservability();
+      void captureServerEvent(user.id ?? user.email ?? "unknown", "auth_sign_in", {
+        ...requestContext,
+        provider: account?.provider ?? "unknown",
+        is_new_user: isNewUser ?? false,
+        email_domain: user.email?.split("@")[1] ?? "unknown",
+      });
     },
   },
   callbacks: {

--- a/src/lib/auth/__tests__/error-kinds.test.ts
+++ b/src/lib/auth/__tests__/error-kinds.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { classifyAuthError } from "@/lib/auth/error-kinds";
+import { classifyAuthError, normalizeAuthErrorCode } from "@/lib/auth/error-kinds";
 
 describe("classifyAuthError", () => {
   describe("given a code that occurs in normal user flows", () => {
@@ -33,6 +33,47 @@ describe("classifyAuthError", () => {
       expect(classifyAuthError("Verification: token expired")).toBe(
         "expected_user_flow"
       );
+    });
+  });
+});
+
+describe("normalizeAuthErrorCode", () => {
+  describe("given a known Auth.js error code", () => {
+    it.each([
+      "Verification",
+      "AccessDenied",
+      "UnknownAction",
+      "Configuration",
+      "OAuthAccountNotLinked",
+      "OAuthCallbackError",
+      "OAuthSignInError",
+      "Default",
+    ])("should keep %s as-is", (code) => {
+      expect(normalizeAuthErrorCode(code)).toBe(code);
+    });
+
+    it("should strip extra information after the colon", () => {
+      expect(normalizeAuthErrorCode("Verification: token expired")).toBe(
+        "Verification"
+      );
+    });
+  });
+
+  describe("given a user-controlled or unset value", () => {
+    it.each([
+      "CredentialsSignin",
+      "<script>alert(1)</script>",
+      "x".repeat(300),
+    ])("should bucket %s under Unknown to bound Sentry tag cardinality", (code) => {
+      expect(normalizeAuthErrorCode(code)).toBe("Unknown");
+    });
+
+    it("should return Unknown for null", () => {
+      expect(normalizeAuthErrorCode(null)).toBe("Unknown");
+    });
+
+    it("should return Unknown for undefined", () => {
+      expect(normalizeAuthErrorCode(undefined)).toBe("Unknown");
     });
   });
 });

--- a/src/lib/auth/error-kinds.ts
+++ b/src/lib/auth/error-kinds.ts
@@ -8,6 +8,24 @@ const EXPECTED_AUTH_ERROR_CODES = new Set([
   "AccessDenied",
 ]);
 
+// Codes Auth.js acceptés tels quels dans les tags/messages Sentry. Le param
+// ?error= étant contrôlable par l'utilisateur, tout le reste est rangé sous
+// "Unknown" pour borner la cardinalité (la valeur brute reste en extra).
+const KNOWN_AUTH_ERROR_CODES = new Set([
+  ...EXPECTED_AUTH_ERROR_CODES,
+  "Configuration",
+  "OAuthAccountNotLinked",
+  "OAuthCallbackError",
+  "OAuthSignInError",
+  "Default",
+]);
+
+export function normalizeAuthErrorCode(code: string | null | undefined): string {
+  if (!code) return "Unknown";
+  const normalized = code.split(":")[0]?.trim() ?? "";
+  return KNOWN_AUTH_ERROR_CODES.has(normalized) ? normalized : "Unknown";
+}
+
 /**
  * Range les codes d'erreur Auth.js en deux familles : ceux qu'on attend dans
  * les flows utilisateurs normaux (token expiré, prefetch scanner, refus OAuth)

--- a/src/lib/auth/request-observability.ts
+++ b/src/lib/auth/request-observability.ts
@@ -1,0 +1,22 @@
+import { headers } from "next/headers";
+
+/**
+ * Contexte requête pour l'observabilité auth (Sentry, PostHog) : user-agent
+ * et referer permettent de distinguer un clic humain d'une détonation de
+ * scanner email (incident @interieur.gouv.fr). Ne jette jamais : hors scope
+ * requête, retourne "unknown" pour ne pas faire perdre la capture appelante.
+ */
+export async function getRequestObservability(): Promise<{
+  user_agent: string;
+  referer: string;
+}> {
+  try {
+    const headersList = await headers();
+    return {
+      user_agent: headersList.get("user-agent") ?? "unknown",
+      referer: headersList.get("referer") ?? "unknown",
+    };
+  } catch {
+    return { user_agent: "unknown", referer: "unknown" };
+  }
+}


### PR DESCRIPTION
## Contexte

L'investigation de l'incident @interieur.gouv.fr (3 inscriptions échouées, 8-10 juin) a été aveugle sur deux points : la capture Sentry de la page /auth/error était client-only (invisible depuis les réseaux qui bloquent les trackers, précisément ceux qui posent problème), et aucun signal serveur ne portait le user-agent, ce qui aurait permis d'identifier les détonations de scanners email en quelques minutes.

## Changements

- **Page /auth/error convertie en server component** : capture Sentry au rendu serveur avec user-agent et referer (tag `surface: server`), uniquement si un code d'erreur est présent. L'UI est déplacée telle quelle dans le composant client `AuthErrorView` (détection webview inchangée). La capture client est supprimée (double comptage).
- **Event `auth_sign_in` PostHog server-side** (`captureServerEvent`, canal documenté pour les Auth.js callbacks) à chaque connexion réussie : user-agent, referer, provider, is_new_user, domaine email. Chaque clic sur un magic link réutilisable apparaît, robot comme humain.
- **Le logger Auth.js reçoit user-agent et referer** via le nouveau helper partagé `getRequestObservability()` (`src/lib/auth/request-observability.ts`), consommé par les trois points de capture. Le cas clé de l'incident (token expiré détonné par un scanner) n'est plus aveugle.
- **Cardinalité Sentry bornée** : le param `?error=` étant contrôlable par l'utilisateur, `normalizeAuthErrorCode()` (allowlist des codes Auth.js connus, le reste sous `Unknown`) alimente messages et tags ; la valeur brute reste en extra. Un param `error` répété (string[]) ne fait plus crasher la page en 500.

## Review

/code-review (high) passé : 7 findings, le critique et les 3 importants corrigés dans f9c7183. Restent 3 mineurs/cosmétiques préexistants (pattern `defaultValue` next-intl inopérant, fallback URL en dur dans du code déplacé, `error ?? null`), volontairement hors périmètre.

## Test plan

- [x] `pnpm typecheck`
- [x] Tests unitaires `error-kinds.test.ts` (24 ✓, dont `normalizeAuthErrorCode`)
- [x] Test E2E existant `auth.spec.ts` (page /auth/error?error=Verification) : rendu inchangé
- [ ] Après déploiement : vérifier dans Sentry les events `auth-error-page: *` tagués `surface: server` avec user-agent, et dans PostHog les events `auth_sign_in`

🤖 Generated with [Claude Code](https://claude.com/claude-code)