### PR TITLE
fix(moment): n'envoie les notifs de modification que pour les événements publiés

### DIFF
--- a/src/app/actions/moment.ts
+++ b/src/app/actions/moment.ts
@@ -271,7 +271,10 @@ export async function updateMomentAction(
       await vercelBlobStorageService.delete(oldCoverImage);
     }
 
-    // Notifier les participants si date/heure ou lieu ont changé
+    // Notifier les participants si date/heure ou lieu ont changé.
+    // Uniquement pour les événements PUBLISHED : un brouillon n'a pas
+    // d'inscrits légitimes (seuls les organisateurs y sont auto-inscrits),
+    // et un passage DRAFT → PUBLISHED est couvert par la notif de création.
     if (existingMoment) {
       const dateChanged =
         (startsAtRaw && new Date(startsAtRaw).getTime() !== existingMoment.startsAt.getTime()) ||
@@ -285,7 +288,11 @@ export async function updateMomentAction(
         (locationName !== null && locationName !== existingMoment.locationName) ||
         (locationAddress !== null && locationAddress !== existingMoment.locationAddress);
 
-      if ((dateChanged || locationChanged) && !isAdminUser(session)) {
+      if (
+        (dateChanged || locationChanged) &&
+        existingMoment.status === "PUBLISHED" &&
+        !isAdminUser(session)
+      ) {
         const resolver = await buildEmailLocaleResolver(userId);
         sendMomentUpdateEmails(
           result.moment,


### PR DESCRIPTION
## Problème

L'organisateur recevait un email « événement modifié » lorsqu'il modifiait la date ou le lieu d'un événement **encore en brouillon** (`DRAFT`).

Cause : à la création d'un Moment, tous les organisateurs actifs (HOST + CO_HOST) sont auto-inscrits `REGISTERED` (`create-moment.ts`). Le bloc de notif de modification (`updateMomentAction`) ne filtrait pas le statut, contrairement au bloc de notif admin juste en dessous. Résultat : modifier un brouillon faisait partir une notif « date/lieu modifié » à l'organisateur, alors que l'événement n'est pas publié et que c'est souvent lui-même qui venait de faire la modification.

## Correctif

Aligne la notif participants sur la notif admin : envoi conditionné à `existingMoment.status === "PUBLISHED"`.

- `existingMoment.status` (et non `result.moment.status`) : un passage `DRAFT → PUBLISHED` via `intent=publish` est déjà couvert par `sendMomentPublishedNotifications`, donc on évite une fausse notif « date changée » lors de la publication.
- Cohérent avec le bloc de notif admin voisin qui utilise le même test.

## Portée

- 1 fichier, `src/app/actions/moment.ts` (une condition + commentaire).
- Pas de changement de schema Prisma.
- Pas de test à mettre à jour (logique dans une server action, non couverte par les tests unitaires).

## Vérifications

- `pnpm typecheck` ✅
- `/code-review` (high) : aucun bug introduit, candidats PAST/CANCELLED/race écartés sur le code (comportements préexistants ou sans effet pratique).

🤖 Generated with [Claude Code](https://claude.com/claude-code)