### PR TITLE
feat(auth): connexion avec LinkedIn (OIDC)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,6 +67,13 @@ AUTH_GOOGLE_SECRET=""
 AUTH_GITHUB_ID=""
 AUTH_GITHUB_SECRET=""
 
+# Option D — LinkedIn OAuth (OpenID Connect)
+#   1. https://www.linkedin.com/developers/apps → "Create app" (rattachée à une Page entreprise)
+#   2. Onglet Products → activer "Sign In with LinkedIn using OpenID Connect"
+#   3. Onglet Auth → Authorized redirect URL : http://localhost:3000/api/auth/callback/linkedin
+AUTH_LINKEDIN_ID=""
+AUTH_LINKEDIN_SECRET=""
+
 
 # ── [OPTION] Stripe Connect (paiements événements) ───────────────────────────
 # Sans ces clés, les événements payants sont KO (mais les gratuits fonctionnent).

--- a/messages/en.json
+++ b/messages/en.json
@@ -146,7 +146,7 @@
       "disposableEmail": "Disposable email addresses are not allowed. Please use a permanent address.",
       "sendFailed": "Couldn't send the email right now. Please try again in a moment.",
       "botDetected": "Security verification failed. Please reload the page and try again.",
-      "webviewNotice": "You're using an in-app browser (LinkedIn, Instagram...). Use the email sign-in below, it works everywhere. To sign in with Google or GitHub, open the site in your browser (Safari, Chrome...)."
+      "webviewNotice": "You're using an in-app browser (LinkedIn, Instagram...). Use the email sign-in below, it works everywhere. To sign in with Google, GitHub or LinkedIn, open the site in your browser (Safari, Chrome...)."
     },
     "verifyRequest": {
       "title": "Check your email",

--- a/messages/en.json
+++ b/messages/en.json
@@ -1681,7 +1681,7 @@
         "stepsLabel": "On the event page:",
         "step1": "Read the details: date, location, description, number of attendees",
         "step2": "Click <strong>Join</strong>",
-        "step3": "If you don't have an account yet, you can sign in in seconds (magic link by email or via Google / GitHub) — no form to fill out",
+        "step3": "If you don't have an account yet, you can sign in in seconds (magic link by email or via Google, GitHub or LinkedIn) — no form to fill out",
         "step4": "Once registered, you receive a <strong>confirmation email</strong> with the details and a link to add the event to your calendar (Google Calendar, Apple Calendar, or .ics file)",
         "callout": "No prior account is needed to view an event page. Registration takes less than a minute.",
         "approvalNote": "Some events require approval by the organizer. In that case, the button reads “Join (subject to approval)”. Your request is sent to the organizer, and you receive a confirmation email once it is accepted. If your request is declined, you are notified by email. While your request is pending, it appears in Dashboard with the status “Pending approval”."
@@ -1929,7 +1929,7 @@
       },
       "q5": {
         "question": "Do attendees need an account to register?",
-        "answer": "They need to create an account, but the process is very quick: an email is enough (magic link, no password), or sign in with Google / GitHub. No long forms."
+        "answer": "They need to create an account, but the process is very quick: an email is enough (magic link, no password), or sign in with Google, GitHub or LinkedIn. No long forms."
       },
       "q6": {
         "question": "How do I access or delete my data?",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1681,7 +1681,7 @@
         "stepsLabel": "Sur la page de l'événement :",
         "step1": "Lisez les informations : date, lieu, description, nombre de participants",
         "step2": "Cliquez sur <strong>S'inscrire</strong>",
-        "step3": "Si vous n'avez pas encore de compte, vous pouvez vous connecter en quelques secondes (lien magique par email ou via Google / GitHub) — aucun formulaire à remplir",
+        "step3": "Si vous n'avez pas encore de compte, vous pouvez vous connecter en quelques secondes (lien magique par email ou via Google, GitHub ou LinkedIn) — aucun formulaire à remplir",
         "step4": "Une fois inscrit, vous recevez un <strong>email de confirmation</strong> avec les détails et un lien pour ajouter l'événement à votre calendrier (Google Calendar, Apple Calendar, ou fichier .ics)",
         "callout": "Aucun compte préalable n'est nécessaire pour voir la page d'un événement. L'inscription se fait en moins d'une minute.",
         "approvalNote": "Certains événements requièrent une validation par l'organisateur. Dans ce cas, le bouton affiche « S'inscrire (soumis à validation) ». Votre demande est transmise à l'organisateur, et vous recevez un email de confirmation dès qu'elle est acceptée. Si votre demande est refusée, vous en êtes notifié par email. Tant que votre demande est en attente, elle apparaît dans Mon espace avec le statut « En attente de validation »."
@@ -1929,7 +1929,7 @@
       },
       "q5": {
         "question": "Les participants ont-ils besoin d'un compte pour s'inscrire ?",
-        "answer": "Ils doivent créer un compte, mais le processus est très rapide : un email suffit (lien magique, sans mot de passe), ou une connexion Google / GitHub. Aucun formulaire long."
+        "answer": "Ils doivent créer un compte, mais le processus est très rapide : un email suffit (lien magique, sans mot de passe), ou une connexion Google, GitHub ou LinkedIn. Aucun formulaire long."
       },
       "q6": {
         "question": "Comment récupérer ou supprimer mes données ?",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -146,7 +146,7 @@
       "disposableEmail": "Les adresses email jetables ne sont pas acceptées. Utilisez une adresse permanente.",
       "sendFailed": "Impossible d'envoyer l'email pour le moment. Réessayez dans un instant.",
       "botDetected": "La vérification de sécurité a échoué. Rechargez la page et réessayez.",
-      "webviewNotice": "Vous utilisez un navigateur intégré (LinkedIn, Instagram...). Utilisez la connexion par email ci-dessous, elle fonctionne partout. Pour vous connecter avec Google ou GitHub, ouvrez le site dans votre navigateur (Safari, Chrome...)."
+      "webviewNotice": "Vous utilisez un navigateur intégré (LinkedIn, Instagram...). Utilisez la connexion par email ci-dessous, elle fonctionne partout. Pour vous connecter avec Google, GitHub ou LinkedIn, ouvrez le site dans votre navigateur (Safari, Chrome...)."
     },
     "verifyRequest": {
       "title": "Vérifiez votre email",

--- a/spec/features/linkedin-oauth.md
+++ b/spec/features/linkedin-oauth.md
@@ -47,30 +47,30 @@ uploadé manuellement.
 > fonctionnera pas sur les URLs de preview Vercel dynamiques. Google/GitHub/magic
 > link couvrent la preview.
 
-## Auto-remplissage du champ « LinkedIn » du profil — BLOQUÉ (décision en attente)
+## Données récupérées à la connexion
 
-**Exigence demandée** : à la connexion LinkedIn, renseigner automatiquement le
-champ `linkedinUrl` du profil de l'utilisateur (`prisma/schema.prisma:149`).
+LinkedIn OIDC (scopes `openid profile email`) renvoie : `sub`, `name`,
+`given_name`, `family_name`, `picture`, `email`, `email_verified`, `locale`.
 
-**Constat technique** : ce n'est **pas réalisable** avec le produit OIDC standard
-de LinkedIn. Les scopes disponibles (`openid profile email`) renvoient uniquement :
-`sub`, `name`, `given_name`, `family_name`, `picture`, `email`, `email_verified`,
-`locale`. **Aucune URL de profil publique n'est exposée.** Le claim `sub` est un
-identifiant membre opaque, qui ne permet pas de reconstruire une URL
-`linkedin.com/in/...`.
+Captés **automatiquement** par Auth.js / l'adapter Prisma, sans code dédié :
 
-L'ancien scope `r_liteprofile` exposait un `vanityName` (d'où on pouvait dériver
-l'URL), mais il est déprécié et indisponible pour les nouvelles apps.
+- **Email** (`email`) — enregistré sur le `User` à la création / liaison du compte,
+  comme pour Google et GitHub.
+- **Nom** (`name`) — idem.
+- **Avatar** (`picture`) — synchronisé par le callback `signIn` existant
+  (`rawProfile.picture`), sans écraser un avatar uploadé manuellement.
 
-**Options :**
+## Auto-remplissage du champ « LinkedIn » du profil — ABANDONNÉ (décision prise)
 
-1. **Abandonner l'auto-remplissage** (recommandé) — techniquement impossible
-   proprement. On s'en tient au cœur OAuth. Le champ `linkedinUrl` reste rempli
-   manuellement par l'utilisateur dans son profil, comme aujourd'hui.
-2. **Nudge à l'onboarding** — après une première connexion LinkedIn, si
-   `linkedinUrl` est vide, proposer (sans pré-remplir) d'ajouter son profil
-   LinkedIn dans l'écran de setup. Ne remplit pas « automatiquement », mais
-   capitalise sur le contexte.
+**Exigence initiale** : à la connexion LinkedIn, renseigner automatiquement le
+champ `linkedinUrl` du profil (`prisma/schema.prisma:149`).
 
-> Décision à trancher avant de coder cette partie. Le reste de la feature
-> (connexion LinkedIn) est fonctionnel indépendamment.
+**Décision (2026-06-15) : abandonné.** Techniquement impossible avec le produit
+OIDC standard de LinkedIn : aucune URL de profil publique n'est exposée dans les
+claims. Le `sub` est un identifiant membre opaque, qui ne permet pas de
+reconstruire une URL `linkedin.com/in/...`. L'ancien scope `r_liteprofile`
+(`vanityName`) est déprécié et indisponible pour les nouvelles apps.
+
+Le champ `linkedinUrl` reste donc rempli manuellement par l'utilisateur dans son
+profil, comme aujourd'hui. L'email, le nom et l'avatar sont eux récupérés
+automatiquement (cf. section ci-dessus).

--- a/spec/features/linkedin-oauth.md
+++ b/spec/features/linkedin-oauth.md
@@ -1,0 +1,76 @@
+# Connexion avec LinkedIn (OAuth / OIDC)
+
+Issue : [#541](https://github.com/DragosDreptate/the-playground/issues/541)
+
+## Objectif
+
+Ajouter LinkedIn comme 3ᵉ fournisseur de connexion (à côté de Google et GitHub),
+via Auth.js v5. L'audience de The Playground (organisateurs et participants de
+communautés professionnelles) est fortement présente sur LinkedIn : ce canal
+réduit la friction d'inscription.
+
+## Périmètre implémenté
+
+| Couche | Fichier | Détail |
+|---|---|---|
+| Provider | `src/infrastructure/auth/auth.config.ts` | `LinkedIn({ allowDangerousEmailAccountLinking: true })`. OIDC, `email_verified` fourni : même mitigation que Google. |
+| Anti-bot | `src/infrastructure/security/bot-protection.ts` | `"linkedin"` ajouté au type `BotBlockProvider`. |
+| Server action | `src/app/actions/auth.ts` | `signInWithLinkedIn` (calquée sur `signInWithGoogle`, passe par `redirectIfBot("linkedin")`). |
+| UI | `src/components/auth/sign-in-form.tsx` | Bouton `outline` + icône LinkedIn (lucide), dans les branches normale et webview. |
+| i18n | `messages/fr.json` / `en.json` | Clés `Auth.signIn.linkedin` (déjà présentes). Page Aide mise à jour (`participant.inscription.step3`, `faq.q5.answer`). |
+| Config | `.env.example` | `AUTH_LINKEDIN_ID` / `AUTH_LINKEDIN_SECRET` documentées (Option D). |
+
+### Protection BotID
+
+La page `/auth/sign-in` est déjà déclarée dans `initBotId({ protect: [...] })`
+(`src/instrumentation-client.ts`). La nouvelle action vit sur cette page : elle
+est couverte sans modification supplémentaire.
+
+### Avatar
+
+LinkedIn OIDC renvoie le claim `picture` (CDN licdn.com). Le callback `signIn`
+existant le synchronise déjà via `rawProfile.picture`, sans écraser un avatar
+uploadé manuellement.
+
+## Setup requis (hors code)
+
+1. App LinkedIn Developer rattachée à la Page entreprise `the-playground-events`.
+2. Produit « Sign In with LinkedIn using OpenID Connect » activé.
+3. Authorized redirect URLs :
+   - `http://localhost:3000/api/auth/callback/linkedin`
+   - `https://the-playground.fr/api/auth/callback/linkedin`
+4. Variables d'env `AUTH_LINKEDIN_ID` / `AUTH_LINKEDIN_SECRET` :
+   - `.env.local` (déjà fait en local)
+   - Vercel Production **et** Preview (à faire)
+
+> LinkedIn n'accepte pas de wildcard de domaine : la connexion LinkedIn ne
+> fonctionnera pas sur les URLs de preview Vercel dynamiques. Google/GitHub/magic
+> link couvrent la preview.
+
+## Auto-remplissage du champ « LinkedIn » du profil — BLOQUÉ (décision en attente)
+
+**Exigence demandée** : à la connexion LinkedIn, renseigner automatiquement le
+champ `linkedinUrl` du profil de l'utilisateur (`prisma/schema.prisma:149`).
+
+**Constat technique** : ce n'est **pas réalisable** avec le produit OIDC standard
+de LinkedIn. Les scopes disponibles (`openid profile email`) renvoient uniquement :
+`sub`, `name`, `given_name`, `family_name`, `picture`, `email`, `email_verified`,
+`locale`. **Aucune URL de profil publique n'est exposée.** Le claim `sub` est un
+identifiant membre opaque, qui ne permet pas de reconstruire une URL
+`linkedin.com/in/...`.
+
+L'ancien scope `r_liteprofile` exposait un `vanityName` (d'où on pouvait dériver
+l'URL), mais il est déprécié et indisponible pour les nouvelles apps.
+
+**Options :**
+
+1. **Abandonner l'auto-remplissage** (recommandé) — techniquement impossible
+   proprement. On s'en tient au cœur OAuth. Le champ `linkedinUrl` reste rempli
+   manuellement par l'utilisateur dans son profil, comme aujourd'hui.
+2. **Nudge à l'onboarding** — après une première connexion LinkedIn, si
+   `linkedinUrl` est vide, proposer (sans pré-remplir) d'ajouter son profil
+   LinkedIn dans l'écran de setup. Ne remplit pas « automatiquement », mais
+   capitalise sur le contexte.
+
+> Décision à trancher avant de coder cette partie. Le reste de la feature
+> (connexion LinkedIn) est fonctionnel indépendamment.

--- a/src/app/actions/auth.ts
+++ b/src/app/actions/auth.ts
@@ -43,32 +43,34 @@ async function signInPath() {
 // être bloquée, redirige vers la page de connexion. Le redirect interrompt
 // l'action, donc l'appelant ne poursuit pas vers signIn(). La journalisation
 // éventuelle est gérée dans evaluateBotSignIn.
-async function redirectIfBot(provider: "google" | "github" | "linkedin") {
+type OAuthProvider = "google" | "github" | "linkedin";
+
+async function redirectIfBot(provider: OAuthProvider) {
   const { shouldBlock } = await evaluateBotSignIn({ provider });
   if (shouldBlock) redirect(`${await signInPath()}?error=BotDetected`);
 }
 
-export async function signInWithGitHub(formData: FormData) {
-  await redirectIfBot("github");
+// Flux OAuth générique partagé par tous les fournisseurs : protection BotID,
+// mémorisation du callbackUrl, puis délégation à Auth.js. Toujours passer par le
+// setup : la page setup redirige vers callbackUrl si le profil est déjà complété,
+// sinon affiche le formulaire.
+async function signInWithOAuth(provider: OAuthProvider, formData: FormData) {
+  await redirectIfBot(provider);
   const callbackUrl = safeCallbackUrl(formData.get("callbackUrl") as string);
   if (callbackUrl) await setCallbackCookie(callbackUrl);
-  // Toujours passer par le setup : la page setup redirige vers callbackUrl
-  // si le profil est déjà complété, sinon affiche le formulaire.
-  await signIn("github", { redirectTo: await postSignInRedirectTo() });
+  await signIn(provider, { redirectTo: await postSignInRedirectTo() });
+}
+
+export async function signInWithGitHub(formData: FormData) {
+  await signInWithOAuth("github", formData);
 }
 
 export async function signInWithGoogle(formData: FormData) {
-  await redirectIfBot("google");
-  const callbackUrl = safeCallbackUrl(formData.get("callbackUrl") as string);
-  if (callbackUrl) await setCallbackCookie(callbackUrl);
-  await signIn("google", { redirectTo: await postSignInRedirectTo() });
+  await signInWithOAuth("google", formData);
 }
 
 export async function signInWithLinkedIn(formData: FormData) {
-  await redirectIfBot("linkedin");
-  const callbackUrl = safeCallbackUrl(formData.get("callbackUrl") as string);
-  if (callbackUrl) await setCallbackCookie(callbackUrl);
-  await signIn("linkedin", { redirectTo: await postSignInRedirectTo() });
+  await signInWithOAuth("linkedin", formData);
 }
 
 export type SignInWithEmailState =

--- a/src/app/actions/auth.ts
+++ b/src/app/actions/auth.ts
@@ -43,7 +43,7 @@ async function signInPath() {
 // être bloquée, redirige vers la page de connexion. Le redirect interrompt
 // l'action, donc l'appelant ne poursuit pas vers signIn(). La journalisation
 // éventuelle est gérée dans evaluateBotSignIn.
-async function redirectIfBot(provider: "google" | "github") {
+async function redirectIfBot(provider: "google" | "github" | "linkedin") {
   const { shouldBlock } = await evaluateBotSignIn({ provider });
   if (shouldBlock) redirect(`${await signInPath()}?error=BotDetected`);
 }
@@ -62,6 +62,13 @@ export async function signInWithGoogle(formData: FormData) {
   const callbackUrl = safeCallbackUrl(formData.get("callbackUrl") as string);
   if (callbackUrl) await setCallbackCookie(callbackUrl);
   await signIn("google", { redirectTo: await postSignInRedirectTo() });
+}
+
+export async function signInWithLinkedIn(formData: FormData) {
+  await redirectIfBot("linkedin");
+  const callbackUrl = safeCallbackUrl(formData.get("callbackUrl") as string);
+  if (callbackUrl) await setCallbackCookie(callbackUrl);
+  await signIn("linkedin", { redirectTo: await postSignInRedirectTo() });
 }
 
 export type SignInWithEmailState =

--- a/src/components/auth/sign-in-form.tsx
+++ b/src/components/auth/sign-in-form.tsx
@@ -6,7 +6,7 @@ import { useFormStatus } from "react-dom";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
-import { Github, Linkedin, Loader2, Mail } from "lucide-react";
+import { Github, Loader2, Mail } from "lucide-react";
 import {
   signInWithGitHub,
   signInWithGoogle,
@@ -23,6 +23,17 @@ function GoogleIcon() {
       <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853" />
       <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l3.66-2.84z" fill="#FBBC05" />
       <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335" />
+    </svg>
+  );
+}
+
+function LinkedInIcon() {
+  return (
+    <svg viewBox="0 0 24 24" className="size-4" aria-hidden="true">
+      <path
+        fill="#0A66C2"
+        d="M20.45 20.45h-3.56v-5.57c0-1.33-.02-3.04-1.85-3.04-1.85 0-2.13 1.45-2.13 2.94v5.67H9.35V9h3.41v1.56h.05c.48-.9 1.64-1.85 3.37-1.85 3.6 0 4.27 2.37 4.27 5.45v6.29zM5.34 7.43a2.06 2.06 0 1 1 0-4.13 2.06 2.06 0 0 1 0 4.13zM7.12 20.45H3.56V9h3.56v11.45zM22.22 0H1.77C.8 0 0 .78 0 1.74v20.52C0 23.22.8 24 1.77 24h20.45c.97 0 1.78-.78 1.78-1.74V1.74C24 .78 23.19 0 22.22 0z"
+      />
     </svg>
   );
 }
@@ -94,8 +105,8 @@ export function SignInForm({ callbackUrl, error }: SignInFormProps) {
         {webview ? (
           <>
             <DisabledOAuthButton label={t("signIn.google")} icon={<GoogleIcon />} />
+            <DisabledOAuthButton label={t("signIn.linkedin")} icon={<LinkedInIcon />} />
             <DisabledOAuthButton label={t("signIn.github")} icon={<Github className="size-4" />} />
-            <DisabledOAuthButton label={t("signIn.linkedin")} icon={<Linkedin className="size-4" />} />
           </>
         ) : (
           <>
@@ -103,13 +114,13 @@ export function SignInForm({ callbackUrl, error }: SignInFormProps) {
               {callbackUrl && <input type="hidden" name="callbackUrl" value={callbackUrl} />}
               <SubmitButton label={t("signIn.google")} icon={<GoogleIcon />} variant="outline" />
             </form>
+            <form action={signInWithLinkedIn}>
+              {callbackUrl && <input type="hidden" name="callbackUrl" value={callbackUrl} />}
+              <SubmitButton label={t("signIn.linkedin")} icon={<LinkedInIcon />} variant="outline" />
+            </form>
             <form action={signInWithGitHub}>
               {callbackUrl && <input type="hidden" name="callbackUrl" value={callbackUrl} />}
               <SubmitButton label={t("signIn.github")} icon={<Github className="size-4" />} variant="outline" />
-            </form>
-            <form action={signInWithLinkedIn}>
-              {callbackUrl && <input type="hidden" name="callbackUrl" value={callbackUrl} />}
-              <SubmitButton label={t("signIn.linkedin")} icon={<Linkedin className="size-4" />} variant="outline" />
             </form>
           </>
         )}

--- a/src/components/auth/sign-in-form.tsx
+++ b/src/components/auth/sign-in-form.tsx
@@ -6,10 +6,11 @@ import { useFormStatus } from "react-dom";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
-import { Github, Loader2, Mail } from "lucide-react";
+import { Github, Linkedin, Loader2, Mail } from "lucide-react";
 import {
   signInWithGitHub,
   signInWithGoogle,
+  signInWithLinkedIn,
   signInWithEmail,
   type SignInWithEmailState,
 } from "@/app/actions/auth";
@@ -94,6 +95,7 @@ export function SignInForm({ callbackUrl, error }: SignInFormProps) {
           <>
             <DisabledOAuthButton label={t("signIn.google")} icon={<GoogleIcon />} />
             <DisabledOAuthButton label={t("signIn.github")} icon={<Github className="size-4" />} />
+            <DisabledOAuthButton label={t("signIn.linkedin")} icon={<Linkedin className="size-4" />} />
           </>
         ) : (
           <>
@@ -104,6 +106,10 @@ export function SignInForm({ callbackUrl, error }: SignInFormProps) {
             <form action={signInWithGitHub}>
               {callbackUrl && <input type="hidden" name="callbackUrl" value={callbackUrl} />}
               <SubmitButton label={t("signIn.github")} icon={<Github className="size-4" />} variant="outline" />
+            </form>
+            <form action={signInWithLinkedIn}>
+              {callbackUrl && <input type="hidden" name="callbackUrl" value={callbackUrl} />}
+              <SubmitButton label={t("signIn.linkedin")} icon={<Linkedin className="size-4" />} variant="outline" />
             </form>
           </>
         )}

--- a/src/infrastructure/auth/auth.config.ts
+++ b/src/infrastructure/auth/auth.config.ts
@@ -2,6 +2,7 @@ import * as Sentry from "@sentry/nextjs";
 import NextAuth from "next-auth";
 import GitHub from "next-auth/providers/github";
 import Google from "next-auth/providers/google";
+import LinkedIn from "next-auth/providers/linkedin";
 import ResendProvider from "next-auth/providers/resend";
 import { PrismaAdapter } from "@auth/prisma-adapter";
 import { getTranslations } from "next-intl/server";
@@ -55,9 +56,11 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
     // feedback. Risque : un attaquant qui contrôlerait un compte OAuth avec un
     // email primaire correspondant à un User existant pourrait usurper. Mitigé
     // pour Google (email_verified=true requis via OIDC) et pour GitHub (verif
-    // email obligatoire avant de marquer une adresse comme primary).
+    // email obligatoire avant de marquer une adresse comme primary). LinkedIn
+    // est OIDC et renvoie également email_verified : même mitigation que Google.
     GitHub({ allowDangerousEmailAccountLinking: true }),
     Google({ allowDangerousEmailAccountLinking: true }),
+    LinkedIn({ allowDangerousEmailAccountLinking: true }),
     ResendProvider({
       apiKey: process.env.AUTH_RESEND_KEY,
       from: process.env.EMAIL_FROM ?? "onboarding@resend.dev",

--- a/src/infrastructure/security/bot-protection.ts
+++ b/src/infrastructure/security/bot-protection.ts
@@ -32,7 +32,7 @@ export async function isLikelyBot(): Promise<boolean> {
 }
 
 /** Provider de connexion à l'origine de la détection BotID. */
-export type BotBlockProvider = "google" | "github" | "resend";
+export type BotBlockProvider = "google" | "github" | "linkedin" | "resend";
 
 /**
  * Mode d'application de BotID au sign-in, piloté par la variable d'environnement


### PR DESCRIPTION
## Objectif

Ajoute **LinkedIn** comme 3ᵉ fournisseur de connexion (à côté de Google et GitHub), via Auth.js v5. L'audience de The Playground (communautés professionnelles) est fortement présente sur LinkedIn : ce canal réduit la friction d'inscription.

Closes #541

## Changements

- **Provider** OIDC LinkedIn dans `auth.config.ts` (`allowDangerousEmailAccountLinking`, même posture que Google). L'avatar (`picture`), l'email et le nom sont captés automatiquement par Auth.js.
- **Server action** `signInWithLinkedIn`, intégrée à la protection **BotID**. Au passage, les 3 actions OAuth sont factorisées dans un helper `signInWithOAuth`.
- **Bouton** LinkedIn sur la page de connexion, entre Google et GitHub, avec le logo officiel en bleu (`#0A66C2`). Branches normale et webview couvertes.
- **Page Aide** + message webview mis à jour (FR + EN) pour mentionner LinkedIn.
- **`.env.example`** documente `AUTH_LINKEDIN_ID` / `AUTH_LINKEDIN_SECRET`.
- **`spec/features/linkedin-oauth.md`** : spec de la feature, dont la décision d'**abandonner l'auto-remplissage du champ `linkedinUrl`** (non exposé par LinkedIn OIDC).

## Auto-remplissage du profil LinkedIn — abandonné (décidé)

LinkedIn OIDC (`openid profile email`) ne renvoie aucune URL de profil publique (le `sub` est opaque). Le champ `linkedinUrl` reste donc rempli manuellement. Email, nom et avatar sont eux récupérés automatiquement.

## ⚠️ Avant la mise en prod

- Configurer `AUTH_LINKEDIN_ID` / `AUTH_LINKEDIN_SECRET` sur **Vercel (Production + Preview)**.
- Vérifier les redirect URLs LinkedIn (`localhost` + `the-playground.fr/api/auth/callback/linkedin`).
- LinkedIn n'accepte pas de wildcard : la connexion LinkedIn ne marchera pas sur les previews Vercel dynamiques (Google/GitHub/magic link couvrent la preview).

## Notes

- Pas de changement de schema Prisma.
- `/code-review` passé (findings #2 copy webview et #3 factorisation appliqués ; #1 laissé volontairement, posture identique à Google/GitHub).

🤖 Generated with [Claude Code](https://claude.com/claude-code)