### PR TITLE
fix(security): réparer le challenge BotID cassé au sign-in (404 proxy via middleware)

### DIFF
--- a/src/__tests__/middleware.test.ts
+++ b/src/__tests__/middleware.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from "vitest";
+
+// L'environnement vitest (node) ne résout pas `next/server`. On mocke les
+// dépendances `next` du module middleware pour pouvoir importer son `config`
+// réel et tester le matcher (source de vérité, sans duplication).
+vi.mock("next/server", () => ({
+  NextResponse: { next: () => ({}), redirect: () => ({}) },
+}));
+vi.mock("next-intl/middleware", () => ({
+  default: () => () => ({}),
+}));
+
+import { config } from "@/middleware";
+
+// Verrouille le matcher du middleware next-intl. Régression critique couverte :
+// le proxy Vercel BotID (`/149e9513-.../...`, challenge servi en first-party)
+// NE DOIT PAS passer par next-intl, sinon ses appels sans extension renvoient
+// 404 et cassent le challenge (faux positifs + latence au sign-in). Les vraies
+// routes de l'app doivent au contraire toujours être prises en charge.
+describe("middleware matcher", () => {
+  const matcher = new RegExp(`^${config.matcher[0]}$`);
+
+  it.each([
+    // Proxy BotID — doit être IGNORÉ par le middleware
+    ["/149e9513-01fa-4fb0-aad4-566afd725d1b/2d206a39/proxy/x", false],
+    ["/149e9513-01fa-4fb0-aad4-566afd725d1b/abc/c.js", false],
+    // Infra technique — ignorée
+    ["/api/auth/session", false],
+    ["/_next/static/chunk.js", false],
+    ["/monitoring", false],
+    // Vraies routes app — le middleware DOIT tourner (i18n, gardes)
+    ["/", true],
+    ["/auth/sign-in", true],
+    ["/en/auth/sign-in", true],
+    ["/fr/circles/mon-cercle", true],
+    ["/dashboard", true],
+  ])("%s -> middleware actif = %s", (path, shouldRun) => {
+    expect(matcher.test(path)).toBe(shouldRun);
+  });
+});

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -92,5 +92,15 @@ export default function middleware(request: NextRequest) {
 export const config = {
   // `embed(?:/|$)` (vs simple `embed`) évite de matcher des paths futurs
   // comme /embedded-foo qui ne sont pas l'app widget embed.
-  matcher: ["/((?!api|_next|_vercel|monitoring|ingest|icon|embed(?:/|$)|.*\\..*).*)"],
+  //
+  // `149e9513-01fa-4fb0-aad4-566afd725d1b` = préfixe proxy FIXE de Vercel BotID
+  // (challenge servi en first-party via les rewrites de withBotId, cf.
+  // next.config.ts). Les chemins du challenge AVEC extension (.js) sont déjà
+  // exclus par `.*\\..*`, mais ses appels proxy SANS extension étaient captés
+  // par next-intl et renvoyés en 404 — cassant le challenge (faux positifs +
+  // latence au sign-in pour tous). Le matcher doit être un littéral statique
+  // (analysé au build), d'où l'UUID en dur. Constante documentée par Vercel.
+  matcher: [
+    "/((?!api|_next|_vercel|monitoring|ingest|icon|embed(?:/|$)|149e9513-01fa-4fb0-aad4-566afd725d1b|.*\\..*).*)",
+  ],
 };


### PR DESCRIPTION
## Incident

En prod, **tous** les utilisateurs (Chrome/macOS vanilla inclus) étaient soit **bloqués** au sign-in (`?error=BotDetected`), soit subissaient une **latence majeure** (« on dirait que c'est bloqué »). Découvert via PostHog puis reproduit en DevTools.

## Cause racine

Le challenge Vercel BotID est servi en first-party via des rewrites proxy (`/149e9513-01fa-4fb0-aad4-566afd725d1b/...`). Le **middleware next-intl** interceptait les appels proxy **sans extension** et les renvoyait en **404** (traités comme une route de locale inexistante). Les chemins avec `.js` passaient déjà (exclus par `.*\.*`), mais les appels dotless du challenge échouaient.

Confirmé empiriquement en prod :
- `GET /149e.../a-4-a/c.js` → **200** (rewrite OK, chemin exclu du middleware via le point)
- `GET|POST /149e.../<sans extension>` → **404** (capté par le middleware)

Conséquence : le challenge ne se complétait jamais → `checkBotId()` sans token valide → `isBot=true` + attente jusqu'au timeout. Le SDK client (`initBotId`) tournant indépendamment de `BOTID_MODE`, passer en `off` retirait le blocage serveur mais **pas** la latence client.

## Fix

Ajout du préfixe proxy BotID (constante fixe documentée par Vercel) aux exclusions du matcher du middleware next-intl. Les appels proxy tombent désormais dans le rewrite `afterFiles` → proxy → 200 → le challenge se complète.

## Fausses pistes écartées (documentées pour la postérité)
- **CSP** : ce sont des 404, pas des violations CSP.
- **Ordre de wrapping `withBotId`** dans `next.config.ts` : A/B local → les deux ordres produisent les mêmes rewrites. No-op, non retenu.

## Vérifications
- Regex du matcher testée : BotID exclu, toutes les vraies routes (`/auth/sign-in`, `/fr/circles/...`, `/`, `/dashboard`) continuent de passer par next-intl → zéro régression i18n.
- Test unitaire ajouté (10 cas) verrouillant l'exclusion.
- `pnpm typecheck` vert. Schema Prisma non touché.
- **À vérifier sur la preview avant merge** : `GET https://<preview>/149e9513-01fa-4fb0-aad4-566afd725d1b/2d206a39-8ed7-437e-a3be-862e0f06eea3/test` doit renvoyer autre chose que 404.

## Après merge
Remettre `BOTID_MODE=enforce` (la protection refonctionnera sans bloquer les humains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)