### PR TITLE
feat(auth): auto-inscription post-auth (événement + Communauté)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -353,7 +353,9 @@
       "manageCircle": "Manage this community",
       "shareableLink": "Shareable link",
       "signInToSeeMembers": "Sign in to see the members of this community",
-      "signInToJoin": "Sign in to join"
+      "signInToJoin": "Sign in to join",
+      "autoJoinSuccess": "You've joined the community",
+      "autoJoinPending": "Membership request sent"
     },
     "removeMember": {
       "action": "Remove from community",
@@ -596,6 +598,9 @@
       "spotsAvailable": "{count} spots",
       "registerFree": "Join",
       "requestToJoin": "Join (subject to approval)",
+      "autoJoinSuccess": "You're registered",
+      "autoJoinWaitlisted": "You're on the waitlist",
+      "autoJoinPending": "Registration request sent",
       "registerPaid": "Join — {price} {currency}",
       "comingSoon": "Coming soon",
       "priceTtc": "All taxes included",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -353,7 +353,9 @@
       "manageCircle": "Gérer cette communauté",
       "shareableLink": "Lien partageable",
       "signInToSeeMembers": "Connecte-toi pour voir les membres de cette communauté",
-      "signInToJoin": "Se connecter pour rejoindre"
+      "signInToJoin": "Se connecter pour rejoindre",
+      "autoJoinSuccess": "Vous avez rejoint la communauté",
+      "autoJoinPending": "Demande d'adhésion envoyée"
     },
     "removeMember": {
       "action": "Retirer de la communauté",
@@ -596,6 +598,9 @@
       "spotsAvailable": "{count} places",
       "registerFree": "S'inscrire",
       "requestToJoin": "S'inscrire (soumis à validation)",
+      "autoJoinSuccess": "Inscription confirmée",
+      "autoJoinWaitlisted": "Vous êtes sur la liste d'attente",
+      "autoJoinPending": "Demande d'inscription envoyée",
       "registerPaid": "S'inscrire — {price} {currency}",
       "comingSoon": "Bientôt disponible",
       "priceTtc": "Prix TTC",

--- a/src/app/[locale]/(routes)/circles/[slug]/page.tsx
+++ b/src/app/[locale]/(routes)/circles/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { cache } from "react";
 import { notFound } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 import { measureTime } from "@/lib/perf-logger";
+import { withAutoJoin } from "@/lib/auto-join";
 import { degradedQuery } from "@/lib/degraded-query";
 import { stripProtocol } from "@/lib/url";
 import type { Metadata } from "next";
@@ -375,7 +376,11 @@ export default async function PublicCirclePage({
           {/* CTA Se connecter — visible pour les visiteurs non-authentifiés */}
           {showSignInToJoin && (
             <Button variant="default" size="sm" asChild className="w-full gap-2">
-              <a href={`/${locale}/auth/sign-in?callbackUrl=/${locale}/circles/${slug}`}>
+              <a
+                href={`/${locale}/auth/sign-in?callbackUrl=${encodeURIComponent(
+                  withAutoJoin(`/${locale}/circles/${slug}`)
+                )}`}
+              >
                 <Users className="size-4" />
                 {t("detail.signInToJoin")}
               </a>

--- a/src/app/[locale]/(routes)/circles/[slug]/page.tsx
+++ b/src/app/[locale]/(routes)/circles/[slug]/page.tsx
@@ -2,7 +2,7 @@ import { cache } from "react";
 import { notFound } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 import { measureTime } from "@/lib/perf-logger";
-import { withAutoJoin } from "@/lib/auto-join";
+import { signInUrlWithAutoJoin } from "@/lib/auto-join";
 import { degradedQuery } from "@/lib/degraded-query";
 import { stripProtocol } from "@/lib/url";
 import type { Metadata } from "next";
@@ -376,11 +376,7 @@ export default async function PublicCirclePage({
           {/* CTA Se connecter — visible pour les visiteurs non-authentifiés */}
           {showSignInToJoin && (
             <Button variant="default" size="sm" asChild className="w-full gap-2">
-              <a
-                href={`/${locale}/auth/sign-in?callbackUrl=${encodeURIComponent(
-                  withAutoJoin(`/${locale}/circles/${slug}`)
-                )}`}
-              >
+              <a href={signInUrlWithAutoJoin(locale, `/${locale}/circles/${slug}`)}>
                 <Users className="size-4" />
                 {t("detail.signInToJoin")}
               </a>

--- a/src/app/[locale]/(routes)/m/[slug]/page.tsx
+++ b/src/app/[locale]/(routes)/m/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import { cache } from "react";
 import { notFound } from "next/navigation";
 import { measureTime } from "@/lib/perf-logger";
-import { withAutoJoin } from "@/lib/auto-join";
+import { signInUrlWithAutoJoin } from "@/lib/auto-join";
 import { isValidSlug } from "@/lib/slug";
 import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
@@ -156,11 +156,9 @@ export default async function PublicMomentPage({
 
   const isFull =
     moment.capacity !== null && registeredCount >= moment.capacity;
-  // `?join=1` (encodé dans le callbackUrl) porte l'intention d'inscription à
-  // travers l'auth : au retour, le bouton auto-inscrit sans re-cliquer.
-  const signInUrl = `/${locale}/auth/sign-in?callbackUrl=${encodeURIComponent(
-    withAutoJoin(`/${locale}/m/${slug}`)
-  )}`;
+  // `?join=1` porte l'intention d'inscription à travers l'auth : au retour,
+  // le bouton auto-inscrit sans re-cliquer.
+  const signInUrl = signInUrlWithAutoJoin(locale, `/${locale}/m/${slug}`);
   const waitlistedCount = allAttendees.filter(
     (r) => r.status === "WAITLISTED"
   ).length;

--- a/src/app/[locale]/(routes)/m/[slug]/page.tsx
+++ b/src/app/[locale]/(routes)/m/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import { cache } from "react";
 import { notFound } from "next/navigation";
 import { measureTime } from "@/lib/perf-logger";
+import { withAutoJoin } from "@/lib/auto-join";
 import { isValidSlug } from "@/lib/slug";
 import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
@@ -155,7 +156,11 @@ export default async function PublicMomentPage({
 
   const isFull =
     moment.capacity !== null && registeredCount >= moment.capacity;
-  const signInUrl = `/${locale}/auth/sign-in?callbackUrl=/${locale}/m/${slug}`;
+  // `?join=1` (encodé dans le callbackUrl) porte l'intention d'inscription à
+  // travers l'auth : au retour, le bouton auto-inscrit sans re-cliquer.
+  const signInUrl = `/${locale}/auth/sign-in?callbackUrl=${encodeURIComponent(
+    withAutoJoin(`/${locale}/m/${slug}`)
+  )}`;
   const waitlistedCount = allAttendees.filter(
     (r) => r.status === "WAITLISTED"
   ).length;

--- a/src/components/auth/use-auto-join.ts
+++ b/src/components/auth/use-auto-join.ts
@@ -1,0 +1,45 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { AUTO_JOIN_PARAM } from "@/lib/auto-join";
+
+/**
+ * Déclenche une action d'inscription une seule fois au montage si l'URL porte le
+ * marqueur `?join=1` (intention mémorisée avant l'authentification) et que
+ * l'inscription est possible (`enabled`).
+ *
+ * Le marqueur est retiré de l'URL dans TOUS les cas (déclenchement ou non) pour
+ * éviter un re-déclenchement au reload et un partage involontaire de l'intention.
+ *
+ * Lit `window.location.search` (et non `useSearchParams`) pour ne pas imposer de
+ * Suspense boundary à la page appelante.
+ */
+export function useAutoJoin({
+  enabled,
+  onTrigger,
+}: {
+  enabled: boolean;
+  onTrigger: () => void;
+}) {
+  const firedRef = useRef(false);
+  const enabledRef = useRef(enabled);
+  enabledRef.current = enabled;
+  const onTriggerRef = useRef(onTrigger);
+  onTriggerRef.current = onTrigger;
+
+  useEffect(() => {
+    if (firedRef.current || typeof window === "undefined") return;
+    const url = new URL(window.location.href);
+    if (url.searchParams.get(AUTO_JOIN_PARAM) !== "1") return;
+
+    firedRef.current = true;
+    url.searchParams.delete(AUTO_JOIN_PARAM);
+    window.history.replaceState(
+      null,
+      "",
+      `${url.pathname}${url.search}${url.hash}`
+    );
+
+    if (enabledRef.current) onTriggerRef.current();
+  }, []);
+}

--- a/src/components/circles/join-circle-button.tsx
+++ b/src/components/circles/join-circle-button.tsx
@@ -3,6 +3,7 @@
 import { useState, useTransition } from "react";
 import { useRouter } from "@/i18n/navigation";
 import posthog from "posthog-js";
+import { toast } from "sonner";
 import { Users, Check, Clock } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { joinCircleDirectlyAction } from "@/app/actions/circle";
@@ -28,6 +29,14 @@ export function JoinCircleButton({ circleId, requiresApproval = false }: Props) 
       if (result.success) {
         posthog.capture("circle_joined_directly", { circle_id: circleId, trigger });
         setState(result.data.pendingApproval ? "pending" : "joined");
+        // L'auto-adhésion se déclenche sans clic : un toast confirme le succès.
+        if (trigger === "auto") {
+          if (result.data.pendingApproval) {
+            toast(t("autoJoinPending"));
+          } else {
+            toast.success(t("autoJoinSuccess"));
+          }
+        }
         router.refresh();
         return;
       }

--- a/src/components/circles/join-circle-button.tsx
+++ b/src/components/circles/join-circle-button.tsx
@@ -7,6 +7,7 @@ import { Users, Check, Clock } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { joinCircleDirectlyAction } from "@/app/actions/circle";
 import { handleOnboardingRequired } from "@/lib/onboarding";
+import { useAutoJoin } from "@/components/auth/use-auto-join";
 import { useTranslations } from "next-intl";
 
 type Props = {
@@ -20,11 +21,12 @@ export function JoinCircleButton({ circleId, requiresApproval = false }: Props) 
   const [state, setState] = useState<"idle" | "joined" | "pending">("idle");
   const [isPending, startTransition] = useTransition();
 
-  function handleJoin() {
+  // Partagé par le clic et l'auto-adhésion post-auth.
+  function runJoin(trigger: "click" | "auto") {
     startTransition(async () => {
       const result = await joinCircleDirectlyAction(circleId);
       if (result.success) {
-        posthog.capture("circle_joined_directly", { circle_id: circleId });
+        posthog.capture("circle_joined_directly", { circle_id: circleId, trigger });
         setState(result.data.pendingApproval ? "pending" : "joined");
         router.refresh();
         return;
@@ -32,6 +34,14 @@ export function JoinCircleButton({ circleId, requiresApproval = false }: Props) 
       handleOnboardingRequired(result, router);
     });
   }
+
+  // Auto-adhésion post-auth : ce composant n'est monté que pour un utilisateur
+  // connecté non-membre. Si l'URL porte `?join=1` (CTA « Rejoindre » avant
+  // authentification), déclenche l'adhésion au retour, sans re-cliquer.
+  useAutoJoin({
+    enabled: state === "idle",
+    onTrigger: () => runJoin("auto"),
+  });
 
   if (state === "joined") {
     return (
@@ -55,7 +65,7 @@ export function JoinCircleButton({ circleId, requiresApproval = false }: Props) 
     <Button
       variant="default"
       size="sm"
-      onClick={handleJoin}
+      onClick={() => runJoin("click")}
       disabled={isPending}
       className="w-full gap-2"
     >

--- a/src/components/moments/registration-button.tsx
+++ b/src/components/moments/registration-button.tsx
@@ -28,6 +28,7 @@ import { formatPrice } from "@/lib/format-price";
 import type { Registration, RegistrationStatus } from "@/domain/models/registration";
 import type { CalendarEventData } from "@/lib/calendar";
 import posthog from "posthog-js";
+import { toast } from "sonner";
 
 type RegistrationButtonProps = {
   momentId: string;
@@ -95,6 +96,17 @@ export function RegistrationButton({
           registration_status: result.data.status,
           trigger,
         });
+        // L'auto-inscription se déclenche sans clic : un toast confirme
+        // explicitement le succès (le clic manuel a déjà le retour du bouton).
+        if (trigger === "auto") {
+          if (result.data.status === "REGISTERED") {
+            toast.success(t("public.autoJoinSuccess"));
+          } else if (result.data.status === "WAITLISTED") {
+            toast(t("public.autoJoinWaitlisted"));
+          } else if (result.data.status === "PENDING_APPROVAL") {
+            toast(t("public.autoJoinPending"));
+          }
+        }
         router.refresh();
         return;
       }

--- a/src/components/moments/registration-button.tsx
+++ b/src/components/moments/registration-button.tsx
@@ -22,6 +22,8 @@ import {
 } from "@/app/actions/registration";
 import { createCheckoutAction } from "@/app/actions/checkout";
 import { handleOnboardingRequired } from "@/lib/onboarding";
+import { canAutoJoin } from "@/lib/auto-join";
+import { useAutoJoin } from "@/components/auth/use-auto-join";
 import { formatPrice } from "@/lib/format-price";
 import type { Registration, RegistrationStatus } from "@/domain/models/registration";
 import type { CalendarEventData } from "@/lib/calendar";
@@ -76,6 +78,45 @@ export function RegistrationButton({
     existingRegistration?.id ?? null
   );
   const [error, setError] = useState<string | null>(null);
+
+  // Inscription gratuite (le chemin payant passe par Stripe, cf. plus bas).
+  // Partagé par le clic et l'auto-inscription post-auth.
+  function runJoin(trigger: "click" | "auto") {
+    startTransition(async () => {
+      setError(null);
+      const result = await joinMomentAction(momentId);
+      if (result.success) {
+        setLocalStatus(result.data.status);
+        setLocalRegistrationId(result.data.id);
+        posthog.capture("moment_joined", {
+          moment_id: momentId,
+          circle_id: circleId,
+          circle_name: circleName,
+          registration_status: result.data.status,
+          trigger,
+        });
+        router.refresh();
+        return;
+      }
+      if (handleOnboardingRequired(result, router)) return;
+      setError(result.error);
+    });
+  }
+
+  // Auto-inscription post-auth : si l'utilisateur vient d'un CTA « S'inscrire »
+  // (marqueur `?join=1`), déclenche l'inscription au retour, sans re-cliquer.
+  // Exclut le payant (blocked) et les inscriptions déjà actives (alreadyEngaged).
+  useAutoJoin({
+    enabled: canAutoJoin({
+      isAuthenticated,
+      alreadyEngaged:
+        localStatus !== null &&
+        localStatus !== "CANCELLED" &&
+        localStatus !== "REJECTED",
+      blocked: price > 0,
+    }),
+    onTrigger: () => runJoin("auto"),
+  });
 
   // Not authenticated: link to sign-in (same for free and paid)
   if (!isAuthenticated) {
@@ -231,26 +272,7 @@ export function RegistrationButton({
         className="w-full"
         size="sm"
         disabled={isPending}
-        onClick={() => {
-          startTransition(async () => {
-            setError(null);
-            const result = await joinMomentAction(momentId);
-            if (result.success) {
-              setLocalStatus(result.data.status);
-              setLocalRegistrationId(result.data.id);
-              posthog.capture("moment_joined", {
-                moment_id: momentId,
-                circle_id: circleId,
-                circle_name: circleName,
-                registration_status: result.data.status,
-              });
-              router.refresh();
-              return;
-            }
-            if (handleOnboardingRequired(result, router)) return;
-            setError(result.error);
-          });
-        }}
+        onClick={() => runJoin("click")}
       >
         {isPending
           ? tCommon("loading")

--- a/src/lib/__tests__/auto-join.test.ts
+++ b/src/lib/__tests__/auto-join.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { AUTO_JOIN_PARAM, withAutoJoin, canAutoJoin } from "@/lib/auto-join";
+
+describe("withAutoJoin", () => {
+  it("should append the join marker to a path", () => {
+    expect(withAutoJoin("/m/cloud-pi-native")).toBe(
+      `/m/cloud-pi-native?${AUTO_JOIN_PARAM}=1`
+    );
+    expect(withAutoJoin("/circles/the-spark")).toBe(
+      `/circles/the-spark?${AUTO_JOIN_PARAM}=1`
+    );
+  });
+});
+
+describe("canAutoJoin", () => {
+  it("should allow auto-join for an authenticated, non-engaged, non-blocked user", () => {
+    expect(
+      canAutoJoin({ isAuthenticated: true, alreadyEngaged: false, blocked: false })
+    ).toBe(true);
+  });
+
+  it.each([
+    ["not authenticated", { isAuthenticated: false, alreadyEngaged: false, blocked: false }],
+    ["already engaged", { isAuthenticated: true, alreadyEngaged: true, blocked: false }],
+    ["blocked (e.g. paid)", { isAuthenticated: true, alreadyEngaged: false, blocked: true }],
+  ])("should refuse auto-join when %s", (_label, opts) => {
+    expect(canAutoJoin(opts)).toBe(false);
+  });
+});

--- a/src/lib/__tests__/auto-join.test.ts
+++ b/src/lib/__tests__/auto-join.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { AUTO_JOIN_PARAM, withAutoJoin, canAutoJoin } from "@/lib/auto-join";
+import {
+  AUTO_JOIN_PARAM,
+  withAutoJoin,
+  canAutoJoin,
+  signInUrlWithAutoJoin,
+} from "@/lib/auto-join";
 
 describe("withAutoJoin", () => {
   it("should append the join marker to a path", () => {
@@ -8,6 +13,21 @@ describe("withAutoJoin", () => {
     );
     expect(withAutoJoin("/circles/the-spark")).toBe(
       `/circles/the-spark?${AUTO_JOIN_PARAM}=1`
+    );
+  });
+});
+
+describe("signInUrlWithAutoJoin", () => {
+  it("should build a sign-in URL with the encoded callbackUrl carrying the join marker", () => {
+    expect(signInUrlWithAutoJoin("fr", "/fr/m/cloud-pi-native")).toBe(
+      `/fr/auth/sign-in?callbackUrl=${encodeURIComponent(
+        `/fr/m/cloud-pi-native?${AUTO_JOIN_PARAM}=1`
+      )}`
+    );
+    expect(signInUrlWithAutoJoin("en", "/en/circles/the-spark")).toBe(
+      `/en/auth/sign-in?callbackUrl=${encodeURIComponent(
+        `/en/circles/the-spark?${AUTO_JOIN_PARAM}=1`
+      )}`
     );
   });
 });

--- a/src/lib/auto-join.ts
+++ b/src/lib/auto-join.ts
@@ -1,0 +1,30 @@
+/**
+ * Auto-inscription post-auth : un visiteur non connecté qui clique « S'inscrire »
+ * (événement) ou « Rejoindre » (Communauté) doit, après authentification, être
+ * inscrit automatiquement au retour, sans re-cliquer.
+ *
+ * L'intention voyage dans le `callbackUrl` via le marqueur `?join=1` (et non
+ * `autojoin`, terme déjà employé dans le domaine pour l'adhésion Circle
+ * automatique via inscription événement). Au retour, le bouton concerné lit le
+ * marqueur et déclenche la même action que le clic (cf. `useAutoJoin`).
+ */
+export const AUTO_JOIN_PARAM = "join";
+
+/** Ajoute le marqueur d'intention d'inscription à un path (sans query existant). */
+export function withAutoJoin(path: string): string {
+  return `${path}?${AUTO_JOIN_PARAM}=1`;
+}
+
+/**
+ * Éligibilité à l'auto-inscription post-auth, vue côté bouton :
+ * - `isAuthenticated` : la session est établie (au retour post-auth, toujours vrai) ;
+ * - `alreadyEngaged` : déjà inscrit / membre / en attente de validation → ne rien faire ;
+ * - `blocked` : raison d'exclure (ex. événement payant → passe par Stripe, pas d'auto-paiement).
+ */
+export function canAutoJoin(opts: {
+  isAuthenticated: boolean;
+  alreadyEngaged: boolean;
+  blocked: boolean;
+}): boolean {
+  return opts.isAuthenticated && !opts.alreadyEngaged && !opts.blocked;
+}

--- a/src/lib/auto-join.ts
+++ b/src/lib/auto-join.ts
@@ -16,6 +16,16 @@ export function withAutoJoin(path: string): string {
 }
 
 /**
+ * URL de connexion qui ramène sur `targetPath` après authentification et y
+ * déclenche l'auto-inscription. Centralise le motif partagé par les CTA
+ * « S'inscrire » (événement) et « Rejoindre » (Communauté) : route d'auth +
+ * callbackUrl encodé + marqueur `?join=1`.
+ */
+export function signInUrlWithAutoJoin(locale: string, targetPath: string): string {
+  return `/${locale}/auth/sign-in?callbackUrl=${encodeURIComponent(withAutoJoin(targetPath))}`;
+}
+
+/**
  * Éligibilité à l'auto-inscription post-auth, vue côté bouton :
  * - `isAuthenticated` : la session est établie (au retour post-auth, toujours vrai) ;
  * - `alreadyEngaged` : déjà inscrit / membre / en attente de validation → ne rien faire ;


### PR DESCRIPTION
## Problème

Dernier trou identifié dans l'inscription « friction zéro » : après authentification, l'utilisateur devait **re-cliquer** « S'inscrire » / « Rejoindre ». L'intention d'inscription n'était pas portée à travers le flux d'auth (clic CTA → sign-in → auth → retour sur la page → re-clic obligatoire).

## Solution

Le CTA encode un marqueur `?join=1` dans le `callbackUrl`. Au retour post-auth, le bouton client concerné **déclenche automatiquement** la même action que le clic, sans intervention. Réutilise les chemins existants (`joinMomentAction` / `joinCircleDirectlyAction`) → tous les contrôles serveur préservés.

- **`lib/auto-join.ts`** : marqueur `?join=1` (pas `autojoin`, déjà employé pour l'adhésion Circle auto via inscription événement), `canAutoJoin` (pure) et `signInUrlWithAutoJoin` (helper centralisé).
- **`components/auth/use-auto-join.ts`** : hook qui lit `window.location.search` (pas `useSearchParams` → pas de contrainte Suspense), déclenche **une fois** (guard `useRef`), et retire le marqueur de l'URL (anti re-déclenchement + anti partage involontaire de l'intention).
- **Événement** : exclut le payant (passe par Stripe) et les inscriptions actives.
- **Communauté** : marqueur **uniquement sur le CTA « Rejoindre »** (pas sur le lien de contact organisateur).
- **Toast de confirmation** (sonner, mobile-friendly) sur le déclenchement `auto` uniquement : sans clic conscient, l'utilisateur n'avait aucun retour visible (hors email). Le clic manuel garde le retour du bouton.
- **PostHog** : property `trigger: "click" | "auto"` sur `moment_joined` et `circle_joined_directly` pour mesurer l'effet.

## Scope

Auto-déclenchement limité à la **webview/parcours déjà couverts** ; payant exclu (pas d'auto-paiement). L'onboarding nom/prénom reste préservé (la cible du redirect reste setup, l'auto-join se fait après).

## Tests

`lib/__tests__/auto-join.test.ts` : `withAutoJoin`, `signInUrlWithAutoJoin`, `canAutoJoin` (matrice).

## Review

`/code-review` (high) : zéro bug de correctness (Strict Mode, timing au mount, boucle refresh, désync router tous vérifiés sains). Cleanup actionnable (helper `signInUrlWithAutoJoin`) appliqué.

🤖 Generated with [Claude Code](https://claude.com/claude-code)