### PR TITLE
fix(moment): prénom seul dans le From du message aux participants

### DIFF
--- a/src/app/[locale]/(routes)/lab/emails/page.tsx
+++ b/src/app/[locale]/(routes)/lab/emails/page.tsx
@@ -323,6 +323,7 @@ async function buildTemplates(): Promise<{ id: string; label: string; subject: s
         to: "alice@example.com",
         replyTo: "bob@example.com",
         hostName: "Bob Dupont",
+        hostFirstName: "Bob",
         hostAvatarUrl: null,
         subject: "Changement de salle pour vendredi",
         // Placeholder {prénom} déjà résolu par destinataire (ici : Alice)

--- a/src/domain/ports/services/email-service.ts
+++ b/src/domain/ports/services/email-service.ts
@@ -185,8 +185,10 @@ export type MomentHostMessageEmailData = {
   to: string;
   /** Email de l'Organisateur — les réponses lui arrivent directement. */
   replyTo: string;
-  /** Nom affiché de l'Organisateur (from + tête de l'email). */
+  /** Nom complet affiché de l'Organisateur (tête de l'email, preheader). */
   hostName: string;
+  /** Prénom seul pour le From (« Dragos via The Playground ») — null si inconnu. */
+  hostFirstName: string | null;
   hostAvatarUrl: string | null;
   /** Objet saisi par l'Organisateur, tel quel. */
   subject: string;

--- a/src/domain/usecases/send-moment-host-message.ts
+++ b/src/domain/usecases/send-moment-host-message.ts
@@ -166,6 +166,7 @@ export async function sendMomentHostMessage(
     })),
     replyTo: sender.email,
     hostName,
+    hostFirstName: sender.firstName,
     hostAvatarUrl: sender.image ?? null,
     subject,
     bodyHtml: input.bodyHtml,

--- a/src/infrastructure/services/email/resend-email-service.ts
+++ b/src/infrastructure/services/email/resend-email-service.ts
@@ -311,9 +311,10 @@ export function createResendEmailService(): EmailService {
       data: MomentHostMessagesBatchEmailData
     ): Promise<void> {
       const { recipients, ...emailData } = data;
-      // From personnalisé : nom de l'Organisateur, adresse plateforme (DKIM).
+      // From personnalisé : prénom de l'Organisateur (fallback nom affiché),
+      // adresse plateforme (DKIM).
       const personalizedFrom = formatFromWithDisplayName(
-        `${emailData.hostName} via The Playground`,
+        `${emailData.hostFirstName ?? emailData.hostName} via The Playground`,
         from
       );
       await sendBatch(


### PR DESCRIPTION
## Résumé

Le From des messages aux participants affichait le nom complet de l'Organisateur (« Dragos Dreptate via The Playground »). La spec prévoyait le prénom seul. Ce fix réaligne le code :

- **From** : « {prénom} via The Playground », fallback sur le nom affiché complet si le prénom est inconnu (toujours quoté RFC 5322)
- **Inchangés** : nom complet en tête de l'email (identité Organisateur) et dans le preheader
- Nouveau champ `hostFirstName` dans le payload du port EmailService, page lab mise à jour

Pas de changement de schema Prisma. Revue de code sautée à la demande.

🤖 Generated with [Claude Code](https://claude.com/claude-code)