### PR TITLE
fix(auth): porte le callbackUrl dans l'URL du magic link

### DIFF
--- a/src/app/actions/auth.ts
+++ b/src/app/actions/auth.ts
@@ -9,6 +9,7 @@ import { routing } from "@/i18n/routing";
 import { isValidEmail } from "@/lib/email";
 import { isDisposableEmailDomain } from "@/lib/email/disposable-domains";
 import { safeCallbackUrl } from "@/lib/url";
+import { buildSetupRedirectPath } from "@/lib/auth/post-sign-in-redirect";
 
 async function setCallbackCookie(callbackUrl: string) {
   (await cookies()).set("auth-callback-url", callbackUrl, {
@@ -18,15 +19,11 @@ async function setCallbackCookie(callbackUrl: string) {
   });
 }
 
-// Le prefix locale dans le `redirectTo` est ce qui permet à
-// `detectLocaleForMagicLink` (côté sendVerificationRequest) de servir le mail
-// dans la bonne langue, indépendamment du cookie NEXT_LOCALE ou du header
-// Accept-Language du navigateur. Cf. spec/magic-link-reusable-token.md (sujet
-// 5). Pour les flows OAuth c'est cosmétique (le middleware next-intl
-// canonicalisera l'URL).
-async function postSignInRedirectTo() {
-  const locale = await getLocale();
-  return `/${locale}/dashboard/profile/setup`;
+// Cible post-connexion. La construction (préfixe locale + portage du
+// callbackUrl dans la query) et ses invariants sont documentés dans
+// `buildSetupRedirectPath`. Cf. spec/magic-link-reusable-token.md (sujet 5).
+async function postSignInRedirectTo(callbackUrl?: string) {
+  return buildSetupRedirectPath(await getLocale(), callbackUrl);
 }
 
 // Page de connexion dans la locale courante (locale par défaut sans préfixe,
@@ -58,7 +55,7 @@ async function signInWithOAuth(provider: OAuthProvider, formData: FormData) {
   await redirectIfBot(provider);
   const callbackUrl = safeCallbackUrl(formData.get("callbackUrl") as string);
   if (callbackUrl) await setCallbackCookie(callbackUrl);
-  await signIn(provider, { redirectTo: await postSignInRedirectTo() });
+  await signIn(provider, { redirectTo: await postSignInRedirectTo(callbackUrl) });
 }
 
 export async function signInWithGitHub(formData: FormData) {
@@ -95,7 +92,10 @@ export async function signInWithEmail(
   const callbackUrl = safeCallbackUrl(formData.get("callbackUrl") as string);
   if (callbackUrl) await setCallbackCookie(callbackUrl);
   try {
-    await signIn("resend", { email, redirectTo: await postSignInRedirectTo() });
+    await signIn("resend", {
+      email,
+      redirectTo: await postSignInRedirectTo(callbackUrl),
+    });
   } catch (error) {
     // Relance les erreurs spéciales Next.js (redirect, notFound) pour préserver le flow nominal.
     unstable_rethrow(error);

--- a/src/lib/auth/__tests__/magic-link-url.test.ts
+++ b/src/lib/auth/__tests__/magic-link-url.test.ts
@@ -30,6 +30,16 @@ describe("detectLocaleForMagicLink", () => {
       expect(detectLocaleForMagicLink(url, makeRequest())).toBe("fr");
     });
 
+    // Non-régression : depuis le portage du callbackUrl dans la query, le
+    // `redirectTo` Auth.js vaut `/${locale}/dashboard/profile/setup?callbackUrl=...`.
+    // La langue doit toujours se déduire du préfixe de tête, pas du param imbriqué.
+    it.each([
+      ["/fr/dashboard/profile/setup?callbackUrl=/m/foo", "fr"],
+      ["/en/dashboard/profile/setup?callbackUrl=/en/m/foo", "en"],
+    ])("should read the head locale prefix of a setup redirect (%s)", (callback, expected) => {
+      expect(detectLocaleForMagicLink(authUrl(callback), makeRequest())).toBe(expected);
+    });
+
     it("should beat the cookie when the prefix says otherwise", () => {
       const request = makeRequest({ cookie: "NEXT_LOCALE=en" });
       expect(detectLocaleForMagicLink(authUrl("/fr/m/foo"), request)).toBe("fr");

--- a/src/lib/auth/__tests__/post-sign-in-redirect.test.ts
+++ b/src/lib/auth/__tests__/post-sign-in-redirect.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { buildSetupRedirectPath } from "@/lib/auth/post-sign-in-redirect";
+
+describe("buildSetupRedirectPath", () => {
+  describe("given no callbackUrl", () => {
+    it.each([
+      ["fr", "/fr/dashboard/profile/setup"],
+      ["en", "/en/dashboard/profile/setup"],
+    ])("should return the bare setup path for locale %s", (locale, expected) => {
+      expect(buildSetupRedirectPath(locale)).toBe(expected);
+    });
+  });
+
+  describe("given a callbackUrl", () => {
+    it("should carry the callbackUrl in the query, url-encoded", () => {
+      expect(buildSetupRedirectPath("fr", "/m/cloud-pi-native")).toBe(
+        "/fr/dashboard/profile/setup?callbackUrl=%2Fm%2Fcloud-pi-native"
+      );
+    });
+
+    it("should keep the locale prefix even when a callbackUrl is present", () => {
+      // Invariant : le préfixe locale reste le signal de langue de l'email.
+      expect(buildSetupRedirectPath("en", "/en/m/foo")).toMatch(
+        /^\/en\/dashboard\/profile\/setup\?callbackUrl=/
+      );
+    });
+
+    it("should fully encode a callbackUrl that itself contains a query string", () => {
+      // Le param imbriqué doit être encodé pour ne pas fuiter dans la query parente.
+      expect(buildSetupRedirectPath("fr", "/m/foo?ref=bar")).toBe(
+        "/fr/dashboard/profile/setup?callbackUrl=%2Fm%2Ffoo%3Fref%3Dbar"
+      );
+    });
+  });
+});

--- a/src/lib/auth/post-sign-in-redirect.ts
+++ b/src/lib/auth/post-sign-in-redirect.ts
@@ -1,0 +1,24 @@
+/**
+ * Construit la cible de redirection post-connexion : la page setup, qui finalise
+ * l'onboarding puis renvoie l'utilisateur sur sa page d'origine.
+ *
+ * Deux invariants encodés ici :
+ *
+ *   1. Le préfixe `/${locale}/` du segment `dashboard/profile/setup` est
+ *      TOUJOURS présent. La langue de l'email magic link est déduite du premier
+ *      segment de ce path (cf. `detectLocaleForMagicLink`). Sans préfixe, tous
+ *      les magic links partiraient en langue par défaut.
+ *
+ *   2. Le `callbackUrl` d'origine (événement, communauté...) est porté dans la
+ *      query, pas seulement dans le cookie `auth-callback-url`. Le cookie ne
+ *      survit pas à un changement de navigateur (webview LinkedIn/Instagram ->
+ *      navigateur système) : le lien magic s'ouvre dans Safari/Chrome alors que
+ *      le cookie a été posé dans la webview. La query, elle, voyage avec le
+ *      lien et permet à la page setup de retrouver la destination.
+ */
+export function buildSetupRedirectPath(locale: string, callbackUrl?: string): string {
+  const base = `/${locale}/dashboard/profile/setup`;
+  return callbackUrl
+    ? `${base}?callbackUrl=${encodeURIComponent(callbackUrl)}`
+    : base;
+}


### PR DESCRIPTION
## Problème

L'analyse du trafic PostHog (24h, event Cloud Pi Native) a montré un funnel cassé : ~20 visiteurs sur la page event, seulement 2 inscriptions. ~43% du trafic arrive via le **navigateur in-app LinkedIn** (webview).

Cause technique : le retour vers la page d'origine (événement, communauté) ne vivait que dans le cookie httpOnly `auth-callback-url`. Ce cookie **ne survit pas à un changement de navigateur** : dans une webview (LinkedIn, Instagram...), l'utilisateur saisit son email dans la webview, mais le clic sur le magic link ouvre le navigateur système (Safari/Chrome), où le cookie est absent. L'utilisateur atterrissait alors sur `/dashboard` au lieu de l'événement.

## Solution

Le `callbackUrl` est désormais aussi porté dans la **query du `redirectTo`** vers la page setup, qui le lit déjà en priorité sur le cookie. La query voyage avec le lien, donc le contexte survit au changement de navigateur.

- `postSignInRedirectTo(callbackUrl?)` propage le callbackUrl (magic link + OAuth).
- Nouveau helper pur `buildSetupRedirectPath(locale, callbackUrl?)` (testé) qui encapsule la construction et l'encodage du param imbriqué.

## Invariants préservés

- **Cookie `auth-callback-url`** conservé en filet de sécurité (parcours same-navigateur inchangés).
- **Préfixe locale** du segment setup intact : il sert de signal de langue à l'email magic link (cf. `detectLocaleForMagicLink`).
- La page setup priorise toujours `queryCallbackUrl ?? cookieCallbackUrl` → pas de régression.
- Le passage par l'onboarding nom/prénom est intégralement préservé.

## Tests

- `post-sign-in-redirect.test.ts` : construction + encodage (y compris callbackUrl contenant lui-même une query string).
- `magic-link-url.test.ts` : cas de non-régression de la détection de locale au nouveau format `/fr/dashboard/profile/setup?callbackUrl=...`.

## Validation manuelle restante

Le double encodage à travers `@auth/core` n'est pas couvrable en test unitaire. À valider en preview : **envoi réel d'un magic link** depuis un parcours event, vérifier l'atterrissage sur `/m/...` (idéalement en simulant le changement de navigateur webview → système).

## Review

`/code-review` (high) : zéro bug de correctness (double encodage tracé sur 5 hops, exactement un décodage net par hop). Un seul point mineur (duplication superficielle de path avec `buildOnboardingSetupUrl`, contextes client/serveur distincts) laissé tel quel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)