### PR TITLE
fix(analytics): renseigner email/nom sur la person dès le tracking serveur

### DIFF
--- a/src/infrastructure/auth/auth.config.ts
+++ b/src/infrastructure/auth/auth.config.ts
@@ -156,6 +156,13 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         provider: account?.provider ?? "unknown",
         is_new_user: isNewUser ?? false,
         email_domain: user.email?.split("@")[1] ?? "unknown",
+        // Renseigne l'email/nom sur la person dès le serveur : si le client
+        // PostHog est bloqué (ad-blocker, ITP), la person reste retrouvable
+        // par email au lieu de devenir un profil anonyme introuvable.
+        $set: {
+          ...(user.email ? { email: user.email } : {}),
+          ...(user.name ? { name: user.name } : {}),
+        },
       });
     },
   },


### PR DESCRIPTION
## Contexte

Investigation suite à « aucune trace PostHog » pour un nouvel utilisateur (`etiennedau-site@yahoo.fr`).

La person existait bien dans PostHog (distinct_id = `User.id`, créée par l'événement serveur `auth_sign_in`), mais :
- `is_identified: false` (le `posthog.identify()` client n'a jamais tourné, client bloqué par ad-blocker / ITP)
- aucune propriété `email`/`name` → **introuvable par recherche email**

## Changement

`captureServerEvent("auth_sign_in", ...)` posait le `distinct_id` mais jamais `email`/`name` sur la person. On ajoute `$set { email, name }` pour que la person porte l'email **même si le client n'identifie jamais**.

Le `distinct_id` serveur étant identique à celui du `identify()` client, les deux convergent sur la même person, sans doublon.

## Effet

- Pas de perte de données ni de doublon
- Les futurs sign-ins (y compris clients bloqués) produisent des persons retrouvables par email
- Ne réécrit pas rétroactivement les persons fantômes existantes (leur prochaine connexion les renseignera)

🤖 Generated with [Claude Code](https://claude.com/claude-code)