### PR TITLE
feat(reporting): primo-visiteurs vs revenants dans les synthèses trafic

### DIFF
--- a/src/app/api/cron/posthog-daily-report/__tests__/build-report-html.test.ts
+++ b/src/app/api/cron/posthog-daily-report/__tests__/build-report-html.test.ts
@@ -88,6 +88,43 @@ describe("buildReportHtml", () => {
       // 2026-04-10 20:30 UTC → 22:30 local summer time varies; we just check the date part
       expect(html).toMatch(/10\/04\/2026/);
     });
+
+    it("should not render the new/returning breakdown when the Primo-visiteurs tile is absent", () => {
+      // The fixture has no "Primo-visiteurs" tile → breakdown is omitted.
+      expect(html).not.toContain("primo-visiteur");
+    });
+  });
+
+  describe("given a dashboard with a Primo-visiteurs tile", () => {
+    function withPrimoTile(newVisitors: number): PosthogDashboard {
+      const dashboard = structuredClone(
+        realDashboard
+      ) as unknown as PosthogDashboard;
+      dashboard.tiles.push({
+        id: 999999,
+        insight: {
+          id: 999999,
+          short_id: "primo24h",
+          name: "Primo-visiteurs – 24h",
+          description: null,
+          result: [{ label: "Pageview", aggregated_value: newVisitors }],
+        },
+      });
+      return dashboard;
+    }
+
+    it("should render the primo / returning split and the percentage", () => {
+      // Fixture unique visitors (unpatched) = 25 ; primo = 10 → revenants = 15, 40%
+      const html = buildReportHtml(withPrimoTile(10), fixedDate);
+      expect(html).toContain("<strong>10</strong> primo-visiteur(s)");
+      expect(html).toContain("(40%)");
+      expect(html).toContain("<strong>15</strong> revenant(s)");
+    });
+
+    it("should render the post-fix reliability caveat", () => {
+      const html = buildReportHtml(withPrimoTile(10), fixedDate);
+      expect(html).toContain("Distinction fiable à partir du 18/06/2026");
+    });
   });
 
   describe("given an empty dashboard", () => {

--- a/src/app/api/cron/posthog-daily-report/__tests__/extract-report-kpis.test.ts
+++ b/src/app/api/cron/posthog-daily-report/__tests__/extract-report-kpis.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { extractReportKpis } from "../extract-report-kpis";
+import type { PosthogDashboard } from "../fetch-dashboard";
+
+function dashboardWith(options: {
+  uniqueVisitors: number;
+  newVisitors?: number;
+}): PosthogDashboard {
+  const tiles: PosthogDashboard["tiles"] = [
+    {
+      id: 1,
+      insight: {
+        id: 1,
+        short_id: "pv24h",
+        name: "Pageviews & visiteurs uniques – 24h",
+        description: null,
+        result: [
+          { label: "Pageviews", count: 100 },
+          { label: "Visiteurs uniques", count: options.uniqueVisitors },
+        ],
+      },
+    },
+  ];
+  if (options.newVisitors != null) {
+    tiles.push({
+      id: 2,
+      insight: {
+        id: 2,
+        short_id: "primo24h",
+        name: "Primo-visiteurs – 24h",
+        description: null,
+        result: [{ label: "Pageview", aggregated_value: options.newVisitors }],
+      },
+    });
+  }
+  return { id: 1, name: "Test", description: null, tiles };
+}
+
+describe("extractReportKpis", () => {
+  describe("given no Primo-visiteurs tile", () => {
+    it("should return null for newVisitors and returningVisitors", () => {
+      const kpis = extractReportKpis(dashboardWith({ uniqueVisitors: 25 }));
+      expect(kpis.newVisitors).toBeNull();
+      expect(kpis.returningVisitors).toBeNull();
+    });
+  });
+
+  describe("given a Primo-visiteurs tile", () => {
+    it("should compute returningVisitors as unique minus new", () => {
+      const kpis = extractReportKpis(
+        dashboardWith({ uniqueVisitors: 25, newVisitors: 10 })
+      );
+      expect(kpis.newVisitors).toBe(10);
+      expect(kpis.returningVisitors).toBe(15);
+    });
+
+    it("should clamp returningVisitors to 0 when new exceeds unique (data skew)", () => {
+      const kpis = extractReportKpis(
+        dashboardWith({ uniqueVisitors: 5, newVisitors: 8 })
+      );
+      expect(kpis.newVisitors).toBe(8);
+      expect(kpis.returningVisitors).toBe(0);
+    });
+  });
+});

--- a/src/app/api/cron/posthog-daily-report/build-report-html.ts
+++ b/src/app/api/cron/posthog-daily-report/build-report-html.ts
@@ -1,4 +1,5 @@
 import { escapeHtml } from "@/lib/html";
+import { extractNewVisitors } from "./fetch-dashboard";
 import type {
   PosthogDashboard,
   PosthogInsight,
@@ -146,6 +147,23 @@ export function buildReportHtml(
   const sessionsSeries = sessionsInsight?.result?.[0];
   const sessions = Math.round(sessionsSeries?.count ?? 0);
 
+  // ─── Primo-visiteurs vs revenants ──────────────────────────
+  // Optionnel : rendu seulement si la tile "Primo-visiteurs" existe.
+  const newVisitors = extractNewVisitors(dashboard);
+  const returningVisitors =
+    newVisitors == null ? null : Math.max(0, uniqueVisitors - newVisitors);
+  const newVisitorsPct =
+    newVisitors != null && uniqueVisitors > 0
+      ? Math.round((newVisitors / uniqueVisitors) * 100)
+      : null;
+  const newVisitorsBlock =
+    newVisitors == null
+      ? ""
+      : `<div style="margin-top:12px;padding:12px 16px;background:#fdf2f8;border-radius:8px;">
+<p style="margin:0;font-size:13px;color:#1a1a1a;">Sur ${uniqueVisitors} visiteur(s) unique(s) : <strong>${newVisitors}</strong> primo-visiteur(s)${newVisitorsPct != null ? ` (${newVisitorsPct}%)` : ""} et <strong>${returningVisitors}</strong> revenant(s).</p>
+<p style="margin:6px 0 0 0;font-size:11px;color:#9ca3af;line-height:1.4;">Distinction fiable à partir du 18/06/2026 (correction du tracking d'identité anonyme). Les primo-visiteurs restent transitoirement surévalués, le temps que les visiteurs récurrents accumulent un historique post-correction.</p>
+</div>`;
+
   // ─── Peaks ─────────────────────────────────────────────────
   const pvPeak = peakPoint(pvSeries[0], period);
   const sessionsPeak = peakPoint(sessionsSeries, period);
@@ -284,6 +302,7 @@ export function buildReportHtml(
 </td>
 </tr>
 </table>
+${newVisitorsBlock}
 </td></tr>
 
 <tr><td style="padding:32px 32px 0 32px;">

--- a/src/app/api/cron/posthog-daily-report/extract-report-kpis.ts
+++ b/src/app/api/cron/posthog-daily-report/extract-report-kpis.ts
@@ -1,4 +1,5 @@
 import type { PosthogDashboard } from "./fetch-dashboard";
+import { extractNewVisitors } from "./fetch-dashboard";
 
 /**
  * Lightweight KPI extractor used by the Slack notification path.
@@ -10,6 +11,10 @@ export interface ReportKpis {
   pageviews: number;
   uniqueVisitors: number;
   sessions: number;
+  /** Primo-visiteurs (null si la tile "Primo-visiteurs" est absente). */
+  newVisitors: number | null;
+  /** Revenants = uniques − primo (null si primo indisponible). */
+  returningVisitors: number | null;
 }
 
 // Match by name prefix so both the daily ("– 24h") and weekly ("– 7j")
@@ -30,5 +35,15 @@ export function extractReportKpis(dashboard: PosthogDashboard): ReportKpis {
   )?.insight;
   const sessions = Math.round(sessionsInsight?.result?.[0]?.count ?? 0);
 
-  return { pageviews, uniqueVisitors, sessions };
+  const newVisitors = extractNewVisitors(dashboard);
+  const returningVisitors =
+    newVisitors == null ? null : Math.max(0, uniqueVisitors - newVisitors);
+
+  return {
+    pageviews,
+    uniqueVisitors,
+    sessions,
+    newVisitors,
+    returningVisitors,
+  };
 }

--- a/src/app/api/cron/posthog-daily-report/fetch-dashboard.ts
+++ b/src/app/api/cron/posthog-daily-report/fetch-dashboard.ts
@@ -109,3 +109,23 @@ export function patchUniqueVisitors(dashboard: PosthogDashboard): number | null 
   }
   return rounded;
 }
+
+const NEW_VISITORS_INSIGHT_PREFIX = "Primo-visiteurs";
+
+/**
+ * Extrait le nombre de primo-visiteurs (personnes dont la toute première venue
+ * tombe dans la période) depuis la tile "Primo-visiteurs" (insight BoldNumber,
+ * math `first_time_for_user`, `aggregated_value`).
+ *
+ * Retourne le nombre de primo-visiteurs, ou null si la tile est absente — le
+ * rapport masque alors la répartition primo / revenants (dégradation propre
+ * tant que la tile n'a pas été ajoutée au dashboard).
+ */
+export function extractNewVisitors(dashboard: PosthogDashboard): number | null {
+  const insight = dashboard.tiles.find((t) =>
+    t.insight?.name.startsWith(NEW_VISITORS_INSIGHT_PREFIX)
+  )?.insight;
+  const value = insight?.result?.[0]?.aggregated_value;
+  if (value == null) return null;
+  return Math.round(value);
+}

--- a/src/app/api/cron/posthog-daily-report/route.ts
+++ b/src/app/api/cron/posthog-daily-report/route.ts
@@ -75,6 +75,8 @@ async function handler(request: NextRequest) {
       pageviews: kpis.pageviews,
       uniqueVisitors: kpis.uniqueVisitors,
       sessions: kpis.sessions,
+      newVisitors: kpis.newVisitors,
+      returningVisitors: kpis.returningVisitors,
       dashboardUrl: DASHBOARD_URL,
     });
 

--- a/src/app/api/cron/posthog-weekly-report/route.ts
+++ b/src/app/api/cron/posthog-weekly-report/route.ts
@@ -84,6 +84,8 @@ async function handler(request: NextRequest) {
       pageviews: kpis.pageviews,
       uniqueVisitors: kpis.uniqueVisitors,
       sessions: kpis.sessions,
+      newVisitors: kpis.newVisitors,
+      returningVisitors: kpis.returningVisitors,
       dashboardUrl: DASHBOARD_URL,
     });
 

--- a/src/infrastructure/services/slack/slack-notification-service.ts
+++ b/src/infrastructure/services/slack/slack-notification-service.ts
@@ -128,8 +128,14 @@ export async function notifySlackTrafficReport(params: {
   uniqueVisitors: number;
   sessions: number;
   dashboardUrl: string;
+  newVisitors?: number | null;
+  returningVisitors?: number | null;
 }): Promise<void> {
-  const summary = `*${params.pageviews}* pageviews · *${params.uniqueVisitors}* visiteurs uniques · *${params.sessions}* sessions`;
+  const breakdown =
+    params.newVisitors != null && params.returningVisitors != null
+      ? ` (${params.newVisitors} primo / ${params.returningVisitors} revenants)`
+      : "";
+  const summary = `*${params.pageviews}* pageviews · *${params.uniqueVisitors}* visiteurs uniques${breakdown} · *${params.sessions}* sessions`;
   await sendSlack({
     text: `📊 ${params.dashboardName} — ${params.pageviews} pv · ${params.uniqueVisitors} vis · ${params.sessions} sess`,
     blocks: [


### PR DESCRIPTION
## Quoi

Ajoute la répartition **primo-visiteurs / revenants** aux rapports trafic quotidien et hebdomadaire (email HTML + Slack).

## Pourquoi

Suite au fix d'identité anonyme (#558), on sait désormais distinguer un nouveau visiteur d'un visiteur qui revient. Ce rapport rend cette distinction visible directement dans les synthèses.

## Comment

- Nouvelle tile PostHog « Primo-visiteurs » (`first_time_for_user`), lue de façon **défensive** via `extractNewVisitors` : si la tile est absente, la répartition est simplement masquée (code sûr à merger seul).
- Revenants = `uniques (dau) − primo`, calculés sur la même population (`filterTestAccounts` identique), avec clamp ≥ 0.
- Lecture après `patchUniqueVisitors` → cohérence email/Slack garantie.
- Caveat affiché : la distinction n'est fiable qu'à partir du 18/06/2026 (date du fix), le temps que les récurrents accumulent un historique post-correction.

## Côté PostHog (déjà en place, hors repo)

Tiles créées via API : « Primo-visiteurs – 24h » (dashboard quotidien), « – 7j » (hebdo), « – 30j » (mensuel), + insights Lifecycle (Dormant masqué).

## Tests & vérifs

- 27 tests verts (rendu du bloc, cas tile présente/absente, clamp, helpers)
- `pnpm typecheck` ✅
- Aucun changement de schéma DB
- Passé par `/code-review` (effort élevé) : aucun bug de correctness, 2 nettoyages optionnels non bloquants

🤖 Generated with [Claude Code](https://claude.com/claude-code)