### PR TITLE
chore(security): bloque l'acteur spam ln941535@mailsecondary.com

### DIFF
--- a/src/infrastructure/auth/sign-in-blocklist.ts
+++ b/src/infrastructure/auth/sign-in-blocklist.ts
@@ -11,7 +11,12 @@
  */
 
 /** Emails bloqués (comparaison insensible à la casse). */
-const BLOCKED_EMAILS = new Set<string>(["ixewufoy22@gmail.com"]);
+const BLOCKED_EMAILS = new Set<string>([
+  "ixewufoy22@gmail.com",
+  // Spam/SEO via magic link — Circle « Yoga Workshop » pointant vers
+  // ticketsfresh.com, proxy résidentiel rotatif (2026-06-21)
+  "ln941535@mailsecondary.com",
+]);
 
 /**
  * Identités OAuth bloquées par `providerAccountId`.

--- a/src/lib/email/disposable-domains.ts
+++ b/src/lib/email/disposable-domains.ts
@@ -24,6 +24,9 @@ const CUSTOM_DISPOSABLE_DOMAINS = [
   "animatimg.com",
   "animateany.com",
   "usechrono.com",
+  // Roundcube auto-hébergé (domaine créé déc. 2024), utilisé comme jetable pour
+  // un compte spam/SEO le 21/06/2026.
+  "mailsecondary.com",
 ];
 
 const DISPOSABLE_DOMAINS = new Set<string>([


### PR DESCRIPTION
## Contexte

Compte spam/SEO inscrit le 21/06/2026 via magic link (aucun OAuth). Investigation DB prod + PostHog :

- Circle public « Yoga Workshop » avec site web `http://ticketsfresh.com` (backlink commercial externe) et Moment « Pilates body shaping » associé.
- Geoip client sautant à travers tous les États-Unis en quelques minutes (Lewis Center → Sarasota → Huntersville → Roseville → Bothell → Philadelphia) = **proxy résidentiel rotatif**.
- Email `mailsecondary.com` = Roundcube auto-hébergé (domaine créé déc. 2024), local part aléatoire `ln941535`.
- Description machine-translated, champ `city` détourné en adresse complète.

Faisceau « signaux forts » au sens du playbook anti-abus.

## Changements

- **`sign-in-blocklist.ts`** : `ln941535@mailsecondary.com` ajouté à `BLOCKED_EMAILS` (rejet au sign-in, l'acteur ne peut pas recréer le compte via magic link).
- **`disposable-domains.ts`** : `mailsecondary.com` ajouté à `CUSTOM_DISPOSABLE_DOMAINS`.

## Actions hors PR (déjà faites)

- Circle « Yoga Workshop » + Moment « Pilates body shaping » **supprimés en prod** (backlink retiré de l'Explorer).
- Compte user laissé en base : inoffensif une fois le cercle supprimé, bloqué au prochain sign-in dès le déploiement.

Pas de changement de schema Prisma.

🤖 Generated with [Claude Code](https://claude.com/claude-code)