### PR TITLE
feat(auth): connexion LinkedIn en un tap dans la webview LinkedIn

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -146,7 +146,8 @@
       "disposableEmail": "Disposable email addresses are not allowed. Please use a permanent address.",
       "sendFailed": "Couldn't send the email right now. Please try again in a moment.",
       "botDetected": "Security verification failed. Please reload the page and try again.",
-      "webviewNotice": "You're using an in-app browser (LinkedIn, Instagram...). Use the email sign-in below, it works everywhere. To sign in with Google, GitHub or LinkedIn, open the site in your browser (Safari, Chrome...)."
+      "webviewNotice": "You're using an in-app browser (LinkedIn, Instagram...). Use the email sign-in below, it works everywhere. To sign in with Google, GitHub or LinkedIn, open the site in your browser (Safari, Chrome...).",
+      "webviewNoticeLinkedin": "You're in LinkedIn's in-app browser. Sign in with LinkedIn below, or by email. For Google or GitHub, open the site in your browser (Safari, Chrome...)."
     },
     "verifyRequest": {
       "title": "Check your email",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -146,7 +146,8 @@
       "disposableEmail": "Les adresses email jetables ne sont pas acceptées. Utilisez une adresse permanente.",
       "sendFailed": "Impossible d'envoyer l'email pour le moment. Réessayez dans un instant.",
       "botDetected": "La vérification de sécurité a échoué. Rechargez la page et réessayez.",
-      "webviewNotice": "Vous utilisez un navigateur intégré (LinkedIn, Instagram...). Utilisez la connexion par email ci-dessous, elle fonctionne partout. Pour vous connecter avec Google, GitHub ou LinkedIn, ouvrez le site dans votre navigateur (Safari, Chrome...)."
+      "webviewNotice": "Vous utilisez un navigateur intégré (LinkedIn, Instagram...). Utilisez la connexion par email ci-dessous, elle fonctionne partout. Pour vous connecter avec Google, GitHub ou LinkedIn, ouvrez le site dans votre navigateur (Safari, Chrome...).",
+      "webviewNoticeLinkedin": "Vous êtes dans le navigateur intégré de LinkedIn. Connectez-vous avec LinkedIn ci-dessous, ou par email. Pour Google ou GitHub, ouvrez le site dans votre navigateur (Safari, Chrome...)."
     },
     "verifyRequest": {
       "title": "Vérifiez votre email",

--- a/src/components/auth/sign-in-form.tsx
+++ b/src/components/auth/sign-in-form.tsx
@@ -14,7 +14,7 @@ import {
   signInWithEmail,
   type SignInWithEmailState,
 } from "@/app/actions/auth";
-import { isInAppBrowser } from "@/lib/detect-webview";
+import { isInAppBrowser, isLinkedInInAppBrowser } from "@/lib/detect-webview";
 
 function GoogleIcon() {
   return (
@@ -65,6 +65,25 @@ function DisabledOAuthButton({ label, icon }: { label: string; icon: ReactNode }
   );
 }
 
+function OAuthForm({
+  action,
+  label,
+  icon,
+  callbackUrl,
+}: {
+  action: (formData: FormData) => void | Promise<void>;
+  label: string;
+  icon: ReactNode;
+  callbackUrl?: string;
+}) {
+  return (
+    <form action={action}>
+      {callbackUrl && <input type="hidden" name="callbackUrl" value={callbackUrl} />}
+      <SubmitButton label={label} icon={icon} variant="outline" />
+    </form>
+  );
+}
+
 type SignInFormProps = {
   callbackUrl?: string;
   error?: string;
@@ -73,6 +92,7 @@ type SignInFormProps = {
 export function SignInForm({ callbackUrl, error }: SignInFormProps) {
   const t = useTranslations("Auth");
   const [webview, setWebview] = useState(false);
+  const [linkedinWebview, setLinkedinWebview] = useState(false);
   const [emailState, emailAction] = useActionState<SignInWithEmailState, FormData>(
     signInWithEmail,
     null
@@ -80,6 +100,7 @@ export function SignInForm({ callbackUrl, error }: SignInFormProps) {
 
   useEffect(() => {
     setWebview(isInAppBrowser());
+    setLinkedinWebview(isLinkedInInAppBrowser());
   }, []);
 
   return (
@@ -97,12 +118,29 @@ export function SignInForm({ callbackUrl, error }: SignInFormProps) {
           <div className="rounded-lg border border-primary/30 bg-primary/5 px-4 py-3 text-sm text-muted-foreground">
             <div className="flex items-start gap-2">
               <Mail className="size-4 shrink-0 mt-0.5 text-primary" />
-              <p>{t("signIn.webviewNotice")}</p>
+              <p>
+                {linkedinWebview
+                  ? t("signIn.webviewNoticeLinkedin")
+                  : t("signIn.webviewNotice")}
+              </p>
             </div>
           </div>
         )}
 
-        {webview ? (
+        {linkedinWebview ? (
+          // Webview LinkedIn : l'OAuth LinkedIn y aboutit, on le propose en
+          // premier et en un tap. Google/GitHub restent bloqués (webview tierce).
+          <>
+            <OAuthForm
+              action={signInWithLinkedIn}
+              label={t("signIn.linkedin")}
+              icon={<LinkedInIcon />}
+              callbackUrl={callbackUrl}
+            />
+            <DisabledOAuthButton label={t("signIn.google")} icon={<GoogleIcon />} />
+            <DisabledOAuthButton label={t("signIn.github")} icon={<Github className="size-4" />} />
+          </>
+        ) : webview ? (
           <>
             <DisabledOAuthButton label={t("signIn.google")} icon={<GoogleIcon />} />
             <DisabledOAuthButton label={t("signIn.linkedin")} icon={<LinkedInIcon />} />
@@ -110,18 +148,24 @@ export function SignInForm({ callbackUrl, error }: SignInFormProps) {
           </>
         ) : (
           <>
-            <form action={signInWithGoogle}>
-              {callbackUrl && <input type="hidden" name="callbackUrl" value={callbackUrl} />}
-              <SubmitButton label={t("signIn.google")} icon={<GoogleIcon />} variant="outline" />
-            </form>
-            <form action={signInWithLinkedIn}>
-              {callbackUrl && <input type="hidden" name="callbackUrl" value={callbackUrl} />}
-              <SubmitButton label={t("signIn.linkedin")} icon={<LinkedInIcon />} variant="outline" />
-            </form>
-            <form action={signInWithGitHub}>
-              {callbackUrl && <input type="hidden" name="callbackUrl" value={callbackUrl} />}
-              <SubmitButton label={t("signIn.github")} icon={<Github className="size-4" />} variant="outline" />
-            </form>
+            <OAuthForm
+              action={signInWithGoogle}
+              label={t("signIn.google")}
+              icon={<GoogleIcon />}
+              callbackUrl={callbackUrl}
+            />
+            <OAuthForm
+              action={signInWithLinkedIn}
+              label={t("signIn.linkedin")}
+              icon={<LinkedInIcon />}
+              callbackUrl={callbackUrl}
+            />
+            <OAuthForm
+              action={signInWithGitHub}
+              label={t("signIn.github")}
+              icon={<Github className="size-4" />}
+              callbackUrl={callbackUrl}
+            />
           </>
         )}
 

--- a/src/lib/__tests__/detect-webview.test.ts
+++ b/src/lib/__tests__/detect-webview.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { isInAppBrowser, isLinkedInInAppBrowser } from "@/lib/detect-webview";
+
+const LINKEDIN_UA =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [LinkedInApp]/9.32.1536";
+const INSTAGRAM_UA =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 Mobile/15E148 Instagram 300.0";
+const SAFARI_UA =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Mobile/15E148 Safari/604.1";
+
+function stubUserAgent(ua: string) {
+  vi.stubGlobal("navigator", { userAgent: ua });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("isInAppBrowser", () => {
+  it.each([
+    ["LinkedIn webview", LINKEDIN_UA, true],
+    ["Instagram webview", INSTAGRAM_UA, true],
+    ["Safari", SAFARI_UA, false],
+  ])("should return %s -> %s", (_label, ua, expected) => {
+    stubUserAgent(ua);
+    expect(isInAppBrowser()).toBe(expected);
+  });
+});
+
+describe("isLinkedInInAppBrowser", () => {
+  it("should detect the LinkedIn in-app browser", () => {
+    stubUserAgent(LINKEDIN_UA);
+    expect(isLinkedInInAppBrowser()).toBe(true);
+  });
+
+  it.each([
+    ["Instagram webview", INSTAGRAM_UA],
+    ["Safari", SAFARI_UA],
+  ])("should not flag %s as the LinkedIn webview", (_label, ua) => {
+    stubUserAgent(ua);
+    expect(isLinkedInInAppBrowser()).toBe(false);
+  });
+});

--- a/src/lib/detect-webview.ts
+++ b/src/lib/detect-webview.ts
@@ -3,11 +3,14 @@
  * Google blocks OAuth from these browsers with `Error 403: disallowed_useragent`.
  */
 
+/** Token UA de la webview in-app LinkedIn (cf. `isLinkedInInAppBrowser`). */
+const LINKEDIN_APP = "LinkedInApp";
+
 const WEBVIEW_PATTERNS = [
   "FBAN", // Facebook App
   "FBAV", // Facebook App (version)
   "Instagram",
-  "LinkedInApp",
+  LINKEDIN_APP,
   "Line/",
   "Twitter", // X app
   "Snapchat",
@@ -31,5 +34,5 @@ export function isInAppBrowser(): boolean {
  */
 export function isLinkedInInAppBrowser(): boolean {
   if (typeof navigator === "undefined") return false;
-  return navigator.userAgent.includes("LinkedInApp");
+  return navigator.userAgent.includes(LINKEDIN_APP);
 }

--- a/src/lib/detect-webview.ts
+++ b/src/lib/detect-webview.ts
@@ -22,3 +22,14 @@ export function isInAppBrowser(): boolean {
   const ua = navigator.userAgent;
   return WEBVIEW_PATTERNS.some((p) => ua.includes(p));
 }
+
+/**
+ * Détecte spécifiquement la webview in-app de LinkedIn. Contrairement aux autres
+ * webviews, l'OAuth LinkedIn y aboutit (l'utilisateur est déjà dans l'écosystème
+ * LinkedIn) : on peut donc proposer la connexion LinkedIn en un tap plutôt que de
+ * forcer l'ouverture dans un navigateur externe. Vérifié manuellement en staging.
+ */
+export function isLinkedInInAppBrowser(): boolean {
+  if (typeof navigator === "undefined") return false;
+  return navigator.userAgent.includes("LinkedInApp");
+}


### PR DESCRIPTION
## Contexte

L'analyse PostHog (24h, event Cloud Pi Native) a montré que **~43% du trafic event provient de la webview in-app LinkedIn**, avec une conversion très faible. Jusqu'ici, tous les OAuth étaient désactivés en webview (Google bloque avec `disallowed_useragent`), ne laissant que le magic link, fragile dans ce contexte.

**Validé en staging** : l'OAuth LinkedIn **aboutit** dans la webview in-app de LinkedIn (l'utilisateur est déjà dans l'écosystème LinkedIn), contrairement à Google.

## Changement

- `isLinkedInInAppBrowser()` détecte spécifiquement le UA `LinkedInApp` (constante `LINKEDIN_APP` partagée avec `WEBVIEW_PATTERNS`).
- **Webview LinkedIn** : bouton LinkedIn **actif et placé en premier** ; Google et GitHub restent désactivés (webview tierce non prouvée).
- **Autres webviews** (Instagram, Facebook...) : comportement inchangé (OAuth désactivés, magic link recommandé).
- Bandeau dédié `webviewNoticeLinkedin` : ne présente plus LinkedIn comme cassé.
- Refacto : extraction du composant `OAuthForm` (supprime la triple duplication form + hidden callbackUrl + SubmitButton).

## Scope

Volontairement limité à la **webview LinkedIn** (seule prouvée). Les autres webviews ne sont pas un pari non testé.

## Tests

`detect-webview.test.ts` : `isInAppBrowser` + `isLinkedInInAppBrowser` (UA LinkedIn / Instagram / Safari).

## Review

`/code-review` (high) : zéro bug de correctness (BotID préservé, ordre des branches correct, guard SSR, i18n synchronisée). Cleanup actionnable (constante `LINKEDIN_APP`) appliqué. Flash d'hydratation pré-existant non embarqué (fix séparé éventuel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)