### PR TITLE
chore(email): aligne l'onboarding sur le pitch "projet pensé pour durer"

### DIFF
--- a/src/content/emails/onboarding-welcome.md
+++ b/src/content/emails/onboarding-welcome.md
@@ -21,7 +21,7 @@ C'est ça, The Playground. Rien de plus, rien de moins.
 
 La plateforme tourne. La structure est solide, les fonctionnalités sont là.
 
-Les premières communautés s'y sont installées, et c'est déjà un signe de confiance et d'utilité.
+Les premières communautés s'y sont installées, et c'est déjà un signe de confiance et d'utilité. The Playground s'enrichit chaque semaine, et c'est un projet pensé pour durer.
 
 Mais pour qu'une plateforme communautaire prouve quelque chose, il en faut plus. Plus de communautés qui vivent, qui grandissent, dont les membres reviennent.
 


### PR DESCRIPTION
## Contexte

Suite à la refonte récente de la page À propos (pivot du cadrage « projet d'expérimentation » vers « projet pensé pour durer »), l'email d'onboarding ne portait aucun signal d'engagement dans la durée. La section « Où on en est » penchait même vers « projet jeune, pas encore prouvé », en décalage avec la page À propos.

## Changement

Ajout dans la section « Où on en est » d'une phrase reprenant le vocabulaire exact de la page À propos :

> The Playground s'enrichit chaque semaine, et c'est un projet pensé pour durer.

Posée juste avant la demande d'aide, elle pose la solidité et la pérennité avant l'appel, et rassure contre la peur d'abandon, tout en gardant la cohérence entre les deux surfaces.

Modification de contenu uniquement (`src/content/emails/onboarding-welcome.md`), pas de changement de schema ni de logique.

🤖 Generated with [Claude Code](https://claude.com/claude-code)