### PR TITLE
feat(security): bloquer le contact des organisateurs pour les comptes de moins de 24h

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -2012,6 +2012,7 @@
     "successTitle": "Message sent",
     "successDescription": "The organizer will receive your message in a few moments.",
     "errorRateLimited": "You've already sent several messages recently. Please try again in an hour.",
+    "errorAccountTooNew": "Your account is too new to contact the organizers. This option will be available 24 hours after it was created.",
     "errorTooShort": "Message must be at least {min} characters.",
     "errorTooLong": "Message cannot exceed {max} characters.",
     "errorNoHosts": "This Community has no reachable organizer at the moment.",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -2012,6 +2012,7 @@
     "successTitle": "Message envoyé",
     "successDescription": "L'organisateur recevra votre message dans quelques instants.",
     "errorRateLimited": "Vous avez déjà envoyé plusieurs messages récemment. Réessayez dans une heure.",
+    "errorAccountTooNew": "Votre compte est trop récent pour contacter les organisateurs. Cette option sera disponible 24 heures après sa création.",
     "errorTooShort": "Le message doit faire au moins {min} caractères.",
     "errorTooLong": "Le message ne peut pas dépasser {max} caractères.",
     "errorNoHosts": "Cette Communauté n'a pas d'organisateur joignable pour le moment.",

--- a/scripts/db-dev-seed-test-users.ts
+++ b/scripts/db-dev-seed-test-users.ts
@@ -23,6 +23,11 @@ const adapter = new PrismaNeon({
 const prisma = new PrismaClient({ adapter });
 
 async function main() {
+  // Comptes "établis" (créés il y a 30 jours) : depuis le hard gate 24h sur
+  // « Contacter les organisateurs », un user créé à l'instant (createdAt = now)
+  // serait gaté. On simule des comptes normaux.
+  const establishedCreatedAt = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+
   for (const { email, firstName, lastName } of TEST_USERS) {
     const name = `${firstName} ${lastName}`;
     const user = await prisma.user.upsert({
@@ -34,6 +39,7 @@ async function main() {
         lastName,
         onboardingCompleted: true,
         emailVerified: new Date(),
+        createdAt: establishedCreatedAt,
       },
       update: {
         name,
@@ -41,6 +47,7 @@ async function main() {
         lastName,
         onboardingCompleted: true,
         emailVerified: new Date(),
+        createdAt: establishedCreatedAt,
       },
     });
     console.log(`✓ ${user.email} (${user.name}) — id: ${user.id}`);

--- a/scripts/db-seed-test-data.ts
+++ b/scripts/db-seed-test-data.ts
@@ -360,6 +360,11 @@ async function main() {
   console.log("👤 Utilisateurs...");
   const userMap: Record<string, string> = {};
 
+  // Comptes "établis" (créés il y a 30 jours) : représente le cas normal des
+  // flows E2E. Indispensable depuis le hard gate 24h sur « Contacter les
+  // organisateurs » — un user fraîchement créé (createdAt = now) serait gaté.
+  const establishedCreatedAt = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+
   for (const { key, email, firstName, lastName, dashboardMode, publicId } of USERS) {
     const user = await prisma.user.upsert({
       where: { email },
@@ -372,6 +377,7 @@ async function main() {
         onboardingCompleted: true,
         emailVerified: new Date(),
         dashboardMode,
+        createdAt: establishedCreatedAt,
       },
       update: {
         name: `${firstName} ${lastName}`,
@@ -381,6 +387,7 @@ async function main() {
         onboardingCompleted: true,
         emailVerified: new Date(),
         dashboardMode,
+        createdAt: establishedCreatedAt,
       },
     });
     userMap[key] = user.id;

--- a/src/app/[locale]/(routes)/circles/[slug]/page.tsx
+++ b/src/app/[locale]/(routes)/circles/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { cache } from "react";
 import { notFound } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 import { measureTime } from "@/lib/perf-logger";
+import { isNewAccount } from "@/lib/account-trust";
 import { signInUrlWithAutoJoin } from "@/lib/auto-join";
 import { degradedQuery } from "@/lib/degraded-query";
 import { stripProtocol } from "@/lib/url";
@@ -310,6 +311,9 @@ export default async function PublicCirclePage({
                     signInUrl: isConnected
                       ? null
                       : `/${locale}/auth/sign-in?callbackUrl=/${locale}/circles/${slug}`,
+                    accountTooNew:
+                      !!session?.user &&
+                      isNewAccount(session.user.createdAt, new Date()),
                   }
             }
           />

--- a/src/app/[locale]/(routes)/circles/[slug]/page.tsx
+++ b/src/app/[locale]/(routes)/circles/[slug]/page.tsx
@@ -2,7 +2,7 @@ import { cache } from "react";
 import { notFound } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 import { measureTime } from "@/lib/perf-logger";
-import { isNewAccount } from "@/lib/account-trust";
+import { isSessionAccountNew } from "@/lib/account-trust";
 import { signInUrlWithAutoJoin } from "@/lib/auto-join";
 import { degradedQuery } from "@/lib/degraded-query";
 import { stripProtocol } from "@/lib/url";
@@ -311,9 +311,7 @@ export default async function PublicCirclePage({
                     signInUrl: isConnected
                       ? null
                       : `/${locale}/auth/sign-in?callbackUrl=/${locale}/circles/${slug}`,
-                    accountTooNew:
-                      !!session?.user &&
-                      isNewAccount(session.user.createdAt, new Date()),
+                    accountTooNew: isSessionAccountNew(session),
                   }
             }
           />

--- a/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/moments/[momentSlug]/page.tsx
+++ b/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/moments/[momentSlug]/page.tsx
@@ -12,7 +12,7 @@ import { getMomentBySlug } from "@/domain/usecases/get-moment";
 import { getMomentComments } from "@/domain/usecases/get-moment-comments";
 import { CircleNotFoundError, MomentNotFoundError } from "@/domain/errors";
 import { MomentDetailView } from "@/components/moments/moment-detail-view";
-import { isNewAccount } from "@/lib/account-trust";
+import { isSessionAccountNew } from "@/lib/account-trust";
 import { resolveCircleRepository } from "@/lib/admin-host-mode";
 import { isActiveOrganizer } from "@/domain/models/circle";
 import { redirectToPublicMoment } from "@/lib/dashboard-event-public-redirect";
@@ -111,7 +111,7 @@ export default async function MomentDetailPage({
         attachments={attachments}
         currentUserId={session.user.id}
         currentUserEmail={session.user.email ?? null}
-        contactAccountTooNew={isNewAccount(session.user.createdAt, new Date())}
+        contactAccountTooNew={isSessionAccountNew(session)}
         isAuthenticated={true}
         isOrganizer={false}
         existingRegistration={existingRegistration}

--- a/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/moments/[momentSlug]/page.tsx
+++ b/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/moments/[momentSlug]/page.tsx
@@ -12,6 +12,7 @@ import { getMomentBySlug } from "@/domain/usecases/get-moment";
 import { getMomentComments } from "@/domain/usecases/get-moment-comments";
 import { CircleNotFoundError, MomentNotFoundError } from "@/domain/errors";
 import { MomentDetailView } from "@/components/moments/moment-detail-view";
+import { isNewAccount } from "@/lib/account-trust";
 import { resolveCircleRepository } from "@/lib/admin-host-mode";
 import { isActiveOrganizer } from "@/domain/models/circle";
 import { redirectToPublicMoment } from "@/lib/dashboard-event-public-redirect";
@@ -110,6 +111,7 @@ export default async function MomentDetailPage({
         attachments={attachments}
         currentUserId={session.user.id}
         currentUserEmail={session.user.email ?? null}
+        contactAccountTooNew={isNewAccount(session.user.createdAt, new Date())}
         isAuthenticated={true}
         isOrganizer={false}
         existingRegistration={existingRegistration}

--- a/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/page.tsx
+++ b/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation";
 import { getLocale, getTranslations } from "next-intl/server";
 import { stripProtocol } from "@/lib/url";
+import { isNewAccount } from "@/lib/account-trust";
 import { degradedQuery } from "@/lib/degraded-query";
 import { formatLongDate } from "@/lib/format-date";
 import type { RegistrationWithUser } from "@/domain/models/registration";
@@ -219,6 +220,10 @@ export default async function CircleDetailPage({
                     circleId: circle.id,
                     senderEmail: session.user.email ?? null,
                     signInUrl: null,
+                    accountTooNew: isNewAccount(
+                      session.user.createdAt,
+                      new Date()
+                    ),
                   }
             }
           />

--- a/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/page.tsx
+++ b/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from "next/navigation";
 import { getLocale, getTranslations } from "next-intl/server";
 import { stripProtocol } from "@/lib/url";
-import { isNewAccount } from "@/lib/account-trust";
+import { isSessionAccountNew } from "@/lib/account-trust";
 import { degradedQuery } from "@/lib/degraded-query";
 import { formatLongDate } from "@/lib/format-date";
 import type { RegistrationWithUser } from "@/domain/models/registration";
@@ -220,10 +220,7 @@ export default async function CircleDetailPage({
                     circleId: circle.id,
                     senderEmail: session.user.email ?? null,
                     signInUrl: null,
-                    accountTooNew: isNewAccount(
-                      session.user.createdAt,
-                      new Date()
-                    ),
+                    accountTooNew: isSessionAccountNew(session),
                   }
             }
           />

--- a/src/app/[locale]/(routes)/m/[slug]/page.tsx
+++ b/src/app/[locale]/(routes)/m/[slug]/page.tsx
@@ -28,6 +28,7 @@ import { getMomentComments } from "@/domain/usecases/get-moment-comments";
 import { MomentNotFoundError } from "@/domain/errors";
 import { MomentViewTracker } from "@/components/moments/moment-view-tracker";
 import { MomentDetailView } from "@/components/moments/moment-detail-view";
+import { isNewAccount } from "@/lib/account-trust";
 import { promoteCurrentUserFirst } from "@/lib/sort-participants";
 
 // Deduplicate DB calls between generateMetadata and the page
@@ -277,6 +278,9 @@ export default async function PublicMomentPage({
         attachments={attachments}
         currentUserId={session?.user?.id ?? null}
         currentUserEmail={session?.user?.email ?? null}
+        contactAccountTooNew={
+          !!session?.user && isNewAccount(session.user.createdAt, new Date())
+        }
         isAuthenticated={isAuthenticated}
         isOrganizer={isOrganizer}
         existingRegistration={existingRegistration}

--- a/src/app/[locale]/(routes)/m/[slug]/page.tsx
+++ b/src/app/[locale]/(routes)/m/[slug]/page.tsx
@@ -28,7 +28,7 @@ import { getMomentComments } from "@/domain/usecases/get-moment-comments";
 import { MomentNotFoundError } from "@/domain/errors";
 import { MomentViewTracker } from "@/components/moments/moment-view-tracker";
 import { MomentDetailView } from "@/components/moments/moment-detail-view";
-import { isNewAccount } from "@/lib/account-trust";
+import { isSessionAccountNew } from "@/lib/account-trust";
 import { promoteCurrentUserFirst } from "@/lib/sort-participants";
 
 // Deduplicate DB calls between generateMetadata and the page
@@ -278,9 +278,7 @@ export default async function PublicMomentPage({
         attachments={attachments}
         currentUserId={session?.user?.id ?? null}
         currentUserEmail={session?.user?.email ?? null}
-        contactAccountTooNew={
-          !!session?.user && isNewAccount(session.user.createdAt, new Date())
-        }
+        contactAccountTooNew={isSessionAccountNew(session)}
         isAuthenticated={isAuthenticated}
         isOrganizer={isOrganizer}
         existingRegistration={existingRegistration}

--- a/src/app/actions/contact-hosts.ts
+++ b/src/app/actions/contact-hosts.ts
@@ -40,6 +40,7 @@ export async function contactCircleHostsAction(input: {
         emailService,
         rateLimiter: prismaRateLimiter,
         appUrl: getAppUrl(),
+        now: new Date(),
         emailStrings: {
           subject: t("subject"),
           heading: t("heading"),

--- a/src/components/circles/circle-organizers-list.tsx
+++ b/src/components/circles/circle-organizers-list.tsx
@@ -8,6 +8,8 @@ type ContactOrganizerConfig = {
   circleId: string;
   senderEmail: string | null;
   signInUrl: string | null;
+  /** Compte de moins de 24h : grise le lien "Contacter l'organisateur". */
+  accountTooNew?: boolean;
 };
 
 type Props = {
@@ -77,6 +79,7 @@ export function CircleOrganizersList({ organizers, linkable, label, anonymousFal
             circleId={contactOrganizer.circleId}
             senderEmail={contactOrganizer.senderEmail}
             signInUrl={contactOrganizer.signInUrl}
+            accountTooNew={contactOrganizer.accountTooNew}
           />
         )}
       </div>

--- a/src/components/contact-organizer-link.tsx
+++ b/src/components/contact-organizer-link.tsx
@@ -45,8 +45,9 @@ type Props = {
   accountTooNew?: boolean;
 };
 
-const triggerClassName =
-  "group inline-flex items-center gap-1.5 py-1 text-xs font-normal text-muted-foreground hover:text-primary dark:hover:text-[oklch(0.76_0.27_341)] transition-colors";
+const baseTriggerClassName =
+  "inline-flex items-center gap-1.5 py-1 text-xs font-normal text-muted-foreground";
+const triggerClassName = `group ${baseTriggerClassName} hover:text-primary dark:hover:text-[oklch(0.76_0.27_341)] transition-colors`;
 
 function TriggerInner() {
   const t = useTranslations("ContactOrganizer");
@@ -58,8 +59,7 @@ function TriggerInner() {
   );
 }
 
-const disabledTriggerClassName =
-  "inline-flex items-center gap-1.5 py-1 text-xs font-normal text-muted-foreground opacity-50 cursor-not-allowed";
+const disabledTriggerClassName = `${baseTriggerClassName} opacity-50 cursor-not-allowed`;
 
 export function ContactOrganizerLink({
   circleId,

--- a/src/components/contact-organizer-link.tsx
+++ b/src/components/contact-organizer-link.tsx
@@ -141,6 +141,8 @@ function errorMessageFor(
   switch (code) {
     case CONTACT_ERROR_CODES.ContactHostsRateLimited:
       return t("errorRateLimited");
+    case CONTACT_ERROR_CODES.ContactHostsAccountTooNew:
+      return t("errorAccountTooNew");
     case CONTACT_ERROR_CODES.ContactMessageTooShort:
       return t("errorTooShort", { min: CONTACT_MESSAGE_MIN_LENGTH });
     case CONTACT_ERROR_CODES.ContactMessageTooLong:

--- a/src/components/contact-organizer-link.tsx
+++ b/src/components/contact-organizer-link.tsx
@@ -16,6 +16,12 @@ import {
 } from "@/components/ui/dialog";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { contactCircleHostsAction } from "@/app/actions/contact-hosts";
 import {
   CONTACT_MESSAGE_MAX_LENGTH,
@@ -30,6 +36,13 @@ type Props = {
   senderEmail: string | null;
   /** Non-null = visiteur non auth → le trigger devient un lien vers signin. */
   signInUrl: string | null;
+  /**
+   * Vrai = compte de moins de 24h (non-organisateur) : on anticipe le gate
+   * serveur en grisant le trigger (tooltip desktop + toast au tap mobile),
+   * plutôt que de laisser écrire un message refusé à l'envoi. Le gate serveur
+   * reste la source de vérité.
+   */
+  accountTooNew?: boolean;
 };
 
 const triggerClassName =
@@ -45,11 +58,15 @@ function TriggerInner() {
   );
 }
 
+const disabledTriggerClassName =
+  "inline-flex items-center gap-1.5 py-1 text-xs font-normal text-muted-foreground opacity-50 cursor-not-allowed";
+
 export function ContactOrganizerLink({
   circleId,
   momentId,
   senderEmail,
   signInUrl,
+  accountTooNew,
 }: Props) {
   const t = useTranslations("ContactOrganizer");
   const [open, setOpen] = React.useState(false);
@@ -61,6 +78,31 @@ export function ContactOrganizerLink({
       <a href={signInUrl} className={triggerClassName} aria-label={t("signInToContact")}>
         <TriggerInner />
       </a>
+    );
+  }
+
+  // Compte de moins de 24h : on anticipe le refus serveur. Trigger grisé,
+  // explication au survol (desktop) et au tap via toast (mobile, pas de hover).
+  // `aria-disabled` plutôt que `disabled` natif pour que le tap déclenche quand
+  // même le toast.
+  if (accountTooNew) {
+    const reason = t("errorAccountTooNew");
+    return (
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              aria-disabled="true"
+              className={disabledTriggerClassName}
+              onClick={() => toast.info(reason)}
+            >
+              <TriggerInner />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent className="max-w-xs">{reason}</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
     );
   }
 

--- a/src/components/moments/moment-detail-view.tsx
+++ b/src/components/moments/moment-detail-view.tsx
@@ -91,6 +91,8 @@ type PublicViewProps = CommonProps & {
   upcomingCircleMoments: UpcomingCircleMoment[];
   /** Email du Participant connecté — pour la note "reply-to" du formulaire de contact. */
   currentUserEmail: string | null;
+  /** Compte de moins de 24h : grise le bouton "Contacter l'organisateur". */
+  contactAccountTooNew: boolean;
 };
 
 export type MomentDetailViewProps = HostViewProps | PublicViewProps;
@@ -376,6 +378,7 @@ export async function MomentDetailView(props: MomentDetailViewProps) {
                     momentId={moment.id}
                     senderEmail={publicProps.currentUserEmail}
                     signInUrl={publicProps.isAuthenticated ? null : publicProps.signInUrl}
+                    accountTooNew={publicProps.contactAccountTooNew}
                   />
                 )}
               </div>

--- a/src/domain/errors/contact-errors.ts
+++ b/src/domain/errors/contact-errors.ts
@@ -6,6 +6,7 @@ export const CONTACT_ERROR_CODES = {
   ContactMessageTooShort: "CONTACT_MESSAGE_TOO_SHORT",
   ContactMessageTooLong: "CONTACT_MESSAGE_TOO_LONG",
   ContactHostsRateLimited: "CONTACT_HOSTS_RATE_LIMITED",
+  ContactHostsAccountTooNew: "CONTACT_HOSTS_ACCOUNT_TOO_NEW",
   SenderEmailMissing: "SENDER_EMAIL_MISSING",
 } as const;
 
@@ -46,6 +47,16 @@ export class ContactHostsRateLimitedError extends DomainError {
 
   constructor() {
     super("Too many contact messages sent in the last hour");
+  }
+}
+
+export class ContactHostsAccountTooNewError extends DomainError {
+  readonly code = CONTACT_ERROR_CODES.ContactHostsAccountTooNew;
+
+  constructor(minAgeHours: number) {
+    super(
+      `Account must be at least ${minAgeHours} hours old to contact organizers`
+    );
   }
 }
 

--- a/src/domain/errors/index.ts
+++ b/src/domain/errors/index.ts
@@ -65,6 +65,7 @@ export {
   ContactMessageTooShortError,
   ContactMessageTooLongError,
   ContactHostsRateLimitedError,
+  ContactHostsAccountTooNewError,
   SenderEmailMissingError,
 } from "./contact-errors";
 export {

--- a/src/domain/usecases/__tests__/contact-circle-hosts.test.ts
+++ b/src/domain/usecases/__tests__/contact-circle-hosts.test.ts
@@ -7,6 +7,7 @@ import {
 } from "@/domain/usecases/contact-circle-hosts";
 import {
   CircleNotFoundError,
+  ContactHostsAccountTooNewError,
   ContactHostsRateLimitedError,
   ContactMessageTooLongError,
   ContactMessageTooShortError,
@@ -85,6 +86,7 @@ function makeDeps(overrides: {
   sender?: ReturnType<typeof makeUser> | null;
   circle?: ReturnType<typeof makeCircle> | null;
   moment?: ReturnType<typeof makeMoment> | null;
+  now?: Date;
 } = {}) {
   const sender =
     overrides.sender === undefined
@@ -116,6 +118,9 @@ function makeDeps(overrides: {
     rateLimiter,
     emailStrings,
     appUrl: "https://app.example.com",
+    // Par défaut bien après le createdAt des users mockés (2026-01-01) : le gate
+    // « compte trop récent » ne se déclenche pas, sauf override explicite.
+    now: overrides.now ?? new Date("2026-06-15T12:00:00.000Z"),
   };
 }
 
@@ -249,6 +254,66 @@ describe("contactCircleHosts", () => {
           deps
         )
       ).rejects.toThrow(NoHostsToContactError);
+    });
+  });
+
+  describe("given the sender account is less than 24h old", () => {
+    const now = new Date("2026-06-15T12:00:00.000Z");
+
+    it("should throw ContactHostsAccountTooNewError when the sender is not an organizer", async () => {
+      const deps = makeDeps({
+        now,
+        sender: makeUser({
+          id: SENDER_ID,
+          email: "player@example.com",
+          createdAt: new Date("2026-06-15T06:00:00.000Z"), // 6h ago
+        }),
+        organizers: [makeOrganizer({ userId: "host-1", email: "host-1@example.com" })],
+      });
+      await expect(
+        contactCircleHosts(
+          { senderId: SENDER_ID, circleId: CIRCLE_ID, message: validMessage() },
+          deps
+        )
+      ).rejects.toThrow(ContactHostsAccountTooNewError);
+      expect(deps.emailService.sendHostContactMessage).not.toHaveBeenCalled();
+    });
+
+    it("should allow a new account that is itself an active organizer of the circle", async () => {
+      const deps = makeDeps({
+        now,
+        sender: makeUser({
+          id: SENDER_ID,
+          email: "player@example.com",
+          createdAt: new Date("2026-06-15T06:00:00.000Z"),
+        }),
+        organizers: [
+          makeOrganizer({ userId: SENDER_ID, email: "player@example.com" }),
+          makeOrganizer({ userId: "host-2", email: "host-2@example.com" }),
+        ],
+      });
+      const result = await contactCircleHosts(
+        { senderId: SENDER_ID, circleId: CIRCLE_ID, message: validMessage() },
+        deps
+      );
+      expect(result.recipientsCount).toBe(2);
+    });
+
+    it("should allow an account exactly 24h old (strict boundary)", async () => {
+      const deps = makeDeps({
+        now,
+        sender: makeUser({
+          id: SENDER_ID,
+          email: "player@example.com",
+          createdAt: new Date(now.getTime() - 24 * 60 * 60 * 1000),
+        }),
+        organizers: [makeOrganizer({ userId: "host-1", email: "host-1@example.com" })],
+      });
+      const result = await contactCircleHosts(
+        { senderId: SENDER_ID, circleId: CIRCLE_ID, message: validMessage() },
+        deps
+      );
+      expect(result.recipientsCount).toBe(1);
     });
   });
 

--- a/src/domain/usecases/contact-circle-hosts.ts
+++ b/src/domain/usecases/contact-circle-hosts.ts
@@ -5,8 +5,10 @@ import type { EmailService } from "@/domain/ports/services/email-service";
 import type { RateLimiter } from "@/domain/ports/services/rate-limiter";
 import { isOrganizerRole } from "@/domain/models/circle";
 import { getDisplayName } from "@/lib/display-name";
+import { isNewAccount, NEW_ACCOUNT_WINDOW_HOURS } from "@/lib/account-trust";
 import {
   CircleNotFoundError,
+  ContactHostsAccountTooNewError,
   ContactHostsRateLimitedError,
   ContactMessageTooLongError,
   ContactMessageTooShortError,
@@ -53,6 +55,8 @@ export type ContactCircleHostsDeps = {
   };
   /** URL de base utilisée par le template pour charger le logo. */
   appUrl: string;
+  /** Horloge injectée (déterminisme/tests) pour le gate « compte trop récent ». */
+  now: Date;
 };
 
 export type ContactCircleHostsResult = {
@@ -102,6 +106,18 @@ export async function contactCircleHosts(
   if (moment && moment.circleId !== input.circleId) {
     throw new MomentNotInCircleError(input.momentId!, input.circleId);
   }
+
+  // Hard gate anti-nuisance : un compte de moins de 24h ne peut pas contacter
+  // les organisateurs, SAUF s'il est lui-même organisateur actif du Circle (ne
+  // jamais gater quelqu'un sur sa propre Communauté). `organizers` est déjà
+  // filtré HOST/CO_HOST + ACTIVE par le repository.
+  const senderIsOrganizer = organizers.some(
+    (m) => m.user.id === input.senderId && isOrganizerRole(m.role) && m.status === "ACTIVE"
+  );
+  if (!senderIsOrganizer && isNewAccount(sender.createdAt, deps.now)) {
+    throw new ContactHostsAccountTooNewError(NEW_ACCOUNT_WINDOW_HOURS);
+  }
+
   if (!rateLimit.allowed) throw new ContactHostsRateLimitedError();
 
   const activeHosts = organizers.filter(

--- a/src/infrastructure/auth/auth.config.ts
+++ b/src/infrastructure/auth/auth.config.ts
@@ -255,7 +255,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
       session.user.onboardingCompleted = dbUser.onboardingCompleted;
       session.user.role = dbUser.role;
       session.user.dashboardMode = dbUser.dashboardMode ?? null;
-      session.user.createdAt = new Date(dbUser.createdAt);
+      session.user.createdAt = new Date(dbUser.createdAt).getTime();
       const ageMs = Date.now() - new Date(dbUser.createdAt).getTime();
       session.user.isNewUser = ageMs < NEW_USER_WINDOW_MS;
       return session;

--- a/src/infrastructure/auth/auth.config.ts
+++ b/src/infrastructure/auth/auth.config.ts
@@ -255,6 +255,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
       session.user.onboardingCompleted = dbUser.onboardingCompleted;
       session.user.role = dbUser.role;
       session.user.dashboardMode = dbUser.dashboardMode ?? null;
+      session.user.createdAt = new Date(dbUser.createdAt);
       const ageMs = Date.now() - new Date(dbUser.createdAt).getTime();
       session.user.isNewUser = ageMs < NEW_USER_WINDOW_MS;
       return session;

--- a/src/infrastructure/auth/auth.d.ts
+++ b/src/infrastructure/auth/auth.d.ts
@@ -11,6 +11,7 @@ declare module "next-auth" {
       role: "USER" | "ADMIN";
       dashboardMode: "PARTICIPANT" | "ORGANIZER" | null;
       isNewUser?: boolean;
+      createdAt: Date;
     };
   }
 }

--- a/src/infrastructure/auth/auth.d.ts
+++ b/src/infrastructure/auth/auth.d.ts
@@ -11,7 +11,8 @@ declare module "next-auth" {
       role: "USER" | "ADMIN";
       dashboardMode: "PARTICIPANT" | "ORGANIZER" | null;
       isNewUser?: boolean;
-      createdAt: Date;
+      /** Epoch millis (sérialisable, contrairement à un Date qui devient string en RSC). */
+      createdAt: number;
     };
   }
 }

--- a/src/lib/__tests__/account-trust.test.ts
+++ b/src/lib/__tests__/account-trust.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   isNewAccount,
+  isSessionAccountNew,
   NEW_ACCOUNT_WINDOW_HOURS,
   NEW_ACCOUNT_WINDOW_MS,
 } from "@/lib/account-trust";
@@ -40,8 +41,35 @@ describe("isNewAccount", () => {
     expect(isNewAccount(now.getTime() - 48 * 60 * 60 * 1000, now)).toBe(false);
   });
 
+  it("should fail-closed on an invalid createdAt (NaN) and treat it as new", () => {
+    expect(isNewAccount("not-a-date", now)).toBe(true);
+    expect(isNewAccount(NaN, now)).toBe(true);
+  });
+
   it("should expose a 24h window", () => {
     expect(NEW_ACCOUNT_WINDOW_HOURS).toBe(24);
     expect(NEW_ACCOUNT_WINDOW_MS).toBe(24 * 60 * 60 * 1000);
+  });
+});
+
+describe("isSessionAccountNew", () => {
+  it("should be false when there is no session", () => {
+    expect(isSessionAccountNew(null)).toBe(false);
+    expect(isSessionAccountNew(undefined)).toBe(false);
+    expect(isSessionAccountNew({})).toBe(false);
+  });
+
+  it("should be true for a session whose account is under 24h", () => {
+    expect(
+      isSessionAccountNew({ user: { createdAt: Date.now() - 60 * 1000 } })
+    ).toBe(true);
+  });
+
+  it("should be false for a session whose account is older than 24h", () => {
+    expect(
+      isSessionAccountNew({
+        user: { createdAt: Date.now() - 48 * 60 * 60 * 1000 },
+      })
+    ).toBe(false);
   });
 });

--- a/src/lib/__tests__/account-trust.test.ts
+++ b/src/lib/__tests__/account-trust.test.ts
@@ -28,6 +28,18 @@ describe("isNewAccount", () => {
     expect(isNewAccount(createdAt, now)).toBe(false);
   });
 
+  it("should accept a serialized createdAt (ISO string, e.g. from a NextAuth session)", () => {
+    const recentIso = new Date(now.getTime() - 60 * 1000).toISOString();
+    expect(isNewAccount(recentIso, now)).toBe(true);
+    const oldIso = new Date(now.getTime() - 48 * 60 * 60 * 1000).toISOString();
+    expect(isNewAccount(oldIso, now)).toBe(false);
+  });
+
+  it("should accept a createdAt as epoch millis (number)", () => {
+    expect(isNewAccount(now.getTime() - 60 * 1000, now)).toBe(true);
+    expect(isNewAccount(now.getTime() - 48 * 60 * 60 * 1000, now)).toBe(false);
+  });
+
   it("should expose a 24h window", () => {
     expect(NEW_ACCOUNT_WINDOW_HOURS).toBe(24);
     expect(NEW_ACCOUNT_WINDOW_MS).toBe(24 * 60 * 60 * 1000);

--- a/src/lib/__tests__/account-trust.test.ts
+++ b/src/lib/__tests__/account-trust.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import {
+  isNewAccount,
+  NEW_ACCOUNT_WINDOW_HOURS,
+  NEW_ACCOUNT_WINDOW_MS,
+} from "@/lib/account-trust";
+
+describe("isNewAccount", () => {
+  const now = new Date("2026-06-15T12:00:00.000Z");
+
+  it("should be true for an account created a few minutes ago", () => {
+    const createdAt = new Date(now.getTime() - 10 * 60 * 1000);
+    expect(isNewAccount(createdAt, now)).toBe(true);
+  });
+
+  it("should be true just under the 24h window", () => {
+    const createdAt = new Date(now.getTime() - (NEW_ACCOUNT_WINDOW_MS - 1));
+    expect(isNewAccount(createdAt, now)).toBe(true);
+  });
+
+  it("should be false exactly at the 24h boundary (strict <)", () => {
+    const createdAt = new Date(now.getTime() - NEW_ACCOUNT_WINDOW_MS);
+    expect(isNewAccount(createdAt, now)).toBe(false);
+  });
+
+  it("should be false for an account older than 24h", () => {
+    const createdAt = new Date(now.getTime() - 48 * 60 * 60 * 1000);
+    expect(isNewAccount(createdAt, now)).toBe(false);
+  });
+
+  it("should expose a 24h window", () => {
+    expect(NEW_ACCOUNT_WINDOW_HOURS).toBe(24);
+    expect(NEW_ACCOUNT_WINDOW_MS).toBe(24 * 60 * 60 * 1000);
+  });
+});

--- a/src/lib/account-trust.ts
+++ b/src/lib/account-trust.ts
@@ -11,7 +11,13 @@
 export const NEW_ACCOUNT_WINDOW_HOURS = 24;
 export const NEW_ACCOUNT_WINDOW_MS = NEW_ACCOUNT_WINDOW_HOURS * 60 * 60 * 1000;
 
-/** Vrai si le compte a été créé il y a moins de `NEW_ACCOUNT_WINDOW_MS`. */
-export function isNewAccount(createdAt: Date, now: Date): boolean {
-  return now.getTime() - createdAt.getTime() < NEW_ACCOUNT_WINDOW_MS;
+/**
+ * Vrai si le compte a été créé il y a moins de `NEW_ACCOUNT_WINDOW_MS`.
+ *
+ * `createdAt` est coercé via `new Date(...)` : côté domaine c'est un vrai `Date`
+ * (mapping Prisma), mais côté session NextAuth il arrive sérialisé en string
+ * après le passage RSC. On accepte donc Date | string | number.
+ */
+export function isNewAccount(createdAt: Date | string | number, now: Date): boolean {
+  return now.getTime() - new Date(createdAt).getTime() < NEW_ACCOUNT_WINDOW_MS;
 }

--- a/src/lib/account-trust.ts
+++ b/src/lib/account-trust.ts
@@ -17,7 +17,26 @@ export const NEW_ACCOUNT_WINDOW_MS = NEW_ACCOUNT_WINDOW_HOURS * 60 * 60 * 1000;
  * `createdAt` est coercé via `new Date(...)` : côté domaine c'est un vrai `Date`
  * (mapping Prisma), mais côté session NextAuth il arrive sérialisé en string
  * après le passage RSC. On accepte donc Date | string | number.
+ *
+ * **Fail-closed** : un `createdAt` invalide (`NaN`) est traité comme « nouveau »
+ * → le gate s'applique. Pour un gate de sécurité, mieux vaut bloquer dans le
+ * doute que laisser passer (le cas est en pratique inatteignable, `createdAt`
+ * étant non-null garanti).
  */
 export function isNewAccount(createdAt: Date | string | number, now: Date): boolean {
-  return now.getTime() - new Date(createdAt).getTime() < NEW_ACCOUNT_WINDOW_MS;
+  const createdMs = new Date(createdAt).getTime();
+  if (Number.isNaN(createdMs)) return true;
+  return now.getTime() - createdMs < NEW_ACCOUNT_WINDOW_MS;
+}
+
+/**
+ * Variante au niveau session : vrai si l'utilisateur connecté a un compte de
+ * moins de 24h. Centralise le calcul utilisé par les pages qui anticipent le
+ * gate (grisé du bouton « Contacter l'organisateur »), avec un guard uniforme
+ * sur l'absence de session. Type structurel pour rester découplé de NextAuth.
+ */
+export function isSessionAccountNew(
+  session: { user?: { createdAt: number } } | null | undefined
+): boolean {
+  return !!session?.user && isNewAccount(session.user.createdAt, new Date());
 }

--- a/src/lib/account-trust.ts
+++ b/src/lib/account-trust.ts
@@ -1,0 +1,17 @@
+/**
+ * Confiance liée à l'ancienneté d'un compte.
+ *
+ * Helper pur (sans dépendance infra) : sert à durcir les actions à fort
+ * potentiel de nuisance (contacter les organisateurs, commenter) pour les
+ * comptes très récents, qui sont le profil typique d'un abus « créer un compte,
+ * frapper tout de suite, recommencer ». `now` est passé explicitement pour
+ * rester déterministe et testable.
+ */
+
+export const NEW_ACCOUNT_WINDOW_HOURS = 24;
+export const NEW_ACCOUNT_WINDOW_MS = NEW_ACCOUNT_WINDOW_HOURS * 60 * 60 * 1000;
+
+/** Vrai si le compte a été créé il y a moins de `NEW_ACCOUNT_WINDOW_MS`. */
+export function isNewAccount(createdAt: Date, now: Date): boolean {
+  return now.getTime() - createdAt.getTime() < NEW_ACCOUNT_WINDOW_MS;
+}


### PR DESCRIPTION
## Contexte

Première brique du durcissement des vecteurs de nuisance (le gate sign-in BotID étant passé en `observe`, cf. #562, les gates au niveau des actions deviennent la défense réelle). Objectif : réduire la capacité de nuisance d'un compte malveillant fraîchement créé, sans pénaliser les utilisateurs légitimes.

Spec : `spec/security/2026-06-20-plan-hard-gate-contact-et-validation-commentaires.md` (Partie 1a).

## Ce que fait cette PR

**Gate serveur (source de vérité)** : un compte de moins de 24h ne peut pas « Contacter les organisateurs » d'une Communauté, **sauf s'il en est lui-même organisateur actif** (on ne gate jamais quelqu'un sur sa propre Communauté). Implémenté dans le usecase `contactCircleHosts`, via le helper pur `isNewAccount`, avec une erreur métier typée `ContactHostsAccountTooNewError` (message i18n FR/EN dédié).

**Anticipation UI** : plutôt que de laisser écrire un message refusé à l'envoi, le bouton « Contacter l'organisateur » est **grisé en amont** pour un compte < 24h.
- Desktop : tooltip au survol/focus.
- Mobile : toast au tap (pas de hover au tactile).
- `aria-disabled` (pas `disabled` natif) pour garder l'interaction explicative.
- Exemption orga déjà gérée à l'affichage (le lien n'est rendu qu'aux non-organisateurs).

**Session** : `createdAt` exposé en epoch millis (sérialisable en RSC), pour calculer l'âge du compte dans les loaders sans requête DB supplémentaire.

## Détails techniques

- Helper pur `src/lib/account-trust.ts` (`isNewAccount` + `isSessionAccountNew`), réutilisable par la future file de validation des commentaires (Partie 1b).
- `isNewAccount` **fail-closed** sur un `createdAt` invalide (NaN → traité comme nouveau → gate appliqué).
- Gate placé dans le domaine (logique métier), anticipation UI dérivée de la session.

## Tests
- `account-trust` : bornes 24h, entrées Date/string/number, NaN fail-closed, `isSessionAccountNew`.
- `contact-circle-hosts` : gate (compte récent non-orga → refus), exemption orga, borne stricte 24h.
- 26 tests verts, `pnpm typecheck` vert.
- Schema Prisma non touché.

## Revue
`/code-review` passé (high effort) : aucun bug de correctness, nettoyage appliqué (DRY des loaders, fail-closed, factorisation CSS).

## Suite
Partie 1b (file de validation des commentaires < 24h, modérée dans le back Admin) dans une PR distincte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)