### PR TITLE
fix(security): bloquer les comptes abusifs au sign-in + garde anti-usurpation de nom

### DIFF
--- a/src/app/actions/profile.ts
+++ b/src/app/actions/profile.ts
@@ -13,6 +13,7 @@ import { after } from "next/server";
 import { createResendEmailService } from "@/infrastructure/services";
 import { formatLongDate } from "@/lib/format-date";
 import { getDisplayName } from "@/lib/display-name";
+import { isImpersonatingName } from "@/lib/impersonation-guard";
 import { notifySlackNewUser, isAdminEmailEnabled } from "@/infrastructure/services/slack/slack-notification-service";
 import type { User, NotificationPreferences } from "@/domain/models/user";
 import type { ActionResult } from "./types";
@@ -39,6 +40,11 @@ export async function updateProfileAction(
   }
   if (!lastName?.trim()) {
     return { success: false, error: "Last name is required", code: "VALIDATION" };
+  }
+  // Anti-usurpation : interdit les noms se faisant passer pour la plateforme,
+  // le support ou l'admin (filet secondaire de la blocklist de sign-in).
+  if (isImpersonatingName(firstName, lastName)) {
+    return { success: false, error: "This name is not allowed", code: "VALIDATION" };
   }
 
   const bio = formData.get("bio") as string | null;

--- a/src/infrastructure/auth/auth.config.ts
+++ b/src/infrastructure/auth/auth.config.ts
@@ -15,6 +15,7 @@ import { classifyAuthError } from "@/lib/auth/error-kinds";
 import { getRequestObservability } from "@/lib/auth/request-observability";
 import { captureServerEvent } from "@/lib/posthog-server";
 import { createReusableVerificationToken } from "@/infrastructure/auth/reusable-verification-token";
+import { isBlockedSignIn } from "@/infrastructure/auth/sign-in-blocklist";
 
 // Validité du magic link. On le rend volontairement court (vs 24h par défaut
 // Auth.js) parce que le token est désormais réutilisable pendant cette fenêtre,
@@ -167,7 +168,13 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
     },
   },
   callbacks: {
-    async signIn({ user, profile }) {
+    async signIn({ user, account, profile }) {
+      // Anti-abus : refuse la connexion des acteurs malveillants connus
+      // (identité OAuth ou email blocklistés), avant toute autre logique.
+      if (isBlockedSignIn(user.email, account?.providerAccountId)) {
+        return false;
+      }
+
       // Synchro image OAuth — ne doit jamais bloquer le sign-in
       try {
         if (user.id && profile) {

--- a/src/infrastructure/auth/sign-in-blocklist.ts
+++ b/src/infrastructure/auth/sign-in-blocklist.ts
@@ -1,0 +1,35 @@
+/**
+ * Blocklist de connexion — mesure anti-abus.
+ *
+ * Bloque les acteurs malveillants connus AU MOMENT DU SIGN-IN, indépendamment
+ * du nom affiché (l'acteur change de nom mais réutilise le même compte Google).
+ * Le levier fiable est l'identité OAuth (`providerAccountId`) + l'email, pas le
+ * nom de profil qui est trivialement falsifiable.
+ *
+ * Maintenue à la main pour les incidents. Pour un volume plus large, migrer
+ * vers une table DB + UI admin (cf. issue suspension de compte).
+ */
+
+/** Emails bloqués (comparaison insensible à la casse). */
+const BLOCKED_EMAILS = new Set<string>(["ixewufoy22@gmail.com"]);
+
+/**
+ * Identités OAuth bloquées par `providerAccountId`.
+ * Robuste face au changement d'email/nom tant que l'acteur réutilise le même
+ * compte du fournisseur (Google).
+ */
+const BLOCKED_OAUTH_ACCOUNT_IDS = new Set<string>([
+  // Google — acteur "PLAYGROUND SUPP0RT" (usurpation du support, 2026-06-14)
+  "113146911556107410982",
+]);
+
+export function isBlockedSignIn(
+  email?: string | null,
+  providerAccountId?: string | null
+): boolean {
+  if (email && BLOCKED_EMAILS.has(email.trim().toLowerCase())) return true;
+  if (providerAccountId && BLOCKED_OAUTH_ACCOUNT_IDS.has(providerAccountId)) {
+    return true;
+  }
+  return false;
+}

--- a/src/lib/__tests__/impersonation-guard.test.ts
+++ b/src/lib/__tests__/impersonation-guard.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { isImpersonatingName } from "@/lib/impersonation-guard";
+
+describe("isImpersonatingName", () => {
+  describe("given a name impersonating the platform or support", () => {
+    it.each([
+      ["PLAYGROUND", "SUPPORT"],
+      ["PLAYGR0UND", "SUPP0RT"], // leet 0 -> o
+      ["PLAYGROUND", "SUPP0RT"],
+      ["Support", "Support"],
+      ["The", "Playground"],
+      ["Adm1n", "Team"], // leet 1 -> i
+      ["Moderation", "Officielle"],
+      ["N0reply", "Service"], // leet 0 -> o
+    ])("should reject %s %s", (firstName, lastName) => {
+      expect(isImpersonatingName(firstName, lastName)).toBe(true);
+    });
+  });
+
+  describe("given a legitimate human name", () => {
+    it.each([
+      ["Jean", "Dupont"],
+      ["Marie", "Curie"],
+      ["Авцин", "Всеволод"],
+      ["Sophie", "Martin"],
+      ["Lucas", "Bernard"],
+    ])("should allow %s %s", (firstName, lastName) => {
+      expect(isImpersonatingName(firstName, lastName)).toBe(false);
+    });
+  });
+
+  it("should handle null/undefined parts safely", () => {
+    expect(isImpersonatingName(null, undefined)).toBe(false);
+    expect(isImpersonatingName("Support", null)).toBe(true);
+  });
+});

--- a/src/lib/impersonation-guard.ts
+++ b/src/lib/impersonation-guard.ts
@@ -1,0 +1,54 @@
+/**
+ * Garde anti-usurpation des noms de profil.
+ *
+ * Filet secondaire contre les comptes qui se font passer pour la plateforme ou
+ * son support (ex. "PLAYGROUND SUPP0RT", "Adm1n"). Ce n'est PAS le bloqueur
+ * principal : un attaquant peut mettre un vrai nom pour passer. Le levier fiable
+ * reste la blocklist d'identité au sign-in (cf. sign-in-blocklist.ts).
+ */
+
+// Normalisation leet courante (0->o, 1->i, etc.) pour neutraliser les
+// contournements type "SUPP0RT" / "PLAYGR0UND" / "Adm1n".
+const LEET: Record<string, string> = {
+  "0": "o",
+  "1": "i",
+  "3": "e",
+  "4": "a",
+  "5": "s",
+  "7": "t",
+  "8": "b",
+  "@": "a",
+  $: "s",
+};
+
+/** Tokens réservés : noms qui usurpent la plateforme, le support ou l'admin. */
+const RESERVED_TOKENS = [
+  "playground",
+  "support",
+  "admin",
+  "moderation",
+  "moderateur",
+  "noreply",
+];
+
+function normalize(value: string): string {
+  return value
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "") // diacritiques
+    .split("")
+    .map((c) => LEET[c] ?? c)
+    .join("")
+    .replace(/[^a-z]/g, ""); // ne garde que les lettres
+}
+
+/**
+ * Retourne true si le nom (prénom + nom concaténés) contient un token réservé,
+ * après normalisation leet/accents/espaces.
+ */
+export function isImpersonatingName(
+  ...parts: Array<string | null | undefined>
+): boolean {
+  const normalized = normalize(parts.filter(Boolean).join(" "));
+  return RESERVED_TOKENS.some((token) => normalized.includes(token));
+}


### PR DESCRIPTION
## Contexte (urgence)
Attaque active : un acteur recrée en boucle un compte via le **même compte Google** (`providerAccountId 113146911556107410982`), avec un nom usurpant le support (« PLAYGROUND SUPP0RT » / « PLAYGR0UND SUPP0RT », chiffres 0 à la place des O), pour préparer du phishing via la fonction « Contacter les organisateurs ». La suppression manuelle est inutile (il recrée en quelques secondes).

## Changements
- **Blocklist de sign-in** (`sign-in-blocklist.ts`) : rejet dans le callback `signIn` par **email** + **providerAccountId OAuth**. Bloqueur fiable, indépendant du nom de profil (l'acteur met parfois de vrais noms).
- **Garde anti-usurpation de nom** (`impersonation-guard.ts`) : interdit les noms se faisant passer pour support/playground/admin, avec normalisation leet (`SUPP0RT` → `support`), appliquée dans l'action de mise à jour de profil. Filet secondaire.
- Tests unitaires de la garde-nom (14 cas).

## Notes
- Aucun changement de schema Prisma.
- Code-review skippé volontairement vu l'urgence (validé).
- Limite : un nouveau compte Google (nouvel email + nouveau providerAccountId) contourne la blocklist → ajouter l'identité au besoin. Correctifs de fond séparés : durcissement `contact_hosts` + mécanisme de suspension (#533).

🤖 Generated with [Claude Code](https://claude.com/claude-code)