### PR TITLE
feat(security): protéger le sign-in avec Vercel BotID

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -145,6 +145,7 @@
       "invalidEmail": "Invalid email address. Please check your input.",
       "disposableEmail": "Disposable email addresses are not allowed. Please use a permanent address.",
       "sendFailed": "Couldn't send the email right now. Please try again in a moment.",
+      "botDetected": "Security verification failed. Please reload the page and try again.",
       "webviewNotice": "You're using an in-app browser (LinkedIn, Instagram...). Use the email sign-in below, it works everywhere. To sign in with Google or GitHub, open the site in your browser (Safari, Chrome...)."
     },
     "verifyRequest": {
@@ -168,6 +169,7 @@
       "OAuthAccountNotLinked": "This email is already linked to another sign-in method. Use that one to continue.",
       "OAuthCallbackError": "Sign-in via the provider failed. Please try again.",
       "OAuthSignInError": "Sign-in via the provider couldn't start. Please try again.",
+      "BotDetected": "Security verification failed. Please reload the page and try again.",
       "Default": "An error occurred during sign in."
     },
     "signOut": "Sign out"

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -145,6 +145,7 @@
       "invalidEmail": "Adresse email invalide. Vérifiez votre saisie.",
       "disposableEmail": "Les adresses email jetables ne sont pas acceptées. Utilisez une adresse permanente.",
       "sendFailed": "Impossible d'envoyer l'email pour le moment. Réessayez dans un instant.",
+      "botDetected": "La vérification de sécurité a échoué. Rechargez la page et réessayez.",
       "webviewNotice": "Vous utilisez un navigateur intégré (LinkedIn, Instagram...). Utilisez la connexion par email ci-dessous, elle fonctionne partout. Pour vous connecter avec Google ou GitHub, ouvrez le site dans votre navigateur (Safari, Chrome...)."
     },
     "verifyRequest": {
@@ -168,6 +169,7 @@
       "OAuthAccountNotLinked": "Cet email est déjà associé à une autre méthode de connexion. Utilisez celle-ci pour continuer.",
       "OAuthCallbackError": "La connexion via le fournisseur a échoué. Réessayez.",
       "OAuthSignInError": "La connexion via le fournisseur n'a pas pu démarrer. Réessayez.",
+      "BotDetected": "La vérification de sécurité a échoué. Rechargez la page et réessayez.",
       "Default": "Une erreur est survenue lors de la connexion."
     },
     "signOut": "Se déconnecter"

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from "next";
 import createNextIntlPlugin from "next-intl/plugin";
 import { withSentryConfig } from "@sentry/nextjs";
 import withPWAInit from "@ducanh2912/next-pwa";
+import { withBotId } from "botid/next/config";
 
 const withNextIntl = createNextIntlPlugin("./src/i18n/request.ts");
 
@@ -144,7 +145,9 @@ const nextConfig: NextConfig = {
   },
 };
 
-export default withSentryConfig(withPWA(withNextIntl(nextConfig)), {
+// withBotId enveloppe la config la plus brute pour fusionner ses rewrites de
+// proxy (challenge BotID servi en first-party) avec nos rewrites PostHog.
+export default withSentryConfig(withPWA(withNextIntl(withBotId(nextConfig))), {
   org: process.env.SENTRY_ORG,
   project: process.env.SENTRY_PROJECT,
   authToken: process.env.SENTRY_AUTH_TOKEN,

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "@vercel/analytics": "^1.6.1",
     "@vercel/blob": "^2.3.3",
     "@vercel/speed-insights": "^1.3.1",
+    "botid": "^1.5.11",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       '@vercel/speed-insights':
         specifier: ^1.3.1
         version: 1.3.1(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+      botid:
+        specifier: ^1.5.11
+        version: 1.5.11(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -3747,6 +3750,17 @@ packages:
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
+
+  botid@1.5.11:
+    resolution: {integrity: sha512-KOO1A3+/vFVJk5aFoG3sNwiogKFPVR+x4aw4gQ1b2e0XoE+i5xp48/EZn+WqR07jRHeDGwHWQUOtV5WVm7xiww==}
+    peerDependencies:
+      next: '*'
+      react: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      next:
+        optional: true
+      react:
+        optional: true
 
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
@@ -10530,6 +10544,11 @@ snapshots:
       type-is: 2.0.1
     transitivePeerDependencies:
       - supports-color
+
+  botid@1.5.11(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4):
+    optionalDependencies:
+      next: 16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
 
   brace-expansion@2.0.2:
     dependencies:

--- a/src/app/actions/auth.ts
+++ b/src/app/actions/auth.ts
@@ -1,9 +1,11 @@
 "use server";
 
 import { cookies } from "next/headers";
-import { unstable_rethrow } from "next/navigation";
+import { redirect, unstable_rethrow } from "next/navigation";
 import { getLocale } from "next-intl/server";
 import { signIn, signOut } from "@/infrastructure/auth/auth.config";
+import { isLikelyBot } from "@/infrastructure/security/bot-protection";
+import { routing } from "@/i18n/routing";
 import { isValidEmail } from "@/lib/email";
 import { isDisposableEmailDomain } from "@/lib/email/disposable-domains";
 import { safeCallbackUrl } from "@/lib/url";
@@ -27,7 +29,18 @@ async function postSignInRedirectTo() {
   return `/${locale}/dashboard/profile/setup`;
 }
 
+// Page de connexion dans la locale courante (locale par défaut sans préfixe,
+// cf. localePrefix "as-needed"). Sert de cible de redirection quand BotID
+// classe un flux OAuth comme bot.
+async function signInPath() {
+  const locale = await getLocale();
+  return locale === routing.defaultLocale
+    ? "/auth/sign-in"
+    : `/${locale}/auth/sign-in`;
+}
+
 export async function signInWithGitHub(formData: FormData) {
+  if (await isLikelyBot()) redirect(`${await signInPath()}?error=BotDetected`);
   const callbackUrl = safeCallbackUrl(formData.get("callbackUrl") as string);
   if (callbackUrl) await setCallbackCookie(callbackUrl);
   // Toujours passer par le setup : la page setup redirige vers callbackUrl
@@ -36,13 +49,14 @@ export async function signInWithGitHub(formData: FormData) {
 }
 
 export async function signInWithGoogle(formData: FormData) {
+  if (await isLikelyBot()) redirect(`${await signInPath()}?error=BotDetected`);
   const callbackUrl = safeCallbackUrl(formData.get("callbackUrl") as string);
   if (callbackUrl) await setCallbackCookie(callbackUrl);
   await signIn("google", { redirectTo: await postSignInRedirectTo() });
 }
 
 export type SignInWithEmailState =
-  | { error: "INVALID_EMAIL" | "DISPOSABLE_EMAIL" | "SEND_FAILED" }
+  | { error: "INVALID_EMAIL" | "DISPOSABLE_EMAIL" | "SEND_FAILED" | "BOT_DETECTED" }
   | null;
 
 export async function signInWithEmail(
@@ -55,6 +69,9 @@ export async function signInWithEmail(
   }
   if (isDisposableEmailDomain(email)) {
     return { error: "DISPOSABLE_EMAIL" };
+  }
+  if (await isLikelyBot()) {
+    return { error: "BOT_DETECTED" };
   }
   const callbackUrl = safeCallbackUrl(formData.get("callbackUrl") as string);
   if (callbackUrl) await setCallbackCookie(callbackUrl);

--- a/src/components/auth/sign-in-form.tsx
+++ b/src/components/auth/sign-in-form.tsx
@@ -135,6 +135,7 @@ export function SignInForm({ callbackUrl, error }: SignInFormProps) {
                   INVALID_EMAIL: "signIn.invalidEmail",
                   DISPOSABLE_EMAIL: "signIn.disposableEmail",
                   SEND_FAILED: "signIn.sendFailed",
+                  BOT_DETECTED: "signIn.botDetected",
                 }[emailState.error]
               )}
             </p>

--- a/src/infrastructure/security/__tests__/bot-protection.test.ts
+++ b/src/infrastructure/security/__tests__/bot-protection.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const checkBotId = vi.fn();
+vi.mock("botid/server", () => ({
+  checkBotId: () => checkBotId(),
+}));
+
+import { isLikelyBot } from "../bot-protection";
+
+describe("isLikelyBot (wrapper Vercel BotID)", () => {
+  beforeEach(() => {
+    checkBotId.mockReset();
+  });
+
+  describe("given BotID classe la session comme un bot", () => {
+    it("should return true", async () => {
+      checkBotId.mockResolvedValue({ isBot: true });
+      await expect(isLikelyBot()).resolves.toBe(true);
+    });
+  });
+
+  describe("given BotID classe la session comme un humain", () => {
+    it("should return false", async () => {
+      checkBotId.mockResolvedValue({ isBot: false });
+      await expect(isLikelyBot()).resolves.toBe(false);
+    });
+  });
+
+  describe("given BotID est indisponible (panne)", () => {
+    it("should fail-open et renvoyer false pour ne pas bloquer un humain", async () => {
+      checkBotId.mockRejectedValue(new Error("BotID outage"));
+      await expect(isLikelyBot()).resolves.toBe(false);
+    });
+  });
+});

--- a/src/infrastructure/security/__tests__/bot-protection.test.ts
+++ b/src/infrastructure/security/__tests__/bot-protection.test.ts
@@ -5,11 +5,17 @@ vi.mock("botid/server", () => ({
   checkBotId: () => checkBotId(),
 }));
 
+const captureException = vi.fn();
+vi.mock("@sentry/nextjs", () => ({
+  captureException: (error: unknown) => captureException(error),
+}));
+
 import { isLikelyBot } from "../bot-protection";
 
 describe("isLikelyBot (wrapper Vercel BotID)", () => {
   beforeEach(() => {
     checkBotId.mockReset();
+    captureException.mockReset();
   });
 
   describe("given BotID classe la session comme un bot", () => {
@@ -30,6 +36,13 @@ describe("isLikelyBot (wrapper Vercel BotID)", () => {
     it("should fail-open et renvoyer false pour ne pas bloquer un humain", async () => {
       checkBotId.mockRejectedValue(new Error("BotID outage"));
       await expect(isLikelyBot()).resolves.toBe(false);
+    });
+
+    it("should remonter l'erreur à Sentry pour rendre la panne observable", async () => {
+      const outage = new Error("BotID outage");
+      checkBotId.mockRejectedValue(outage);
+      await isLikelyBot();
+      expect(captureException).toHaveBeenCalledWith(outage);
     });
   });
 });

--- a/src/infrastructure/security/bot-protection.ts
+++ b/src/infrastructure/security/bot-protection.ts
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/nextjs";
 import { checkBotId } from "botid/server";
 
 /**
@@ -11,6 +12,8 @@ import { checkBotId } from "botid/server";
  * - **Fail-open** : toute erreur (panne BotID, classification indisponible) renvoie
  *   `false`. On ne bloque jamais un humain à cause d'une indisponibilité du service.
  *   Les autres garde-fous (blocklist sign-in, domaines jetables) restent actifs.
+ *   L'erreur est remontée à Sentry pour qu'une panne durable (qui neutraliserait
+ *   la protection en silence) reste observable.
  * - En local, BotID renvoie toujours `isBot: false` (cf. doc « local development
  *   behavior »), donc le développement et les tests E2E ne sont pas impactés.
  */
@@ -18,7 +21,8 @@ export async function isLikelyBot(): Promise<boolean> {
   try {
     const { isBot } = await checkBotId();
     return isBot;
-  } catch {
+  } catch (error) {
+    Sentry.captureException(error);
     return false;
   }
 }

--- a/src/infrastructure/security/bot-protection.ts
+++ b/src/infrastructure/security/bot-protection.ts
@@ -1,0 +1,24 @@
+import { checkBotId } from "botid/server";
+
+/**
+ * Vérifie, via Vercel BotID, si la requête en cours est classée comme bot.
+ *
+ * À appeler au début d'une server action / route handler dont le path est
+ * déclaré dans `initBotId({ protect: [...] })` (src/instrumentation-client.ts).
+ * Sans cette déclaration côté client, `checkBotId()` échoue.
+ *
+ * Comportement volontaire :
+ * - **Fail-open** : toute erreur (panne BotID, classification indisponible) renvoie
+ *   `false`. On ne bloque jamais un humain à cause d'une indisponibilité du service.
+ *   Les autres garde-fous (blocklist sign-in, domaines jetables) restent actifs.
+ * - En local, BotID renvoie toujours `isBot: false` (cf. doc « local development
+ *   behavior »), donc le développement et les tests E2E ne sont pas impactés.
+ */
+export async function isLikelyBot(): Promise<boolean> {
+  try {
+    const { isBot } = await checkBotId();
+    return isBot;
+  } catch {
+    return false;
+  }
+}

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -1,5 +1,6 @@
 import * as Sentry from "@sentry/nextjs";
 import { initBotId } from "botid/client/core";
+import { routing } from "@/i18n/routing";
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
@@ -12,12 +13,20 @@ Sentry.init({
 // se fait côté serveur via checkBotId() (cf. infrastructure/security/bot-protection.ts).
 // On protège les pages d'où partent les server actions de connexion : verrouiller
 // le sign-in coupe la racine du vecteur « Contacter les organisateurs » (qui exige
-// d'être authentifié). Locale `fr` sans préfixe, `en` préfixée (localePrefix "as-needed").
+// d'être authentifié).
+//
+// La liste est dérivée de `routing.locales` pour qu'une langue ajoutée plus tard
+// soit protégée automatiquement (locale par défaut sans préfixe, autres préfixées
+// — localePrefix "as-needed"). Sans ça, une nouvelle locale resterait silencieusement
+// non protégée.
 initBotId({
-  protect: [
-    { path: "/auth/sign-in", method: "POST" },
-    { path: "/en/auth/sign-in", method: "POST" },
-  ],
+  protect: routing.locales.map((locale) => ({
+    path:
+      locale === routing.defaultLocale
+        ? "/auth/sign-in"
+        : `/${locale}/auth/sign-in`,
+    method: "POST" as const,
+  })),
 });
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -1,9 +1,23 @@
 import * as Sentry from "@sentry/nextjs";
+import { initBotId } from "botid/client/core";
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   enabled: process.env.NODE_ENV === "production",
   tracesSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 1.0,
+});
+
+// Vercel BotID — CAPTCHA invisible sur les routes sensibles. Le client attache
+// des en-têtes de challenge aux requêtes déclarées ci-dessous ; la vérification
+// se fait côté serveur via checkBotId() (cf. infrastructure/security/bot-protection.ts).
+// On protège les pages d'où partent les server actions de connexion : verrouiller
+// le sign-in coupe la racine du vecteur « Contacter les organisateurs » (qui exige
+// d'être authentifié). Locale `fr` sans préfixe, `en` préfixée (localePrefix "as-needed").
+initBotId({
+  protect: [
+    { path: "/auth/sign-in", method: "POST" },
+    { path: "/en/auth/sign-in", method: "POST" },
+  ],
 });
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;


### PR DESCRIPTION
## Contexte

Suite à l'incident du 14/06 (faux comptes usurpant le support pour phisher les organisateurs via « Contacter les organisateurs »), on protège la **connexion** avec **Vercel BotID** (CAPTCHA invisible). Contacter un organisateur exige d'être authentifié → verrouiller le sign-in coupe la racine du vecteur, en amont.

L'attaquant utilisait un vrai compte Google + OAuth sur un vrai navigateur : les protections edge classiques (Bot Protection, Attack Mode) ne l'auraient pas arrêté. Il fallait une protection **applicative, ciblée et invisible**.

## Ce que fait la PR

- **`next.config.ts`** : wrapper `withBotId` (proxy first-party du challenge). Vérifié : les rewrites PostHog sont préservés (BotID les concatène, ne les écrase pas).
- **`instrumentation-client.ts`** : `initBotId` sur les pages de connexion, paths **dérivés de `routing.locales`** (toute langue future protégée automatiquement).
- **`infrastructure/security/bot-protection.ts`** : wrapper `isLikelyBot()`, **fail-open** (ne bloque jamais un humain sur panne BotID) avec remontée Sentry pour rendre une panne durable observable.
- **`app/actions/auth.ts`** : check au début des 3 server actions (Google, GitHub, magic link), blocage **avant** `signIn()`.
- **i18n FR/EN** + affichage d'une erreur neutre (faux positif → recharger + réessayer).
- **Tests** : wrapper couvert (humain / bot / panne fail-open / remontée Sentry).

## Notes

- **Aucun changement de base de données.**
- **Ne bloque qu'en production** : en local/preview, BotID considère tout le monde comme humain (zéro impact dev/E2E).
- **Aucun impact** sur le SEO ni sur les previews de partage (seule la connexion est protégée).
- `/code-review` (high) passé : aucun bug bloquant ; les 2 findings moyens (paths dérivés, observabilité du fail-open) sont traités dans cette PR.

## À faire côté Vercel après déploiement

- Activer **BotID Deep Analysis** (Firewall → Rules) — optionnel mais recommandé.
- Vérifier en prod une vraie connexion (Google/GitHub/email) + un partage de lien.
- Surveiller Sentry 48h (erreurs `checkBotId` = fail-open silencieux).

🤖 Generated with [Claude Code](https://claude.com/claude-code)