### PR TITLE
fix(observability): ne plus alerter sur les rejets d'auth attendus (Sentry)

### DIFF
--- a/src/lib/__tests__/sentry-before-send.test.ts
+++ b/src/lib/__tests__/sentry-before-send.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import type { ErrorEvent } from "@sentry/nextjs";
+
+import { dropExpectedAuthRejections } from "@/lib/sentry-before-send";
+
+const exceptionEvent = (message: string, over: Partial<ErrorEvent> = {}) =>
+  ({
+    level: "error",
+    exception: { values: [{ type: "Error", value: message }] },
+    ...over,
+  }) as ErrorEvent;
+
+const ACCESS_DENIED =
+  "AccessDenied. Read more at https://errors.authjs.dev#accessdenied";
+const VERIFICATION =
+  "Verification. Read more at https://errors.authjs.dev#verification";
+
+describe("dropExpectedAuthRejections", () => {
+  describe("given le doublon error-level auto-capté par le SDK (sans tag auth)", () => {
+    it.each([ACCESS_DENIED, VERIFICATION])("should droper %s", (message) => {
+      expect(dropExpectedAuthRejections(exceptionEvent(message))).toBeNull();
+    });
+  });
+
+  describe("given une capture délibérée taggée context=auth", () => {
+    it("should la conserver même si le message matche (observabilité préservée)", () => {
+      const event = exceptionEvent(ACCESS_DENIED, {
+        level: "warning",
+        tags: { context: "auth", error_code: "AccessDenied" },
+      });
+      expect(dropExpectedAuthRejections(event)).toBe(event);
+    });
+
+    it("should conserver un message-event sans exception (page /auth/error)", () => {
+      const event = {
+        level: "warning",
+        message: "auth-error-page: AccessDenied",
+        tags: { context: "auth" },
+      } as unknown as ErrorEvent;
+      expect(dropExpectedAuthRejections(event)).toBe(event);
+    });
+  });
+
+  describe("given une vraie erreur à ne pas masquer", () => {
+    it("should conserver une exception sans hash authjs attendu", () => {
+      const event = exceptionEvent("TypeError: cannot read properties of undefined");
+      expect(dropExpectedAuthRejections(event)).toBe(event);
+    });
+
+    it("should conserver un CallbackRouteError (hash non attendu, vrai bug d'auth)", () => {
+      const event = exceptionEvent(
+        "Read more at https://errors.authjs.dev#callbackrouteerror"
+      );
+      expect(dropExpectedAuthRejections(event)).toBe(event);
+    });
+
+    it("should conserver un event sans exception ni tag", () => {
+      const event = { level: "error", message: "boom" } as unknown as ErrorEvent;
+      expect(dropExpectedAuthRejections(event)).toBe(event);
+    });
+  });
+});

--- a/src/lib/auth/__tests__/error-kinds.test.ts
+++ b/src/lib/auth/__tests__/error-kinds.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { classifyAuthError, normalizeAuthErrorCode } from "@/lib/auth/error-kinds";
+import {
+  classifyAuthError,
+  isExpectedAuthRejectionMessage,
+  normalizeAuthErrorCode,
+} from "@/lib/auth/error-kinds";
 
 describe("classifyAuthError", () => {
   describe("given a code that occurs in normal user flows", () => {
@@ -74,6 +78,34 @@ describe("normalizeAuthErrorCode", () => {
 
     it("should return Unknown for undefined", () => {
       expect(normalizeAuthErrorCode(undefined)).toBe("Unknown");
+    });
+  });
+});
+
+describe("isExpectedAuthRejectionMessage", () => {
+  describe("given un message d'exception @auth/core d'un rejet attendu", () => {
+    it.each([
+      "AccessDenied. Read more at https://errors.authjs.dev#accessdenied",
+      "Verification. Read more at https://errors.authjs.dev#verification",
+      "Read more at HTTPS://ERRORS.AUTHJS.DEV#ACCESSDENIED", // insensible à la casse
+    ])("should reconnaître %s", (message) => {
+      expect(isExpectedAuthRejectionMessage(message)).toBe(true);
+    });
+  });
+
+  describe("given un message d'erreur non attendu ou hors auth", () => {
+    it.each([
+      "Configuration. Read more at https://errors.authjs.dev#configuration",
+      "OAuthCallbackError. Read more at https://errors.authjs.dev#oauthcallbackerror",
+      "TypeError: cannot read properties of undefined",
+      "Database connection failed",
+      "",
+    ])("should ne pas reconnaître %s", (message) => {
+      expect(isExpectedAuthRejectionMessage(message)).toBe(false);
+    });
+
+    it.each([null, undefined])("should gérer %s sans lever", (message) => {
+      expect(isExpectedAuthRejectionMessage(message)).toBe(false);
     });
   });
 });

--- a/src/lib/auth/error-kinds.ts
+++ b/src/lib/auth/error-kinds.ts
@@ -37,3 +37,26 @@ export function classifyAuthError(code: string | null | undefined): AuthErrorKin
   const normalized = code.split(":")[0]?.trim() ?? "";
   return EXPECTED_AUTH_ERROR_CODES.has(normalized) ? "expected_user_flow" : "unexpected";
 }
+
+// Hash des codes attendus dans l'URL d'erreur @auth/core (ex. "#accessdenied").
+const EXPECTED_AUTHJS_HASHES = new Set(
+  [...EXPECTED_AUTH_ERROR_CODES].map((code) => code.toLowerCase())
+);
+
+/**
+ * Détecte si un message d'exception correspond à un rejet d'authentification
+ * ATTENDU levé par `@auth/core` (ex. « AccessDenied. Read more at
+ * https://errors.authjs.dev#accessdenied »).
+ *
+ * Sert au `beforeSend` de Sentry à droper l'exception error-level auto-captée
+ * par le SDK sur les routes `/api/auth/*` : ces refus (blocklist, token expiré)
+ * sont déjà observés via le `captureMessage` warning de la page `/auth/error`.
+ * On supprime le doublon error-level, pas l'observabilité.
+ */
+export function isExpectedAuthRejectionMessage(
+  message: string | null | undefined
+): boolean {
+  if (!message) return false;
+  const hash = message.toLowerCase().match(/errors\.authjs\.dev#([a-z]+)/)?.[1];
+  return hash !== undefined && EXPECTED_AUTHJS_HASHES.has(hash);
+}

--- a/src/lib/sentry-before-send.ts
+++ b/src/lib/sentry-before-send.ts
@@ -2,18 +2,36 @@ import type { ErrorEvent } from "@sentry/nextjs";
 
 import { isExpectedAuthRejectionMessage } from "@/lib/auth/error-kinds";
 
+/** Tag posé par NOS captures d'auth délibérées (logger auth + page /auth/error). */
+const DELIBERATE_AUTH_CONTEXT = "auth";
+
 /**
  * `beforeSend` Sentry partagé (server + edge).
  *
- * Drope l'exception error-level que le SDK capte automatiquement quand
- * `@auth/core` lève un rejet d'authentification ATTENDU (AccessDenied via
- * blocklist, token expiré…) sur une route `/api/auth/*`. Ces refus restent
- * observés via le `captureMessage` warning de `/auth/error` : on retire le
- * doublon error-level (fausses alertes), pas l'observabilité.
+ * Objectif unique : supprimer le DOUBLON error-level que le SDK auto-capte
+ * quand `@auth/core` lève un rejet d'authentification ATTENDU (AccessDenied via
+ * blocklist, Verification d'un token expiré…) sur une route `/api/auth/*`. Avec
+ * la blocklist active, ces refus généraient de fausses alertes high-priority.
+ *
+ * On ne touche JAMAIS à l'observabilité voulue : nos captures délibérées
+ * (`logger.error` d'auth.config + `captureMessage` de /auth/error) portent le
+ * tag `context: "auth"` et sont en niveau warning. Elles passent telles quelles
+ * — ce sont elles qui gardent la trace (user-agent, code) et le signal d'abus
+ * (pic de Verification falsifiés). Seule l'exception SANS ce tag (l'auto-capture
+ * brute du SDK) est dropée.
+ *
+ * Détection par le message `@auth/core` (`errors.authjs.dev#<code>`) faute de
+ * code structuré sur l'auto-capture. Mode d'échec volontairement sûr : si un
+ * futur `@auth/core` reformule ses messages, le filtre cesse de matcher et ces
+ * erreurs RÉAPPARAISSENT (bruit), au lieu de masquer silencieusement de vraies
+ * erreurs.
  */
 export function dropExpectedAuthRejections(
   event: ErrorEvent
 ): ErrorEvent | null {
+  // Capture délibérée (taggée context=auth) → toujours conservée.
+  if (event.tags?.context === DELIBERATE_AUTH_CONTEXT) return event;
+
   const values = event.exception?.values;
   if (values?.some((value) => isExpectedAuthRejectionMessage(value.value))) {
     return null;

--- a/src/lib/sentry-before-send.ts
+++ b/src/lib/sentry-before-send.ts
@@ -1,0 +1,22 @@
+import type { ErrorEvent } from "@sentry/nextjs";
+
+import { isExpectedAuthRejectionMessage } from "@/lib/auth/error-kinds";
+
+/**
+ * `beforeSend` Sentry partagé (server + edge).
+ *
+ * Drope l'exception error-level que le SDK capte automatiquement quand
+ * `@auth/core` lève un rejet d'authentification ATTENDU (AccessDenied via
+ * blocklist, token expiré…) sur une route `/api/auth/*`. Ces refus restent
+ * observés via le `captureMessage` warning de `/auth/error` : on retire le
+ * doublon error-level (fausses alertes), pas l'observabilité.
+ */
+export function dropExpectedAuthRejections(
+  event: ErrorEvent
+): ErrorEvent | null {
+  const values = event.exception?.values;
+  if (values?.some((value) => isExpectedAuthRejectionMessage(value.value))) {
+    return null;
+  }
+  return event;
+}

--- a/src/sentry.edge.config.ts
+++ b/src/sentry.edge.config.ts
@@ -1,7 +1,10 @@
 import * as Sentry from "@sentry/nextjs";
 
+import { dropExpectedAuthRejections } from "@/lib/sentry-before-send";
+
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   enabled: process.env.NODE_ENV === "production",
   tracesSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 1.0,
+  beforeSend: dropExpectedAuthRejections,
 });

--- a/src/sentry.server.config.ts
+++ b/src/sentry.server.config.ts
@@ -1,7 +1,10 @@
 import * as Sentry from "@sentry/nextjs";
 
+import { dropExpectedAuthRejections } from "@/lib/sentry-before-send";
+
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   enabled: process.env.NODE_ENV === "production",
   tracesSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 1.0,
+  beforeSend: dropExpectedAuthRejections,
 });


### PR DESCRIPTION
## Problème

Quand `@auth/core` lève un rejet d'authentification **attendu** (`AccessDenied` via la blocklist, `Verification` d'un token expiré) sur une route `/api/auth/*`, le SDK Sentry capte l'exception en niveau **error** (priorité haute), en court-circuitant notre classification `expected_user_flow`. Avec la blocklist active, **chaque tentative bloquée générait une fausse alerte**.

## Correctif

`beforeSend` Sentry partagé (server + edge) qui **drope ces exceptions attendues** auto-captées par le SDK, en se basant sur le hash d'URL `@auth/core` (`errors.authjs.dev#accessdenied` / `#verification` / `#unknownaction`).

**L'observabilité est préservée** : nos captures délibérées (logger d'auth + `captureMessage` de `/auth/error`) portent le tag `context: "auth"` et sont conservées telles quelles (niveau warning). On retire **uniquement** le doublon error-level non taggé. → une tentative bloquée reste visible en warning, plus en fausse alerte.

## Détails

- Discriminant par tag `context: "auth"` → ne jamais droper une capture volontaire (corrige le finding code-review : ne pas tuer l'observabilité).
- `coerceBlocklist`-style : ciblage étroit (seuls AccessDenied/Verification/UnknownAction, qui sont des rejets, pas des bugs applicatifs). `Configuration`, `OAuthCallbackError`, etc. remontent toujours en erreur.
- Mode d'échec sûr : si `@auth/core` reformule ses messages, le filtre cesse de matcher et ces erreurs **réapparaissent** (bruit), au lieu de masquer silencieusement de vraies erreurs.
- Tests : `isExpectedAuthRejectionMessage` + `dropExpectedAuthRejections` (warning gardé, message-event gardé, vrai bug gardé, doublon error-level droppé).

`/code-review` (workflow high) passé, findings corrigés. Pas de changement de schema Prisma.

🤖 Generated with [Claude Code](https://claude.com/claude-code)