### PR TITLE
fix(admin): clés uniques sur les graduations Y du sparkline

### DIFF
--- a/src/components/admin/sparkline-chart.tsx
+++ b/src/components/admin/sparkline-chart.tsx
@@ -48,10 +48,12 @@ export function SparklineChart({ data, id, height = 72 }: SparklineChartProps) {
   const gradId = `grad-${id}`;
   const total = data.reduce((sum, d) => sum + d.count, 0);
 
+  // key par position (pas par valeur) : quand max vaut 1, mid = ceil(1/2) = 1,
+  // donc deux graduations partageraient la même valeur → clés React dupliquées.
   const yTicks = [
-    { value: max, y: toY(max) },
-    { value: mid, y: toY(mid) },
-    { value: 0, y: toY(0) },
+    { id: "max", value: max, y: toY(max) },
+    { id: "mid", value: mid, y: toY(mid) },
+    { id: "zero", value: 0, y: toY(0) },
   ];
 
   return (
@@ -70,9 +72,9 @@ export function SparklineChart({ data, id, height = 72 }: SparklineChartProps) {
         </defs>
 
         {/* Lignes de grille horizontales */}
-        {yTicks.map(({ value, y }) => (
+        {yTicks.map(({ id, y }) => (
           <line
-            key={value}
+            key={id}
             x1={PAD_LEFT}
             y1={y.toFixed(1)}
             x2={W - PAD_RIGHT}
@@ -84,9 +86,9 @@ export function SparklineChart({ data, id, height = 72 }: SparklineChartProps) {
         ))}
 
         {/* Labels axe Y */}
-        {yTicks.map(({ value, y }) => (
+        {yTicks.map(({ id, value, y }) => (
           <text
-            key={value}
+            key={id}
             x={PAD_LEFT - 5}
             y={y.toFixed(1)}
             textAnchor="end"


### PR DESCRIPTION
## Problème

Sur le dashboard admin (`/admin`), erreur console React : « Encountered two children with the same key, `1` » (stack : `SparklineChart` → `ChartCard` → `AdminDashboardPage`).

## Cause

Les 3 graduations Y du sparkline étaient keyées **par leur valeur** :
```ts
const mid = Math.ceil(max / 2);
const yTicks = [{ value: max }, { value: mid }, { value: 0 }]; // key={value}
```
Quand le pic de la série vaut **1** (données creuses, fréquent en dev), `mid = ceil(1/2) = 1 = max` → deux graduations partagent `key={1}`.

Bug **latent** depuis l'ajout de l'axe Y (mars 2026, commit `3c09f0c`) : invisible dès que le pic ≥ 2, donc jamais déclenché en prod avec du trafic réel, mais systématique sur des données à pic = 1.

## Fix

Key par **position** (`max` / `mid` / `zero`) au lieu de la valeur → robuste quelle que soit la série. La valeur reste utilisée pour l'affichage du label.

## Périmètre

`SparklineChart` / `ChartCard` ne sont utilisés que sous `/admin` (dashboard + pages insights). **Aucun usage hors admin**, zéro impact user-facing. Changement purement présentationnel (clés React d'un SVG).

🤖 Generated with [Claude Code](https://claude.com/claude-code)