### PR TITLE
feat(security): observabilité et kill switch BotID au sign-in

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -118,6 +118,15 @@ SENTRY_WEBHOOK_SECRET=""
 SENTRY_ALERT_EMAIL=""
 
 
+# ── [OPTION] BotID — protection anti-bot du sign-in ──────────────────────────
+# Pilote le comportement de Vercel BotID au sign-in. Sans impact en local
+# (BotID renvoie toujours isBot=false hors prod).
+#   enforce (défaut) : détecte, journalise et bloque les bots
+#   observe          : détecte et journalise mais laisse passer (mesure des FP)
+#   off              : kill switch — désactive totalement BotID
+# BOTID_MODE="enforce"
+
+
 # ── [OPTION] Cron jobs / E2E secrets ─────────────────────────────────────────
 # Nécessaires uniquement si tu travailles sur les cron jobs ou des tests E2E custom.
 # Génère avec : openssl rand -hex 32

--- a/src/app/actions/auth.ts
+++ b/src/app/actions/auth.ts
@@ -4,7 +4,7 @@ import { cookies } from "next/headers";
 import { redirect, unstable_rethrow } from "next/navigation";
 import { getLocale } from "next-intl/server";
 import { signIn, signOut } from "@/infrastructure/auth/auth.config";
-import { isLikelyBot } from "@/infrastructure/security/bot-protection";
+import { isLikelyBot, recordBotBlock } from "@/infrastructure/security/bot-protection";
 import { routing } from "@/i18n/routing";
 import { isValidEmail } from "@/lib/email";
 import { isDisposableEmailDomain } from "@/lib/email/disposable-domains";
@@ -39,8 +39,18 @@ async function signInPath() {
     : `/${locale}/auth/sign-in`;
 }
 
+// Pour les flux OAuth : si BotID classe la requête comme bot, journalise le
+// blocage puis redirige vers la page de connexion (le redirect interrompt
+// l'action, donc l'appelant ne poursuit pas vers signIn()).
+async function redirectIfBot(provider: "google" | "github") {
+  if (await isLikelyBot()) {
+    await recordBotBlock({ provider });
+    redirect(`${await signInPath()}?error=BotDetected`);
+  }
+}
+
 export async function signInWithGitHub(formData: FormData) {
-  if (await isLikelyBot()) redirect(`${await signInPath()}?error=BotDetected`);
+  await redirectIfBot("github");
   const callbackUrl = safeCallbackUrl(formData.get("callbackUrl") as string);
   if (callbackUrl) await setCallbackCookie(callbackUrl);
   // Toujours passer par le setup : la page setup redirige vers callbackUrl
@@ -49,7 +59,7 @@ export async function signInWithGitHub(formData: FormData) {
 }
 
 export async function signInWithGoogle(formData: FormData) {
-  if (await isLikelyBot()) redirect(`${await signInPath()}?error=BotDetected`);
+  await redirectIfBot("google");
   const callbackUrl = safeCallbackUrl(formData.get("callbackUrl") as string);
   if (callbackUrl) await setCallbackCookie(callbackUrl);
   await signIn("google", { redirectTo: await postSignInRedirectTo() });
@@ -71,6 +81,7 @@ export async function signInWithEmail(
     return { error: "DISPOSABLE_EMAIL" };
   }
   if (await isLikelyBot()) {
+    await recordBotBlock({ provider: "resend", email });
     return { error: "BOT_DETECTED" };
   }
   const callbackUrl = safeCallbackUrl(formData.get("callbackUrl") as string);

--- a/src/app/actions/auth.ts
+++ b/src/app/actions/auth.ts
@@ -4,7 +4,7 @@ import { cookies } from "next/headers";
 import { redirect, unstable_rethrow } from "next/navigation";
 import { getLocale } from "next-intl/server";
 import { signIn, signOut } from "@/infrastructure/auth/auth.config";
-import { isLikelyBot, recordBotBlock } from "@/infrastructure/security/bot-protection";
+import { evaluateBotSignIn } from "@/infrastructure/security/bot-protection";
 import { routing } from "@/i18n/routing";
 import { isValidEmail } from "@/lib/email";
 import { isDisposableEmailDomain } from "@/lib/email/disposable-domains";
@@ -39,14 +39,13 @@ async function signInPath() {
     : `/${locale}/auth/sign-in`;
 }
 
-// Pour les flux OAuth : si BotID classe la requête comme bot, journalise le
-// blocage puis redirige vers la page de connexion (le redirect interrompt
-// l'action, donc l'appelant ne poursuit pas vers signIn()).
+// Pour les flux OAuth : évalue BotID (selon BOTID_MODE) et, si la requête doit
+// être bloquée, redirige vers la page de connexion. Le redirect interrompt
+// l'action, donc l'appelant ne poursuit pas vers signIn(). La journalisation
+// éventuelle est gérée dans evaluateBotSignIn.
 async function redirectIfBot(provider: "google" | "github") {
-  if (await isLikelyBot()) {
-    await recordBotBlock({ provider });
-    redirect(`${await signInPath()}?error=BotDetected`);
-  }
+  const { shouldBlock } = await evaluateBotSignIn({ provider });
+  if (shouldBlock) redirect(`${await signInPath()}?error=BotDetected`);
 }
 
 export async function signInWithGitHub(formData: FormData) {
@@ -80,8 +79,8 @@ export async function signInWithEmail(
   if (isDisposableEmailDomain(email)) {
     return { error: "DISPOSABLE_EMAIL" };
   }
-  if (await isLikelyBot()) {
-    await recordBotBlock({ provider: "resend", email });
+  const { shouldBlock } = await evaluateBotSignIn({ provider: "resend", email });
+  if (shouldBlock) {
     return { error: "BOT_DETECTED" };
   }
   const callbackUrl = safeCallbackUrl(formData.get("callbackUrl") as string);

--- a/src/infrastructure/security/__tests__/bot-protection.test.ts
+++ b/src/infrastructure/security/__tests__/bot-protection.test.ts
@@ -105,6 +105,7 @@ describe("evaluateBotSignIn (modes BotID + journalisation)", () => {
     after.mockClear();
     checkBotId.mockReset();
     captureServerEvent.mockReset();
+    captureException.mockReset();
     getLocale.mockReset();
     getRequestObservability.mockReset();
     getPosthogDistinctId.mockReset();
@@ -131,6 +132,17 @@ describe("evaluateBotSignIn (modes BotID + journalisation)", () => {
       await expect(evaluateBotSignIn({ provider: "google" })).resolves.toEqual({
         shouldBlock: true,
       });
+    });
+
+    it("should bloquer quand même si la journalisation échoue (télémétrie best-effort)", async () => {
+      // getLocale n'est pas protégé en interne : s'il throw, le sign-in ne doit
+      // pas planter et le blocage doit rester effectif.
+      getLocale.mockRejectedValue(new Error("i18n context indisponible"));
+
+      await expect(evaluateBotSignIn({ provider: "google" })).resolves.toEqual({
+        shouldBlock: true,
+      });
+      expect(captureException).toHaveBeenCalled();
     });
 
     it("should émettre bot_detected avec blocked=true et le contexte de requête", async () => {

--- a/src/infrastructure/security/__tests__/bot-protection.test.ts
+++ b/src/infrastructure/security/__tests__/bot-protection.test.ts
@@ -10,7 +10,31 @@ vi.mock("@sentry/nextjs", () => ({
   captureException: (error: unknown) => captureException(error),
 }));
 
-import { isLikelyBot } from "../bot-protection";
+// `after()` exécute son callback immédiatement dans les tests pour observer
+// l'envoi de l'event sans dépendre du lifecycle de requête Next.js.
+const after = vi.fn((cb: () => unknown) => cb());
+vi.mock("next/server", () => ({
+  after: (cb: () => unknown) => after(cb),
+}));
+
+const getLocale = vi.fn();
+vi.mock("next-intl/server", () => ({
+  getLocale: () => getLocale(),
+}));
+
+const getRequestObservability = vi.fn();
+vi.mock("@/lib/auth/request-observability", () => ({
+  getRequestObservability: () => getRequestObservability(),
+}));
+
+const captureServerEvent = vi.fn();
+const getPosthogDistinctId = vi.fn();
+vi.mock("@/lib/posthog-server", () => ({
+  captureServerEvent: (...args: unknown[]) => captureServerEvent(...args),
+  getPosthogDistinctId: () => getPosthogDistinctId(),
+}));
+
+import { isLikelyBot, recordBotBlock } from "../bot-protection";
 
 describe("isLikelyBot (wrapper Vercel BotID)", () => {
   beforeEach(() => {
@@ -43,6 +67,80 @@ describe("isLikelyBot (wrapper Vercel BotID)", () => {
       checkBotId.mockRejectedValue(outage);
       await isLikelyBot();
       expect(captureException).toHaveBeenCalledWith(outage);
+    });
+  });
+});
+
+describe("recordBotBlock (journalisation des blocages BotID)", () => {
+  beforeEach(() => {
+    after.mockClear();
+    captureServerEvent.mockReset();
+    getLocale.mockReset();
+    getRequestObservability.mockReset();
+    getPosthogDistinctId.mockReset();
+    getLocale.mockResolvedValue("fr");
+    getRequestObservability.mockResolvedValue({
+      user_agent: "Mozilla/5.0 (X11; Linux) Firefox/126",
+      referer: "https://the-playground.fr/en/circles/tech-speak-her",
+    });
+    getPosthogDistinctId.mockResolvedValue("ph-distinct-123");
+  });
+
+  describe("given un blocage OAuth (Google)", () => {
+    it("should émettre un event bot_blocked avec le contexte de requête", async () => {
+      await recordBotBlock({ provider: "google" });
+
+      expect(captureServerEvent).toHaveBeenCalledWith(
+        "ph-distinct-123",
+        "bot_blocked",
+        {
+          provider: "google",
+          locale: "fr",
+          user_agent: "Mozilla/5.0 (X11; Linux) Firefox/126",
+          referer: "https://the-playground.fr/en/circles/tech-speak-her",
+        }
+      );
+    });
+
+    it("should détacher l'envoi via after() pour survivre au redirect", async () => {
+      await recordBotBlock({ provider: "google" });
+      expect(after).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("given un blocage magic link avec email", () => {
+    it("should ajouter le email_domain sans exposer l'adresse complète", async () => {
+      await recordBotBlock({ provider: "resend", email: "spammer@ibymail.com" });
+
+      expect(captureServerEvent).toHaveBeenCalledWith(
+        "ph-distinct-123",
+        "bot_blocked",
+        expect.objectContaining({ provider: "resend", email_domain: "ibymail.com" })
+      );
+    });
+  });
+
+  describe("given le cookie PostHog est absent (navigateur neuf / PostHog bloqué)", () => {
+    it("should retomber sur l'email comme distinct_id si disponible", async () => {
+      getPosthogDistinctId.mockResolvedValue(null);
+      await recordBotBlock({ provider: "resend", email: "spammer@ibymail.com" });
+
+      expect(captureServerEvent).toHaveBeenCalledWith(
+        "spammer@ibymail.com",
+        "bot_blocked",
+        expect.any(Object)
+      );
+    });
+
+    it("should retomber sur 'anonymous_bot' quand ni cookie ni email", async () => {
+      getPosthogDistinctId.mockResolvedValue(null);
+      await recordBotBlock({ provider: "github" });
+
+      expect(captureServerEvent).toHaveBeenCalledWith(
+        "anonymous_bot",
+        "bot_blocked",
+        expect.any(Object)
+      );
     });
   });
 });

--- a/src/infrastructure/security/__tests__/bot-protection.test.ts
+++ b/src/infrastructure/security/__tests__/bot-protection.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const checkBotId = vi.fn();
 vi.mock("botid/server", () => ({
@@ -34,7 +34,7 @@ vi.mock("@/lib/posthog-server", () => ({
   getPosthogDistinctId: () => getPosthogDistinctId(),
 }));
 
-import { isLikelyBot, recordBotBlock } from "../bot-protection";
+import { evaluateBotSignIn, getBotIdMode, isLikelyBot } from "../bot-protection";
 
 describe("isLikelyBot (wrapper Vercel BotID)", () => {
   beforeEach(() => {
@@ -71,9 +71,39 @@ describe("isLikelyBot (wrapper Vercel BotID)", () => {
   });
 });
 
-describe("recordBotBlock (journalisation des blocages BotID)", () => {
+describe("getBotIdMode (lecture de BOTID_MODE)", () => {
+  const ORIGINAL = process.env.BOTID_MODE;
+  afterEach(() => {
+    if (ORIGINAL === undefined) delete process.env.BOTID_MODE;
+    else process.env.BOTID_MODE = ORIGINAL;
+  });
+
+  it.each([
+    ["observe", "observe"],
+    ["off", "off"],
+    ["enforce", "enforce"],
+  ] as const)("should mapper %s -> %s", (raw, expected) => {
+    process.env.BOTID_MODE = raw;
+    expect(getBotIdMode()).toBe(expected);
+  });
+
+  it("should retomber sur enforce si la variable est absente", () => {
+    delete process.env.BOTID_MODE;
+    expect(getBotIdMode()).toBe("enforce");
+  });
+
+  it("should retomber sur enforce si la valeur est invalide", () => {
+    process.env.BOTID_MODE = "yolo";
+    expect(getBotIdMode()).toBe("enforce");
+  });
+});
+
+describe("evaluateBotSignIn (modes BotID + journalisation)", () => {
+  const ORIGINAL_MODE = process.env.BOTID_MODE;
+
   beforeEach(() => {
     after.mockClear();
+    checkBotId.mockReset();
     captureServerEvent.mockReset();
     getLocale.mockReset();
     getRequestObservability.mockReset();
@@ -86,15 +116,33 @@ describe("recordBotBlock (journalisation des blocages BotID)", () => {
     getPosthogDistinctId.mockResolvedValue("ph-distinct-123");
   });
 
-  describe("given un blocage OAuth (Google)", () => {
-    it("should émettre un event bot_blocked avec le contexte de requête", async () => {
-      await recordBotBlock({ provider: "google" });
+  afterEach(() => {
+    if (ORIGINAL_MODE === undefined) delete process.env.BOTID_MODE;
+    else process.env.BOTID_MODE = ORIGINAL_MODE;
+  });
+
+  describe("given mode enforce et un bot détecté", () => {
+    beforeEach(() => {
+      process.env.BOTID_MODE = "enforce";
+      checkBotId.mockResolvedValue({ isBot: true });
+    });
+
+    it("should demander le blocage", async () => {
+      await expect(evaluateBotSignIn({ provider: "google" })).resolves.toEqual({
+        shouldBlock: true,
+      });
+    });
+
+    it("should émettre bot_detected avec blocked=true et le contexte de requête", async () => {
+      await evaluateBotSignIn({ provider: "google" });
 
       expect(captureServerEvent).toHaveBeenCalledWith(
         "ph-distinct-123",
-        "bot_blocked",
+        "bot_detected",
         {
           provider: "google",
+          mode: "enforce",
+          blocked: true,
           locale: "fr",
           user_agent: "Mozilla/5.0 (X11; Linux) Firefox/126",
           referer: "https://the-playground.fr/en/circles/tech-speak-her",
@@ -103,42 +151,91 @@ describe("recordBotBlock (journalisation des blocages BotID)", () => {
     });
 
     it("should détacher l'envoi via after() pour survivre au redirect", async () => {
-      await recordBotBlock({ provider: "google" });
+      await evaluateBotSignIn({ provider: "google" });
       expect(after).toHaveBeenCalledTimes(1);
     });
-  });
 
-  describe("given un blocage magic link avec email", () => {
-    it("should ajouter le email_domain sans exposer l'adresse complète", async () => {
-      await recordBotBlock({ provider: "resend", email: "spammer@ibymail.com" });
+    it("should ajouter le email_domain pour le flux magic link sans exposer l'adresse", async () => {
+      await evaluateBotSignIn({ provider: "resend", email: "spammer@ibymail.com" });
 
       expect(captureServerEvent).toHaveBeenCalledWith(
         "ph-distinct-123",
-        "bot_blocked",
+        "bot_detected",
         expect.objectContaining({ provider: "resend", email_domain: "ibymail.com" })
       );
     });
   });
 
+  describe("given mode observe et un bot détecté", () => {
+    beforeEach(() => {
+      process.env.BOTID_MODE = "observe";
+      checkBotId.mockResolvedValue({ isBot: true });
+    });
+
+    it("should journaliser mais NE PAS bloquer (mesure des faux positifs)", async () => {
+      const result = await evaluateBotSignIn({ provider: "google" });
+
+      expect(result).toEqual({ shouldBlock: false });
+      expect(captureServerEvent).toHaveBeenCalledWith(
+        "ph-distinct-123",
+        "bot_detected",
+        expect.objectContaining({ mode: "observe", blocked: false })
+      );
+    });
+  });
+
+  describe("given mode off", () => {
+    beforeEach(() => {
+      process.env.BOTID_MODE = "off";
+      checkBotId.mockResolvedValue({ isBot: true });
+    });
+
+    it("should ne jamais appeler BotID ni journaliser (kill switch)", async () => {
+      const result = await evaluateBotSignIn({ provider: "google" });
+
+      expect(result).toEqual({ shouldBlock: false });
+      expect(checkBotId).not.toHaveBeenCalled();
+      expect(captureServerEvent).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("given une session humaine (non-bot) en mode enforce", () => {
+    beforeEach(() => {
+      process.env.BOTID_MODE = "enforce";
+      checkBotId.mockResolvedValue({ isBot: false });
+    });
+
+    it("should laisser passer sans journaliser", async () => {
+      const result = await evaluateBotSignIn({ provider: "google" });
+
+      expect(result).toEqual({ shouldBlock: false });
+      expect(captureServerEvent).not.toHaveBeenCalled();
+    });
+  });
+
   describe("given le cookie PostHog est absent (navigateur neuf / PostHog bloqué)", () => {
-    it("should retomber sur l'email comme distinct_id si disponible", async () => {
+    beforeEach(() => {
+      process.env.BOTID_MODE = "enforce";
+      checkBotId.mockResolvedValue({ isBot: true });
       getPosthogDistinctId.mockResolvedValue(null);
-      await recordBotBlock({ provider: "resend", email: "spammer@ibymail.com" });
+    });
+
+    it("should retomber sur l'email comme distinct_id si disponible", async () => {
+      await evaluateBotSignIn({ provider: "resend", email: "spammer@ibymail.com" });
 
       expect(captureServerEvent).toHaveBeenCalledWith(
         "spammer@ibymail.com",
-        "bot_blocked",
+        "bot_detected",
         expect.any(Object)
       );
     });
 
     it("should retomber sur 'anonymous_bot' quand ni cookie ni email", async () => {
-      getPosthogDistinctId.mockResolvedValue(null);
-      await recordBotBlock({ provider: "github" });
+      await evaluateBotSignIn({ provider: "github" });
 
       expect(captureServerEvent).toHaveBeenCalledWith(
         "anonymous_bot",
-        "bot_blocked",
+        "bot_detected",
         expect.any(Object)
       );
     });

--- a/src/infrastructure/security/bot-protection.ts
+++ b/src/infrastructure/security/bot-protection.ts
@@ -31,15 +31,56 @@ export async function isLikelyBot(): Promise<boolean> {
   }
 }
 
-/** Provider de connexion à l'origine du blocage BotID. */
+/** Provider de connexion à l'origine de la détection BotID. */
 export type BotBlockProvider = "google" | "github" | "resend";
 
 /**
- * Journalise un blocage BotID dans PostHog (event `bot_blocked`).
+ * Mode d'application de BotID au sign-in, piloté par la variable d'environnement
+ * `BOTID_MODE` (modifiable dans Vercel, prise en compte au prochain déploiement) :
  *
- * Objectif : mesurer le taux de blocage et distinguer un faux positif récurrent
+ * - `enforce` (défaut) : détecte, journalise **et bloque** le bot.
+ * - `observe` : détecte et journalise, mais **laisse passer** — sert à mesurer le
+ *   taux de faux positifs en prod sans pénaliser de vrais utilisateurs.
+ * - `off` : kill switch — ne vérifie même pas (aucun appel BotID, aucun event).
+ *
+ * Toute valeur absente ou invalide retombe sur `enforce` (sécurité par défaut).
+ */
+export type BotIdMode = "enforce" | "observe" | "off";
+
+export function getBotIdMode(): BotIdMode {
+  const mode = process.env.BOTID_MODE;
+  return mode === "observe" || mode === "off" ? mode : "enforce";
+}
+
+/**
+ * Évalue une tentative de sign-in vis-à-vis de BotID, en respectant `BOTID_MODE`.
+ *
+ * Retourne `shouldBlock` : l'appelant bloque (redirect OAuth / état d'erreur
+ * email) seulement si vrai. Toute détection (modes `enforce` et `observe`) est
+ * journalisée via `recordBotDetection`. En mode `off`, aucun appel BotID n'est
+ * fait et rien n'est journalisé.
+ */
+export async function evaluateBotSignIn(input: {
+  provider: BotBlockProvider;
+  email?: string;
+}): Promise<{ shouldBlock: boolean }> {
+  const mode = getBotIdMode();
+  if (mode === "off") return { shouldBlock: false };
+
+  if (!(await isLikelyBot())) return { shouldBlock: false };
+
+  await recordBotDetection({ ...input, mode });
+  return { shouldBlock: mode === "enforce" };
+}
+
+/**
+ * Journalise une détection BotID dans PostHog (event `bot_detected`).
+ *
+ * Objectif : mesurer le taux de détection et distinguer un faux positif récurrent
  * (ex. profil Firefox/Linux mal classé) d'une vraie attaque, sans avoir à
- * corréler à la main les navigations `?error=BotDetected` dans PostHog.
+ * corréler à la main les navigations `?error=BotDetected` dans PostHog. La
+ * propriété `blocked` distingue un vrai blocage (`enforce`) d'une simple
+ * observation (`observe`).
  *
  * - Le contexte (user-agent, referer, locale, `distinct_id` navigateur) est lu
  *   **dans le request context**, avant `after()`, pour rester fiable.
@@ -50,9 +91,10 @@ export type BotBlockProvider = "google" | "github" | "resend";
  *   (la page communauté visitée avant la tentative), rendant l'alerte
  *   directement actionnable.
  */
-export async function recordBotBlock(input: {
+async function recordBotDetection(input: {
   provider: BotBlockProvider;
   email?: string;
+  mode: Exclude<BotIdMode, "off">;
 }): Promise<void> {
   const [{ user_agent, referer }, locale, distinctId] = await Promise.all([
     getRequestObservability(),
@@ -62,6 +104,8 @@ export async function recordBotBlock(input: {
 
   const properties = {
     provider: input.provider,
+    mode: input.mode,
+    blocked: input.mode === "enforce",
     locale,
     user_agent,
     referer,
@@ -73,7 +117,7 @@ export async function recordBotBlock(input: {
   after(() =>
     captureServerEvent(
       distinctId ?? input.email ?? "anonymous_bot",
-      "bot_blocked",
+      "bot_detected",
       properties
     )
   );

--- a/src/infrastructure/security/bot-protection.ts
+++ b/src/infrastructure/security/bot-protection.ts
@@ -96,29 +96,36 @@ async function recordBotDetection(input: {
   email?: string;
   mode: Exclude<BotIdMode, "off">;
 }): Promise<void> {
-  const [{ user_agent, referer }, locale, distinctId] = await Promise.all([
-    getRequestObservability(),
-    getLocale(),
-    getPosthogDistinctId(),
-  ]);
+  // Télémétrie best-effort : ne doit JAMAIS faire échouer le sign-in. La collecte
+  // de contexte (notamment getLocale, non protégé en interne contrairement à
+  // getRequestObservability/getPosthogDistinctId) est donc entièrement gardée.
+  try {
+    const [{ user_agent, referer }, locale, distinctId] = await Promise.all([
+      getRequestObservability(),
+      getLocale(),
+      getPosthogDistinctId(),
+    ]);
 
-  const properties = {
-    provider: input.provider,
-    mode: input.mode,
-    blocked: input.mode === "enforce",
-    locale,
-    user_agent,
-    referer,
-    ...(input.email
-      ? { email_domain: input.email.split("@")[1] ?? "unknown" }
-      : {}),
-  };
+    const properties = {
+      provider: input.provider,
+      mode: input.mode,
+      blocked: input.mode === "enforce",
+      locale,
+      user_agent,
+      referer,
+      ...(input.email
+        ? { email_domain: input.email.split("@")[1] ?? "unknown" }
+        : {}),
+    };
 
-  after(() =>
-    captureServerEvent(
-      distinctId ?? input.email ?? "anonymous_bot",
-      "bot_detected",
-      properties
-    )
-  );
+    after(() =>
+      captureServerEvent(
+        distinctId ?? input.email ?? "anonymous_bot",
+        "bot_detected",
+        properties
+      )
+    );
+  } catch (error) {
+    Sentry.captureException(error);
+  }
 }

--- a/src/infrastructure/security/bot-protection.ts
+++ b/src/infrastructure/security/bot-protection.ts
@@ -1,5 +1,9 @@
 import * as Sentry from "@sentry/nextjs";
 import { checkBotId } from "botid/server";
+import { after } from "next/server";
+import { getLocale } from "next-intl/server";
+import { getRequestObservability } from "@/lib/auth/request-observability";
+import { captureServerEvent, getPosthogDistinctId } from "@/lib/posthog-server";
 
 /**
  * Vérifie, via Vercel BotID, si la requête en cours est classée comme bot.
@@ -25,4 +29,52 @@ export async function isLikelyBot(): Promise<boolean> {
     Sentry.captureException(error);
     return false;
   }
+}
+
+/** Provider de connexion à l'origine du blocage BotID. */
+export type BotBlockProvider = "google" | "github" | "resend";
+
+/**
+ * Journalise un blocage BotID dans PostHog (event `bot_blocked`).
+ *
+ * Objectif : mesurer le taux de blocage et distinguer un faux positif récurrent
+ * (ex. profil Firefox/Linux mal classé) d'une vraie attaque, sans avoir à
+ * corréler à la main les navigations `?error=BotDetected` dans PostHog.
+ *
+ * - Le contexte (user-agent, referer, locale, `distinct_id` navigateur) est lu
+ *   **dans le request context**, avant `after()`, pour rester fiable.
+ * - L'envoi réseau est détaché via `after()` : il ne bloque pas la réponse et
+ *   survit au `redirect()` qui suit côté OAuth. C'est ce qui évite le bug
+ *   fire-and-forget connu (events serveur perdus par intermittence sur Vercel).
+ * - Le `distinct_id` du cookie PostHog rattache l'event au parcours client
+ *   (la page communauté visitée avant la tentative), rendant l'alerte
+ *   directement actionnable.
+ */
+export async function recordBotBlock(input: {
+  provider: BotBlockProvider;
+  email?: string;
+}): Promise<void> {
+  const [{ user_agent, referer }, locale, distinctId] = await Promise.all([
+    getRequestObservability(),
+    getLocale(),
+    getPosthogDistinctId(),
+  ]);
+
+  const properties = {
+    provider: input.provider,
+    locale,
+    user_agent,
+    referer,
+    ...(input.email
+      ? { email_domain: input.email.split("@")[1] ?? "unknown" }
+      : {}),
+  };
+
+  after(() =>
+    captureServerEvent(
+      distinctId ?? input.email ?? "anonymous_bot",
+      "bot_blocked",
+      properties
+    )
+  );
 }

--- a/src/lib/posthog-server.ts
+++ b/src/lib/posthog-server.ts
@@ -4,8 +4,34 @@
  * Non-bloquant : une erreur ici ne doit jamais interrompre le flux utilisateur.
  */
 
+import { cookies } from "next/headers";
+
 const POSTHOG_KEY = process.env.NEXT_PUBLIC_POSTHOG_KEY;
 const POSTHOG_HOST = "https://eu.posthog.com";
+
+/**
+ * Récupère le `distinct_id` du navigateur depuis le cookie PostHog
+ * (`ph_<key>_posthog`), pour rattacher un event serveur à la même person et au
+ * même parcours que les events client ($pageview, etc.). Indispensable pour
+ * corréler un blocage serveur (ex. `bot_blocked`) avec la navigation qui l'a
+ * précédé, sans jointure manuelle.
+ *
+ * Renvoie `null` si le cookie est absent (navigateur neuf, PostHog bloqué) ou
+ * illisible — l'appelant retombe alors sur un identifiant de repli.
+ */
+export async function getPosthogDistinctId(): Promise<string | null> {
+  if (!POSTHOG_KEY) return null;
+  try {
+    const raw = (await cookies()).get(`ph_${POSTHOG_KEY}_posthog`)?.value;
+    if (!raw) return null;
+    // La valeur est un JSON, parfois URL-encodé selon le navigateur.
+    const json = raw.startsWith("{") ? raw : decodeURIComponent(raw);
+    const parsed = JSON.parse(json) as { distinct_id?: string };
+    return parsed.distinct_id ?? null;
+  } catch {
+    return null;
+  }
+}
 
 export async function captureServerEvent(
   distinctId: string,

--- a/src/lib/posthog-server.ts
+++ b/src/lib/posthog-server.ts
@@ -13,8 +13,8 @@ const POSTHOG_HOST = "https://eu.posthog.com";
  * Récupère le `distinct_id` du navigateur depuis le cookie PostHog
  * (`ph_<key>_posthog`), pour rattacher un event serveur à la même person et au
  * même parcours que les events client ($pageview, etc.). Indispensable pour
- * corréler un blocage serveur (ex. `bot_blocked`) avec la navigation qui l'a
- * précédé, sans jointure manuelle.
+ * corréler une détection serveur (ex. `bot_detected`) avec la navigation qui
+ * l'a précédée, sans jointure manuelle.
  *
  * Renvoie `null` si le cookie est absent (navigateur neuf, PostHog bloqué) ou
  * illisible — l'appelant retombe alors sur un identifiant de repli.


### PR DESCRIPTION
## Contexte

Suite à l'observation en prod de navigations `?error=BotDetected` (BotID a bloqué des sessions au sign-in), enquête PostHog : 2 acteurs distincts sur une soirée, **0 compte créé** (BotID a bien fermé la porte). Un cluster clairement malveillant (datacenter US, ciblage de la communauté `tech-speak-her`, retries automatisés) et un cluster probablement **faux positif humain** (Firefox/Linux, accès direct) bloqué **malgré Deep Analysis activé**.

Deux manques sont apparus :
1. Aucune observabilité fiable des blocages (on ne les voyait que par effet de bord dans PostHog).
2. Aucun moyen de débrancher ou d'observer BotID sans modifier le code.

## Ce que fait cette PR

### 1. Journalisation `bot_detected` (PostHog)
À chaque détection BotID, un event est émis avec `provider`, `mode`, `blocked`, `user_agent`, `referer`, `locale`, `email_domain`.
- Envoi détaché via `after()` (fiable, survit au `redirect()` OAuth, évite le bug fire-and-forget).
- `distinct_id` lu depuis le cookie PostHog → l'event serveur se rattache au **parcours client** (la page visitée avant la tentative), rendant l'analyse directement actionnable.

### 2. Kill switch 3 états via `BOTID_MODE`
Pilotable depuis Vercel, effet au prochain déploiement :
| Mode | Détecte | Journalise | Bloque |
|---|---|---|---|
| `enforce` (défaut) | ✅ | ✅ | ✅ |
| `observe` | ✅ | ✅ | ❌ (mesure des faux positifs sans pénaliser de vrais utilisateurs) |
| `off` | ❌ | ❌ | ❌ (kill switch total) |

Toute valeur absente/invalide retombe sur `enforce` (sécurité par défaut). Orchestration via `evaluateBotSignIn`, point d'entrée unique des 3 server actions de sign-in.

### 3. Robustesse (revue de code)
`recordBotDetection` est entièrement gardé : la télémétrie ne peut jamais faire échouer l'authentification, et le blocage reste effectif même si le logging échoue.

## Détails
- Event renommé `bot_blocked` → `bot_detected` (plus juste avec le mode `observe`).
- `BOTID_MODE` documenté dans `.env.example`.
- Note : la télémétrie serveur ne tourne qu'en production, l'event n'apparaîtra qu'une fois déployé.

## Tests
- 19 tests unitaires (3 modes, défaut/valeur invalide, observe ne bloque pas, off n'appelle pas BotID, replis distinct_id, logging incassable).
- `pnpm typecheck` vert.
- Schema Prisma non touché.

## Suite recommandée
Déployer en `enforce` (statu quo), laisser tourner la journalisation 1 à 2 semaines pour mesurer le vrai taux de faux positifs, puis arbitrer entre rester en `enforce` ou passer le sign-in en `observe` + durcir `contact_hosts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)