### PR TITLE
feat(reporting): le rapport quotidien résume hier, pas les 24h glissantes

### DIFF
--- a/src/app/api/cron/posthog-daily-report/__tests__/fetch-dashboard.test.ts
+++ b/src/app/api/cron/posthog-daily-report/__tests__/fetch-dashboard.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  overrideDailyTilesToYesterday,
+  PosthogFetchError,
+  type PosthogDashboard,
+} from "../fetch-dashboard";
+
+/**
+ * Construit un dashboard quotidien minimal : une tile Trends (BoldNumber) et
+ * une tile Lifecycle, chacune configurée sur « aujourd'hui depuis minuit »
+ * (dStart). C'est l'état réel du dashboard 601861 après bascule live.
+ */
+function dailyDashboard(): PosthogDashboard {
+  return {
+    id: 601861,
+    name: "Synthèse trafic quotidienne",
+    description: null,
+    tiles: [
+      {
+        id: 1,
+        insight: {
+          id: 3841046,
+          short_id: "uv",
+          name: "Visiteurs uniques (total) – 24h",
+          description: null,
+          result: [{ label: "Pageview", aggregated_value: 12 }],
+          query: {
+            kind: "InsightVizNode",
+            source: {
+              kind: "TrendsQuery",
+              dateRange: { date_from: "dStart", date_to: null },
+              series: [{ event: "$pageview", math: "dau" }],
+            },
+          },
+        },
+      },
+      {
+        id: 2,
+        insight: {
+          id: 4629813,
+          short_id: "life",
+          name: "Cycle de vie des visiteurs – 30j",
+          description: null,
+          result: [{ label: "new", count: 6 }],
+          query: {
+            kind: "InsightVizNode",
+            source: {
+              kind: "LifecycleQuery",
+              dateRange: { date_from: "-30d", date_to: null },
+              series: [{ event: "$pageview", math: "total" }],
+            },
+          },
+        },
+      },
+    ],
+  };
+}
+
+describe("overrideDailyTilesToYesterday", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    process.env.POSTHOG_PERSONAL_API_KEY = "test-key";
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe("given a daily dashboard configured on today", () => {
+    it("should replay the Trends tile on yesterday and replace its result", async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: async () => ({ results: [{ label: "Pageview", aggregated_value: 30 }] }),
+      });
+
+      const dashboard = dailyDashboard();
+      await overrideDailyTilesToYesterday(dashboard);
+
+      // Le résultat de la tile Trends est désormais celui d'hier (30, pas 12).
+      const trends = dashboard.tiles[0].insight!;
+      expect(trends.result).toEqual([
+        { label: "Pageview", aggregated_value: 30 },
+      ]);
+
+      // La requête envoyée force la fenêtre « hier complet ».
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [, init] = fetchMock.mock.calls[0];
+      const body = JSON.parse(init.body as string);
+      expect(body.query.dateRange).toEqual({
+        date_from: "-1dStart",
+        date_to: "-1dEnd",
+        explicitDate: false,
+      });
+      expect(body.refresh).toBe("force_blocking");
+      // Le reste de la requête (event, math) est préservé.
+      expect(body.query.series).toEqual([{ event: "$pageview", math: "dau" }]);
+    });
+
+    it("should leave the Lifecycle tile untouched (not a TrendsQuery)", async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: async () => ({ results: [{ label: "Pageview", aggregated_value: 30 }] }),
+      });
+
+      const dashboard = dailyDashboard();
+      const lifecycleResultBefore = dashboard.tiles[1].insight!.result;
+
+      await overrideDailyTilesToYesterday(dashboard);
+
+      // Une seule requête (la Trends) ; la Lifecycle n'est pas rejouée.
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(dashboard.tiles[1].insight!.result).toBe(lifecycleResultBefore);
+    });
+  });
+
+  describe("given the PostHog API fails", () => {
+    it("should throw a PosthogFetchError mentioning the insight name", async () => {
+      fetchMock.mockResolvedValue({
+        ok: false,
+        status: 503,
+        statusText: "Service Unavailable",
+        json: async () => ({}),
+      });
+
+      await expect(
+        overrideDailyTilesToYesterday(dailyDashboard())
+      ).rejects.toThrowError(PosthogFetchError);
+    });
+  });
+
+  describe("given the API key is missing", () => {
+    it("should throw before any network call", async () => {
+      delete process.env.POSTHOG_PERSONAL_API_KEY;
+
+      await expect(
+        overrideDailyTilesToYesterday(dailyDashboard())
+      ).rejects.toThrowError(/POSTHOG_PERSONAL_API_KEY/);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/api/cron/posthog-daily-report/fetch-dashboard.ts
+++ b/src/app/api/cron/posthog-daily-report/fetch-dashboard.ts
@@ -16,12 +16,35 @@ export interface PosthogSeries {
   days?: string[];
 }
 
+/**
+ * Source d'une insight PostHog (TrendsQuery, LifecycleQuery, …) telle que
+ * renvoyée dans `insight.query.source`. On ne modélise finement que
+ * `dateRange` (la seule partie qu'on réécrit) ; le reste est conservé tel
+ * quel et renvoyé à l'API /query pour rejouer la requête sur une autre fenêtre.
+ */
+export interface PosthogQuerySource {
+  kind: string;
+  dateRange?: {
+    date_from?: string | null;
+    date_to?: string | null;
+    explicitDate?: boolean;
+  } | null;
+  [key: string]: unknown;
+}
+
+export interface PosthogInsightQuery {
+  kind: string;
+  source: PosthogQuerySource;
+}
+
 export interface PosthogInsight {
   id: number;
   short_id: string;
   name: string;
   description: string | null;
   result: PosthogSeries[] | null;
+  /** Définition de la requête — utilisée pour rejouer la tile sur une autre période. */
+  query?: PosthogInsightQuery | null;
 }
 
 export interface PosthogTile {
@@ -47,7 +70,8 @@ export class PosthogFetchError extends Error {
 }
 
 export async function fetchPosthogDashboard(
-  dashboardId: number
+  dashboardId: number,
+  { forceRefresh = true }: { forceRefresh?: boolean } = {}
 ): Promise<PosthogDashboard> {
   const apiKey = process.env.POSTHOG_PERSONAL_API_KEY;
   if (!apiKey) {
@@ -64,7 +88,14 @@ export async function fetchPosthogDashboard(
   // (vu en prod : rapport généré à J affichant la période J-2 → J-1).
   // Mesuré en local : ~7s pour le daily dashboard (5 tiles), ~8s pour le weekly.
   // Couvert côté route par `export const maxDuration = 60`.
-  const url = `${POSTHOG_BASE_URL}/api/projects/${POSTHOG_PROJECT_ID}/dashboards/${dashboardId}/?refresh=force_blocking`;
+  //
+  // `forceRefresh: false` : le rapport quotidien n'a pas besoin de recalculer
+  // les résultats du dashboard (configuré sur « aujourd'hui »), puisqu'il les
+  // réécrit ensuite sur « hier » via overrideDailyTilesToYesterday. On évite
+  // ainsi un recalcul inutile (et lent) côté today. La définition des requêtes
+  // (`insight.query`) est renvoyée par l'API quel que soit le refresh.
+  const refreshParam = forceRefresh ? "?refresh=force_blocking" : "";
+  const url = `${POSTHOG_BASE_URL}/api/projects/${POSTHOG_PROJECT_ID}/dashboards/${dashboardId}/${refreshParam}`;
   const response = await fetch(url, {
     headers: {
       Authorization: `Bearer ${apiKey}`,
@@ -81,6 +112,81 @@ export async function fetchPosthogDashboard(
   }
 
   return (await response.json()) as PosthogDashboard;
+}
+
+/**
+ * Fenêtre « hier complet » au sens PostHog : de minuit à minuit (timezone du
+ * projet), recalculée à chaque exécution. C'est la période que doit couvrir
+ * le rapport matinal.
+ */
+const YESTERDAY_RANGE = {
+  date_from: "-1dStart",
+  date_to: "-1dEnd",
+  explicitDate: false,
+} as const;
+
+/**
+ * Réécrit les tiles Trends du dashboard quotidien sur la journée d'HIER, en
+ * remplaçant `insight.result` par le résultat recalculé via l'API /query.
+ *
+ * Pourquoi : le dashboard quotidien est configuré sur « aujourd'hui depuis
+ * minuit » (consultation live), mais le rapport matinal de 8h doit résumer la
+ * veille complète. Plutôt que de dupliquer le dashboard, on garde une source
+ * unique et on rejoue chaque requête sur la bonne fenêtre.
+ *
+ * Seules les tiles `TrendsQuery` sont rejouées : le rapport ne consomme pas la
+ * tile Lifecycle (qui a besoin de son historique 30j et n'a pas de sens sur un
+ * seul jour). Les requêtes sont rejouées en parallèle, avec `force_blocking`
+ * pour garantir des chiffres frais.
+ */
+export async function overrideDailyTilesToYesterday(
+  dashboard: PosthogDashboard
+): Promise<void> {
+  const apiKey = process.env.POSTHOG_PERSONAL_API_KEY;
+  if (!apiKey) {
+    throw new PosthogFetchError(
+      "POSTHOG_PERSONAL_API_KEY is not configured",
+      500
+    );
+  }
+
+  const trendsInsights = dashboard.tiles
+    .map((t) => t.insight)
+    .filter(
+      (i): i is PosthogInsight => i?.query?.source?.kind === "TrendsQuery"
+    );
+
+  await Promise.all(
+    trendsInsights.map(async (insight) => {
+      const source: PosthogQuerySource = {
+        ...insight.query!.source,
+        dateRange: YESTERDAY_RANGE,
+      };
+
+      const response = await fetch(
+        `${POSTHOG_BASE_URL}/api/projects/${POSTHOG_PROJECT_ID}/query/`,
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+            "Content-Type": "application/json",
+          },
+          cache: "no-store",
+          body: JSON.stringify({ query: source, refresh: "force_blocking" }),
+        }
+      );
+
+      if (!response.ok) {
+        throw new PosthogFetchError(
+          `PostHog query failed for insight "${insight.name}" (${response.status} ${response.statusText})`,
+          response.status
+        );
+      }
+
+      const data = (await response.json()) as { results: PosthogSeries[] };
+      insight.result = data.results;
+    })
+  );
 }
 
 const PAGEVIEWS_INSIGHT_PREFIX = "Pageviews & visiteurs uniques";

--- a/src/app/api/cron/posthog-daily-report/route.ts
+++ b/src/app/api/cron/posthog-daily-report/route.ts
@@ -3,7 +3,11 @@ import { NextRequest, NextResponse } from "next/server";
 import { createSafeResend } from "@/lib/email/safe-resend";
 import { getSender } from "@/infrastructure/services/email/resend-email-service";
 import { notifySlackTrafficReport } from "@/infrastructure/services/slack/slack-notification-service";
-import { fetchPosthogDashboard, patchUniqueVisitors } from "./fetch-dashboard";
+import {
+  fetchPosthogDashboard,
+  overrideDailyTilesToYesterday,
+  patchUniqueVisitors,
+} from "./fetch-dashboard";
 import { buildReportHtml } from "./build-report-html";
 import { extractReportKpis } from "./extract-report-kpis";
 
@@ -11,8 +15,13 @@ import { extractReportKpis } from "./extract-report-kpis";
  * GET /api/cron/posthog-daily-report
  *
  * Envoie chaque matin un récap HTML du dashboard PostHog "Synthèse trafic
- * quotidienne" (trafic 24h, interactions, engagement, top pages) au
- * destinataire configuré via DAILY_REPORT_RECIPIENT.
+ * quotidienne" (interactions, engagement, top pages) au destinataire configuré
+ * via DAILY_REPORT_RECIPIENT.
+ *
+ * Le dashboard est configuré sur « aujourd'hui depuis minuit » (consultation
+ * live), mais le rapport matinal doit résumer la veille complète : on rejoue
+ * donc les tiles sur « hier » via overrideDailyTilesToYesterday avant de
+ * construire l'email. Voir fetch-dashboard.ts pour le détail.
  *
  * Déclenché quotidiennement à 08:07 UTC via Vercel Cron (vercel.json).
  * Vercel Cron invoque les endpoints en GET — on expose aussi POST pour
@@ -55,7 +64,13 @@ async function handler(request: NextRequest) {
   const startedAt = Date.now();
 
   try {
-    const dashboard = await fetchPosthogDashboard(DASHBOARD_ID);
+    // Pas de force_refresh : on récupère les définitions de requêtes, qu'on
+    // rejoue ensuite sur « hier » (le recalcul « today » du dashboard serait
+    // jeté).
+    const dashboard = await fetchPosthogDashboard(DASHBOARD_ID, {
+      forceRefresh: false,
+    });
+    await overrideDailyTilesToYesterday(dashboard);
     patchUniqueVisitors(dashboard);
     const html = buildReportHtml(dashboard);
 


### PR DESCRIPTION
## Contexte

Le dashboard PostHog « Synthèse trafic quotidienne » et le rapport matinal partageaient les mêmes tiles, calées sur `-24h` **glissant**. Conséquences :
- le nombre de « visiteurs uniques » ne correspondait jamais à la somme `new + returning + resurrecting` du « cycle de vie » (fenêtres différentes) ;
- le rapport du matin décrivait une fenêtre à cheval sur deux jours, pas une journée.

## Décisions (côté config PostHog, déjà appliquées)

- **Dashboard quotidien (601861)** : les tiles passent en **aujourd'hui depuis minuit → maintenant** (consultation live temps réel).
- **Timezone du projet** : `UTC → Europe/Paris` (« minuit » = minuit Paris).
- Le **lifecycle** reste la référence (déjà par jour calendaire) ; il est désormais prouvé cohérent avec les visiteurs uniques sur une même fenêtre.

## Ce que fait ce PR (code)

Le **rapport quotidien** (cron 8h07) doit, lui, résumer **la veille complète** (minuit → minuit). Comme le dashboard est passé en « live today », on découple le report :

- `overrideDailyTilesToYesterday` rejoue chaque tile `TrendsQuery` du dashboard sur « hier » (`-1dStart`/`-1dEnd`) via l'API `/query`, et remplace `insight.result`. Source unique conservée, pas de dashboard dupliqué.
- `fetchPosthogDashboard` gagne une option `forceRefresh` : le daily passe `false` (les résultats « today » seraient jetés de toute façon), le **rapport hebdo conserve son comportement** (`force_blocking` par défaut).
- Le lifecycle n'est pas rejoué (besoin de son historique 30j, et non consommé par le report).

## Vérifications

- `pnpm typecheck` ✅
- Tests unitaires de `overrideDailyTilesToYesterday` (4 cas, `fetch` mocké) ✅
- Compatibilité du format `/query` vs fetch dashboard **vérifiée empiriquement** sur les vraies tiles : mêmes champs (`count` / `aggregated_value`) et **mêmes labels** (Interactions clés, Engagement social) → aucune section ne tombe à zéro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)