### PR TITLE
fix(registration): notifier l'Organisateur quand un admin s'inscrit

### DIFF
--- a/src/app/actions/registration.ts
+++ b/src/app/actions/registration.ts
@@ -3,7 +3,7 @@
 import { after } from "next/server";
 import * as Sentry from "@sentry/nextjs";
 import { auth } from "@/infrastructure/auth/auth.config";
-import { isAdminUser, resolveCircleRepository } from "@/lib/admin-host-mode";
+import { resolveCircleRepository } from "@/lib/admin-host-mode";
 import {
   prismaCircleRepository,
   prismaMomentRepository,
@@ -55,24 +55,22 @@ export async function joinMomentAction(
       }
     );
 
-    if (!isAdminUser(session)) {
-      // `buildEmailLocaleResolver` lit `getLocale()` (dépend de `headers()`) :
-      // doit s'exécuter dans le request context, avant `after()`.
-      const resolver = await buildEmailLocaleResolver(userId);
-      // `after()` garantit la complétion sur Vercel Fluid Compute après le retour
-      // de la Server Action. Une promesse fire-and-forget nue serait larguée au
-      // gel de l'instance (emails + Slack perdus par intermittence).
-      after(async () => {
-        try {
-          await (result.pendingApproval
-            ? notifyHostsPendingApproval(momentId, userId, resolver)
-            : sendRegistrationEmails(momentId, userId, result.registration, resolver));
-        } catch (err) {
-          console.error(err);
-          Sentry.captureException(err);
-        }
-      });
-    }
+    // `buildEmailLocaleResolver` lit `getLocale()` (dépend de `headers()`) :
+    // doit s'exécuter dans le request context, avant `after()`.
+    const resolver = await buildEmailLocaleResolver(userId);
+    // `after()` garantit la complétion sur Vercel Fluid Compute après le retour
+    // de la Server Action. Une promesse fire-and-forget nue serait larguée au
+    // gel de l'instance (emails + Slack perdus par intermittence).
+    after(async () => {
+      try {
+        await (result.pendingApproval
+          ? notifyHostsPendingApproval(momentId, userId, resolver)
+          : sendRegistrationEmails(momentId, userId, result.registration, resolver));
+      } catch (err) {
+        console.error(err);
+        Sentry.captureException(err);
+      }
+    });
 
     invalidateDashboardCache(userId);
     return result.registration;


### PR DESCRIPTION
## Problème

Quand un **admin** s'inscrivait à un événement, ni la confirmation Participant, ni la notification à l'Organisateur (ni le message Slack) ne partaient. L'inscription était bien enregistrée en base, mais silencieuse.

En cause : la garde `if (!isAdminUser(session))` dans `joinMomentAction` enveloppait **tout** le bloc `after()` d'envoi de notifications. Dès que le Participant était admin, l'intégralité des envois était sautée — y compris la notif côté Organisateur, qui devrait partir pour toute inscription légitime.

## Correctif

Retrait du filtre admin sur `joinMomentAction` : l'admin déclenche désormais les emails/notifs comme un Participant normal.

- ✅ Confirmation Participant (+ `.ics` si REGISTERED)
- ✅ Notification Organisateur (`sendHostNewRegistration`, si préf active)
- ✅ Notification Slack

Le filtre **self-host** (`host.userId !== userId`) reste inchangé : si l'admin est lui-même Organisateur du Circle, il ne reçoit pas la notif Host de sa propre inscription (comportement voulu).

## Portée

- 1 fichier : `src/app/actions/registration.ts`
- Retrait de la garde + nettoyage de l'import `isAdminUser` (devenu unused)
- Pas de changement de schema Prisma
- `pnpm typecheck` ✅ — `/code-review` (high) ✅ aucun finding

🤖 Generated with [Claude Code](https://claude.com/claude-code)