### PR TITLE
feat(auth): tracker le clic sur les providers de connexion

### DIFF
--- a/src/app/actions/auth.ts
+++ b/src/app/actions/auth.ts
@@ -40,7 +40,7 @@ async function signInPath() {
 // être bloquée, redirige vers la page de connexion. Le redirect interrompt
 // l'action, donc l'appelant ne poursuit pas vers signIn(). La journalisation
 // éventuelle est gérée dans evaluateBotSignIn.
-type OAuthProvider = "google" | "github" | "linkedin";
+export type OAuthProvider = "google" | "github" | "linkedin";
 
 async function redirectIfBot(provider: OAuthProvider) {
   const { shouldBlock } = await evaluateBotSignIn({ provider });

--- a/src/components/auth/sign-in-form.tsx
+++ b/src/components/auth/sign-in-form.tsx
@@ -13,19 +13,22 @@ import {
   signInWithGoogle,
   signInWithLinkedIn,
   signInWithEmail,
+  type OAuthProvider,
   type SignInWithEmailState,
 } from "@/app/actions/auth";
 import { isInAppBrowser, isLinkedInInAppBrowser } from "@/lib/detect-webview";
 
-type SignInProvider = "google" | "linkedin" | "github" | "email";
+type SignInProvider = OAuthProvider | "email";
 
-// Capture l'intention de connexion juste avant la redirection (OAuth) ou
-// l'envoi du magic link. Permet de mesurer le taux clic → connexion aboutie,
+// Capture l'intention de connexion à la soumission du formulaire (donc après
+// la validation native du champ email pour le magic link), juste avant la
+// redirection OAuth. Permet de mesurer le taux clic → connexion aboutie,
 // notamment la déperdition après le départ vers le fournisseur OAuth.
 function trackProviderClick(provider: SignInProvider, callbackUrl?: string) {
   posthog.capture("sign_in_provider_clicked", {
     provider,
-    callback_url: callbackUrl,
+    // Pathname seul : la query string du callbackUrl peut transporter du PII.
+    callback_path: callbackUrl?.split("?")[0],
   });
 }
 
@@ -55,22 +58,14 @@ function SubmitButton({
   label,
   icon,
   variant = "default",
-  onClick,
 }: {
   label: string;
   icon?: ReactNode;
   variant?: "default" | "outline";
-  onClick?: () => void;
 }) {
   const { pending } = useFormStatus();
   return (
-    <Button
-      variant={variant}
-      className="w-full"
-      type="submit"
-      disabled={pending}
-      onClick={onClick}
-    >
+    <Button variant={variant} className="w-full" type="submit" disabled={pending}>
       {pending ? <Loader2 className="size-4 animate-spin" /> : icon}
       {label}
     </Button>
@@ -100,14 +95,9 @@ function OAuthForm({
   callbackUrl?: string;
 }) {
   return (
-    <form action={action}>
+    <form action={action} onSubmit={() => trackProviderClick(provider, callbackUrl)}>
       {callbackUrl && <input type="hidden" name="callbackUrl" value={callbackUrl} />}
-      <SubmitButton
-        label={label}
-        icon={icon}
-        variant="outline"
-        onClick={() => trackProviderClick(provider, callbackUrl)}
-      />
+      <SubmitButton label={label} icon={icon} variant="outline" />
     </form>
   );
 }
@@ -207,7 +197,11 @@ export function SignInForm({ callbackUrl, error }: SignInFormProps) {
           <Separator className="flex-1" />
         </div>
 
-        <form action={emailAction} className="space-y-3">
+        <form
+          action={emailAction}
+          onSubmit={() => trackProviderClick("email", callbackUrl)}
+          className="space-y-3"
+        >
           {callbackUrl && <input type="hidden" name="callbackUrl" value={callbackUrl} />}
           <Input
             name="email"
@@ -233,10 +227,7 @@ export function SignInForm({ callbackUrl, error }: SignInFormProps) {
               )}
             </p>
           )}
-          <SubmitButton
-            label={t("signIn.magicLink")}
-            onClick={() => trackProviderClick("email", callbackUrl)}
-          />
+          <SubmitButton label={t("signIn.magicLink")} />
         </form>
     </div>
   );

--- a/src/components/auth/sign-in-form.tsx
+++ b/src/components/auth/sign-in-form.tsx
@@ -3,6 +3,7 @@
 import { type ReactNode, useActionState, useEffect, useState } from "react";
 import { useTranslations } from "next-intl";
 import { useFormStatus } from "react-dom";
+import posthog from "posthog-js";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
@@ -15,6 +16,18 @@ import {
   type SignInWithEmailState,
 } from "@/app/actions/auth";
 import { isInAppBrowser, isLinkedInInAppBrowser } from "@/lib/detect-webview";
+
+type SignInProvider = "google" | "linkedin" | "github" | "email";
+
+// Capture l'intention de connexion juste avant la redirection (OAuth) ou
+// l'envoi du magic link. Permet de mesurer le taux clic → connexion aboutie,
+// notamment la déperdition après le départ vers le fournisseur OAuth.
+function trackProviderClick(provider: SignInProvider, callbackUrl?: string) {
+  posthog.capture("sign_in_provider_clicked", {
+    provider,
+    callback_url: callbackUrl,
+  });
+}
 
 function GoogleIcon() {
   return (
@@ -42,14 +55,22 @@ function SubmitButton({
   label,
   icon,
   variant = "default",
+  onClick,
 }: {
   label: string;
   icon?: ReactNode;
   variant?: "default" | "outline";
+  onClick?: () => void;
 }) {
   const { pending } = useFormStatus();
   return (
-    <Button variant={variant} className="w-full" type="submit" disabled={pending}>
+    <Button
+      variant={variant}
+      className="w-full"
+      type="submit"
+      disabled={pending}
+      onClick={onClick}
+    >
       {pending ? <Loader2 className="size-4 animate-spin" /> : icon}
       {label}
     </Button>
@@ -67,11 +88,13 @@ function DisabledOAuthButton({ label, icon }: { label: string; icon: ReactNode }
 
 function OAuthForm({
   action,
+  provider,
   label,
   icon,
   callbackUrl,
 }: {
   action: (formData: FormData) => void | Promise<void>;
+  provider: SignInProvider;
   label: string;
   icon: ReactNode;
   callbackUrl?: string;
@@ -79,7 +102,12 @@ function OAuthForm({
   return (
     <form action={action}>
       {callbackUrl && <input type="hidden" name="callbackUrl" value={callbackUrl} />}
-      <SubmitButton label={label} icon={icon} variant="outline" />
+      <SubmitButton
+        label={label}
+        icon={icon}
+        variant="outline"
+        onClick={() => trackProviderClick(provider, callbackUrl)}
+      />
     </form>
   );
 }
@@ -133,6 +161,7 @@ export function SignInForm({ callbackUrl, error }: SignInFormProps) {
           <>
             <OAuthForm
               action={signInWithLinkedIn}
+              provider="linkedin"
               label={t("signIn.linkedin")}
               icon={<LinkedInIcon />}
               callbackUrl={callbackUrl}
@@ -150,18 +179,21 @@ export function SignInForm({ callbackUrl, error }: SignInFormProps) {
           <>
             <OAuthForm
               action={signInWithGoogle}
+              provider="google"
               label={t("signIn.google")}
               icon={<GoogleIcon />}
               callbackUrl={callbackUrl}
             />
             <OAuthForm
               action={signInWithLinkedIn}
+              provider="linkedin"
               label={t("signIn.linkedin")}
               icon={<LinkedInIcon />}
               callbackUrl={callbackUrl}
             />
             <OAuthForm
               action={signInWithGitHub}
+              provider="github"
               label={t("signIn.github")}
               icon={<Github className="size-4" />}
               callbackUrl={callbackUrl}
@@ -201,7 +233,10 @@ export function SignInForm({ callbackUrl, error }: SignInFormProps) {
               )}
             </p>
           )}
-          <SubmitButton label={t("signIn.magicLink")} />
+          <SubmitButton
+            label={t("signIn.magicLink")}
+            onClick={() => trackProviderClick("email", callbackUrl)}
+          />
         </form>
     </div>
   );


### PR DESCRIPTION
## Contexte

Enquête PostHog sur un visiteur perdu après avoir cliqué « Login with Google » : le clic n'était visible que dans le session replay, aucun event ne le traçait. Sans event dédié, impossible de mesurer le taux clic → connexion aboutie ni la déperdition après le départ vers le fournisseur OAuth.

## Changements

Nouvel event PostHog **`sign_in_provider_clicked`**, capturé à la soumission du formulaire de connexion (`src/components/auth/sign-in-form.tsx`), pour les 4 méthodes : Google, LinkedIn, GitHub, magic link email.

Propriétés :
- `provider` : `"google" | "linkedin" | "github" | "email"`
- `callback_path` : pathname d'origine (query string retirée pour éviter tout PII)

## Ce que ça débloque

Funnel **`sign_in_provider_clicked` → `user_signed_up`** segmenté par provider : la déperdition après le clic Google (le cas qui a motivé la PR) devient une métrique suivie, sans avoir à ouvrir un replay.

## Notes techniques

- Tracking sur `onSubmit` du formulaire (pas `onClick` du bouton) : l'event email ne part que si la validation native du champ passe, le dénominateur du funnel reste juste.
- `SignInProvider` dérive de `OAuthProvider` (exporté depuis `auth.ts`) : la liste des providers OAuth reste single-sourced.
- L'event OAuth survit à la redirection via le flush `sendBeacon` de PostHog sur `pagehide` (même mécanisme que `$pageleave`).
- PostHog n'étant initialisé qu'en production, le tracking n'émet qu'en prod (comme les autres trackers du projet).

## Tests

- `pnpm typecheck` ✅
- `/code-review` (high) lancé, findings traités.

🤖 Generated with [Claude Code](https://claude.com/claude-code)