### PR TITLE
fix(auth): classer les rejets minifiés + journaliser l'identité bloquée dans Sentry

### DIFF
--- a/src/infrastructure/auth/__tests__/dynamic-blocklist.test.ts
+++ b/src/infrastructure/auth/__tests__/dynamic-blocklist.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+  checkBlockedSignIn,
   coerceBlocklist,
   isBlockedSignIn,
   matchesIdentityBlocklist,
+  matchIdentityReason,
   type DynamicBlocklist,
 } from "@/infrastructure/auth/dynamic-blocklist";
 
@@ -58,6 +60,26 @@ describe("matchesIdentityBlocklist", () => {
         matchesIdentityBlocklist(data, { email: null, oauthId: null })
       ).toBe(false);
     });
+  });
+});
+
+describe("matchIdentityReason", () => {
+  it("should renvoyer 'email' sur correspondance email (prioritaire)", () => {
+    const data = blocklist({ emails: ["a@b.com"], oauthIds: ["x"] });
+    expect(matchIdentityReason(data, { email: "A@B.com", oauthId: "x" })).toBe(
+      "email"
+    );
+  });
+
+  it("should renvoyer 'oauth' quand seul l'oauthId matche", () => {
+    const data = blocklist({ oauthIds: ["x"] });
+    expect(
+      matchIdentityReason(data, { email: "legit@gmail.com", oauthId: "x" })
+    ).toBe("oauth");
+  });
+
+  it("should renvoyer null sans correspondance", () => {
+    expect(matchIdentityReason(blocklist(), { email: "a@b.com" })).toBeNull();
   });
 });
 
@@ -152,5 +174,47 @@ describe("isBlockedSignIn", () => {
       getMock.mockResolvedValue({ oauthIds: ["github-999"] });
       expect(await isBlockedSignIn("whoever@gmail.com", "github-999")).toBe(true);
     });
+  });
+});
+
+describe("checkBlockedSignIn", () => {
+  const ORIGINAL_EDGE_CONFIG = process.env.EDGE_CONFIG;
+
+  beforeEach(() => {
+    getMock.mockReset();
+    process.env.EDGE_CONFIG = "edge-config-connection-string";
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_EDGE_CONFIG === undefined) delete process.env.EDGE_CONFIG;
+    else process.env.EDGE_CONFIG = ORIGINAL_EDGE_CONFIG;
+  });
+
+  it("should renvoyer 'static' pour une entrée de la baseline du code", async () => {
+    // Email présent dans sign-in-blocklist.ts (baseline statique).
+    expect(await checkBlockedSignIn("ixewufoy22@gmail.com")).toBe("static");
+    expect(getMock).not.toHaveBeenCalled(); // court-circuite Edge Config
+  });
+
+  it("should renvoyer 'email' pour un email bloqué dynamiquement", async () => {
+    getMock.mockResolvedValue({ emails: ["x@y.com"] });
+    expect(await checkBlockedSignIn("X@Y.com")).toBe("email");
+  });
+
+  it("should renvoyer 'oauth' pour un providerAccountId bloqué", async () => {
+    getMock.mockResolvedValue({ oauthIds: ["github-999"] });
+    expect(await checkBlockedSignIn("whoever@gmail.com", "github-999")).toBe(
+      "oauth"
+    );
+  });
+
+  it("should renvoyer 'domain' pour un domaine bloqué (sous-domaine inclus)", async () => {
+    getMock.mockResolvedValue({ domains: ["evil.com"] });
+    expect(await checkBlockedSignIn("attacker@sub.evil.com")).toBe("domain");
+  });
+
+  it("should renvoyer null pour un acteur non bloqué", async () => {
+    getMock.mockResolvedValue({ emails: ["someone@evil.test"] });
+    expect(await checkBlockedSignIn("legit@gmail.com", "42")).toBeNull();
   });
 });

--- a/src/infrastructure/auth/__tests__/dynamic-blocklist.test.ts
+++ b/src/infrastructure/auth/__tests__/dynamic-blocklist.test.ts
@@ -3,8 +3,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   checkBlockedSignIn,
   coerceBlocklist,
-  isBlockedSignIn,
-  matchesIdentityBlocklist,
   matchIdentityReason,
   type DynamicBlocklist,
 } from "@/infrastructure/auth/dynamic-blocklist";
@@ -21,65 +19,54 @@ const blocklist = (over: Partial<DynamicBlocklist> = {}): DynamicBlocklist => ({
   ...over,
 });
 
-describe("matchesIdentityBlocklist", () => {
+describe("matchIdentityReason", () => {
   describe("given un email présent dans la surcouche dynamique", () => {
-    it("should bloquer, insensible à la casse et aux espaces", () => {
+    it("should renvoyer 'email', insensible à la casse et aux espaces", () => {
       const data = blocklist({ emails: ["ln941535@mailsecondary.com"] });
       expect(
-        matchesIdentityBlocklist(data, { email: "  LN941535@MailSecondary.com  " })
-      ).toBe(true);
+        matchIdentityReason(data, { email: "  LN941535@MailSecondary.com  " })
+      ).toBe("email");
     });
   });
 
-  describe("given un providerAccountId présent", () => {
-    it("should bloquer sur correspondance exacte", () => {
+  describe("given un email ET un oauthId tous deux bloqués", () => {
+    it("should renvoyer 'email' (prioritaire)", () => {
+      const data = blocklist({ emails: ["a@b.com"], oauthIds: ["x"] });
+      expect(matchIdentityReason(data, { email: "A@B.com", oauthId: "x" })).toBe(
+        "email"
+      );
+    });
+  });
+
+  describe("given un providerAccountId présent (sans email bloqué)", () => {
+    it("should renvoyer 'oauth' sur correspondance exacte", () => {
       const data = blocklist({ oauthIds: ["113146911556107410982"] });
       expect(
-        matchesIdentityBlocklist(data, { oauthId: "113146911556107410982" })
-      ).toBe(true);
+        matchIdentityReason(data, {
+          email: "legit@gmail.com",
+          oauthId: "113146911556107410982",
+        })
+      ).toBe("oauth");
     });
   });
 
   describe("given une identité absente de la surcouche", () => {
-    it("should ne pas bloquer", () => {
+    it("should renvoyer null", () => {
       const data = blocklist({ emails: ["someone@evil.test"] });
       expect(
-        matchesIdentityBlocklist(data, {
-          email: "legit@gmail.com",
-          oauthId: "999",
-        })
-      ).toBe(false);
+        matchIdentityReason(data, { email: "legit@gmail.com", oauthId: "999" })
+      ).toBeNull();
     });
   });
 
   describe("given une identité sans email ni oauthId", () => {
-    it("should ne pas bloquer (pas de faux positif sur null)", () => {
+    it("should renvoyer null (pas de faux positif sur null)", () => {
       const data = blocklist({ emails: ["a@b.com"], oauthIds: ["x"] });
-      expect(matchesIdentityBlocklist(data, {})).toBe(false);
+      expect(matchIdentityReason(data, {})).toBeNull();
       expect(
-        matchesIdentityBlocklist(data, { email: null, oauthId: null })
-      ).toBe(false);
+        matchIdentityReason(data, { email: null, oauthId: null })
+      ).toBeNull();
     });
-  });
-});
-
-describe("matchIdentityReason", () => {
-  it("should renvoyer 'email' sur correspondance email (prioritaire)", () => {
-    const data = blocklist({ emails: ["a@b.com"], oauthIds: ["x"] });
-    expect(matchIdentityReason(data, { email: "A@B.com", oauthId: "x" })).toBe(
-      "email"
-    );
-  });
-
-  it("should renvoyer 'oauth' quand seul l'oauthId matche", () => {
-    const data = blocklist({ oauthIds: ["x"] });
-    expect(
-      matchIdentityReason(data, { email: "legit@gmail.com", oauthId: "x" })
-    ).toBe("oauth");
-  });
-
-  it("should renvoyer null sans correspondance", () => {
-    expect(matchIdentityReason(blocklist(), { email: "a@b.com" })).toBeNull();
   });
 });
 
@@ -110,73 +97,6 @@ describe("coerceBlocklist", () => {
   });
 });
 
-describe("isBlockedSignIn", () => {
-  const ORIGINAL_EDGE_CONFIG = process.env.EDGE_CONFIG;
-
-  beforeEach(() => {
-    getMock.mockReset();
-    process.env.EDGE_CONFIG = "edge-config-connection-string";
-  });
-
-  afterEach(() => {
-    if (ORIGINAL_EDGE_CONFIG === undefined) delete process.env.EDGE_CONFIG;
-    else process.env.EDGE_CONFIG = ORIGINAL_EDGE_CONFIG;
-  });
-
-  describe("given EDGE_CONFIG absent (local)", () => {
-    it("should fail-open : ne pas lire Edge Config, ne pas bloquer", async () => {
-      delete process.env.EDGE_CONFIG;
-      expect(await isBlockedSignIn("legit@gmail.com", "42")).toBe(false);
-      expect(getMock).not.toHaveBeenCalled();
-    });
-  });
-
-  describe("given une lecture Edge Config en erreur", () => {
-    it("should fail-open (pas de lock-out)", async () => {
-      getMock.mockRejectedValue(new Error("edge config down"));
-      expect(await isBlockedSignIn("legit@gmail.com")).toBe(false);
-    });
-  });
-
-  describe("given une lecture Edge Config qui hang", () => {
-    it("should fail-open après le timeout (pas de connexion bloquée)", async () => {
-      vi.useFakeTimers();
-      try {
-        getMock.mockReturnValue(new Promise(() => {})); // ne se résout jamais
-        const pending = isBlockedSignIn("legit@gmail.com");
-        await vi.advanceTimersByTimeAsync(800);
-        expect(await pending).toBe(false);
-      } finally {
-        vi.useRealTimers();
-      }
-    });
-  });
-
-  describe("given un domaine bloqué dynamiquement", () => {
-    it("should bloquer quel que soit le provider (OAuth inclus)", async () => {
-      getMock.mockResolvedValue({ domains: ["evil.com"] });
-      // Pas de provider/email resend ici : couvre le chemin OAuth.
-      expect(await isBlockedSignIn("attacker@evil.com", "google-123")).toBe(true);
-      expect(await isBlockedSignIn("attacker@sub.evil.com")).toBe(true);
-    });
-  });
-
-  describe("given une surcouche corrompue (email non-string)", () => {
-    it("should coercer sans crasher et bloquer les vraies entrées", async () => {
-      getMock.mockResolvedValue({ emails: [null, "x@y.com"] });
-      expect(await isBlockedSignIn("x@y.com")).toBe(true);
-      expect(await isBlockedSignIn("safe@gmail.com")).toBe(false);
-    });
-  });
-
-  describe("given un providerAccountId bloqué dynamiquement", () => {
-    it("should bloquer", async () => {
-      getMock.mockResolvedValue({ oauthIds: ["github-999"] });
-      expect(await isBlockedSignIn("whoever@gmail.com", "github-999")).toBe(true);
-    });
-  });
-});
-
 describe("checkBlockedSignIn", () => {
   const ORIGINAL_EDGE_CONFIG = process.env.EDGE_CONFIG;
 
@@ -190,31 +110,70 @@ describe("checkBlockedSignIn", () => {
     else process.env.EDGE_CONFIG = ORIGINAL_EDGE_CONFIG;
   });
 
-  it("should renvoyer 'static' pour une entrée de la baseline du code", async () => {
-    // Email présent dans sign-in-blocklist.ts (baseline statique).
-    expect(await checkBlockedSignIn("ixewufoy22@gmail.com")).toBe("static");
-    expect(getMock).not.toHaveBeenCalled(); // court-circuite Edge Config
+  describe("raison du blocage", () => {
+    it("should renvoyer 'static' pour une entrée de la baseline du code", async () => {
+      // Email présent dans sign-in-blocklist.ts (baseline statique).
+      expect(await checkBlockedSignIn("ixewufoy22@gmail.com")).toBe("static");
+      expect(getMock).not.toHaveBeenCalled(); // court-circuite Edge Config
+    });
+
+    it("should renvoyer 'email' pour un email bloqué dynamiquement", async () => {
+      getMock.mockResolvedValue({ emails: ["x@y.com"] });
+      expect(await checkBlockedSignIn("X@Y.com")).toBe("email");
+    });
+
+    it("should renvoyer 'oauth' pour un providerAccountId bloqué", async () => {
+      getMock.mockResolvedValue({ oauthIds: ["github-999"] });
+      expect(await checkBlockedSignIn("whoever@gmail.com", "github-999")).toBe(
+        "oauth"
+      );
+    });
+
+    it("should renvoyer 'domain' pour un domaine bloqué (sous-domaine inclus)", async () => {
+      getMock.mockResolvedValue({ domains: ["evil.com"] });
+      // Pas de provider resend ici : couvre aussi le chemin OAuth.
+      expect(await checkBlockedSignIn("attacker@evil.com", "google-123")).toBe(
+        "domain"
+      );
+      expect(await checkBlockedSignIn("attacker@sub.evil.com")).toBe("domain");
+    });
+
+    it("should renvoyer null pour un acteur non bloqué", async () => {
+      getMock.mockResolvedValue({ emails: ["someone@evil.test"] });
+      expect(await checkBlockedSignIn("legit@gmail.com", "42")).toBeNull();
+    });
   });
 
-  it("should renvoyer 'email' pour un email bloqué dynamiquement", async () => {
-    getMock.mockResolvedValue({ emails: ["x@y.com"] });
-    expect(await checkBlockedSignIn("X@Y.com")).toBe("email");
+  describe("fail-open (jamais de lock-out)", () => {
+    it("should ne pas lire Edge Config ni bloquer si EDGE_CONFIG absent (local)", async () => {
+      delete process.env.EDGE_CONFIG;
+      expect(await checkBlockedSignIn("legit@gmail.com", "42")).toBeNull();
+      expect(getMock).not.toHaveBeenCalled();
+    });
+
+    it("should fail-open sur une lecture Edge Config en erreur", async () => {
+      getMock.mockRejectedValue(new Error("edge config down"));
+      expect(await checkBlockedSignIn("legit@gmail.com")).toBeNull();
+    });
+
+    it("should fail-open après le timeout si la lecture hang", async () => {
+      vi.useFakeTimers();
+      try {
+        getMock.mockReturnValue(new Promise(() => {})); // ne se résout jamais
+        const pending = checkBlockedSignIn("legit@gmail.com");
+        await vi.advanceTimersByTimeAsync(800);
+        expect(await pending).toBeNull();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 
-  it("should renvoyer 'oauth' pour un providerAccountId bloqué", async () => {
-    getMock.mockResolvedValue({ oauthIds: ["github-999"] });
-    expect(await checkBlockedSignIn("whoever@gmail.com", "github-999")).toBe(
-      "oauth"
-    );
-  });
-
-  it("should renvoyer 'domain' pour un domaine bloqué (sous-domaine inclus)", async () => {
-    getMock.mockResolvedValue({ domains: ["evil.com"] });
-    expect(await checkBlockedSignIn("attacker@sub.evil.com")).toBe("domain");
-  });
-
-  it("should renvoyer null pour un acteur non bloqué", async () => {
-    getMock.mockResolvedValue({ emails: ["someone@evil.test"] });
-    expect(await checkBlockedSignIn("legit@gmail.com", "42")).toBeNull();
+  describe("robustesse de la surcouche", () => {
+    it("should coercer une entrée corrompue (email non-string) sans crasher", async () => {
+      getMock.mockResolvedValue({ emails: [null, "x@y.com"] });
+      expect(await checkBlockedSignIn("x@y.com")).toBe("email");
+      expect(await checkBlockedSignIn("safe@gmail.com")).toBeNull();
+    });
   });
 });

--- a/src/infrastructure/auth/auth.config.ts
+++ b/src/infrastructure/auth/auth.config.ts
@@ -20,7 +20,10 @@ import {
   checkBlockedSignIn,
   type BlockMatch,
 } from "@/infrastructure/auth/dynamic-blocklist";
-import { isDisposableEmailDomain } from "@/lib/email/disposable-domains";
+import {
+  extractDomain,
+  isDisposableEmailDomain,
+} from "@/lib/email/disposable-domains";
 
 // Validité du magic link. On le rend volontairement court (vs 24h par défaut
 // Auth.js) parce que le token est désormais réutilisable pendant cette fenêtre,
@@ -71,7 +74,10 @@ async function reportRejectedSignIn(
     provider?: string | null;
   }
 ) {
-  const emailDomain = identity.email?.split("@")[1] || "unknown";
+  // Domaine normalisé (minuscules, sans point FQDN) : sinon « Evil.COM » et
+  // « evil.com » fingerprinteraient en 2 issues distinctes => avalanche.
+  const emailDomain =
+    (identity.email ? extractDomain(identity.email) : null) ?? "unknown";
   Sentry.captureMessage(`auth: connexion bloquée [${reason}] ${emailDomain}`, {
     level: "warning",
     fingerprint: ["auth-sign-in-blocked", reason, emailDomain],

--- a/src/infrastructure/auth/auth.config.ts
+++ b/src/infrastructure/auth/auth.config.ts
@@ -12,15 +12,14 @@ import { MagicLinkEmail } from "@/infrastructure/services/email/templates/magic-
 import { isUploadedUrl } from "@/lib/blob";
 import { prismaUserRepository } from "@/infrastructure/repositories/prisma-user-repository";
 import { detectLocaleForMagicLink } from "@/lib/auth/magic-link-url";
-import {
-  classifyAuthError,
-  normalizeAuthErrorCode,
-  resolveAuthErrorCode,
-} from "@/lib/auth/error-kinds";
+import { classifyAuthError, resolveAuthErrorCode } from "@/lib/auth/error-kinds";
 import { getRequestObservability } from "@/lib/auth/request-observability";
 import { captureServerEvent } from "@/lib/posthog-server";
 import { createReusableVerificationToken } from "@/infrastructure/auth/reusable-verification-token";
-import { checkBlockedSignIn } from "@/infrastructure/auth/dynamic-blocklist";
+import {
+  checkBlockedSignIn,
+  type BlockMatch,
+} from "@/infrastructure/auth/dynamic-blocklist";
 import { isDisposableEmailDomain } from "@/lib/email/disposable-domains";
 
 // Validité du magic link. On le rend volontairement court (vs 24h par défaut
@@ -45,6 +44,51 @@ const adapter: typeof basePrismaAdapter = {
   ...basePrismaAdapter,
   useVerificationToken: createReusableVerificationToken(prisma),
 };
+
+/** Raison d'un rejet de sign-in journalisé (blocklist + domaine jetable). */
+type RejectReason = BlockMatch | "disposable";
+
+/**
+ * Journalise un rejet de sign-in dans Sentry AVANT le `return false` du callback.
+ *
+ * Le `return false` lève un AccessDenied anonyme (le hook logger.error ne reçoit
+ * que l'Error, sans identité) ; on capte donc ICI qui est rejeté et pourquoi.
+ * L'identité va dans le titre (domaine) et les tags (email complet, raison,
+ * provider) car ce sont les seuls champs que les notifs Sentry email/Slack
+ * affichent, ce qui évite d'aller fouiller les logs.
+ *
+ * - Niveau warning : déclenche la règle « new issue » (notif) sans high-priority.
+ * - `context: auth` : conservé par le beforeSend.
+ * - fingerprint borné à (raison, domaine) : un scanner faisant tourner les
+ *   adresses ne crée qu'UNE issue par domaine, pas une avalanche de notifs ;
+ *   l'AccessDenied doublon, lui, est dropé par le beforeSend.
+ */
+async function reportRejectedSignIn(
+  reason: RejectReason,
+  identity: {
+    email?: string | null;
+    oauthId?: string | null;
+    provider?: string | null;
+  }
+) {
+  const emailDomain = identity.email?.split("@")[1] || "unknown";
+  Sentry.captureMessage(`auth: connexion bloquée [${reason}] ${emailDomain}`, {
+    level: "warning",
+    fingerprint: ["auth-sign-in-blocked", reason, emailDomain],
+    tags: {
+      context: "auth",
+      auth_event: "sign_in_blocked",
+      blocked_reason: reason,
+      email_domain: emailDomain,
+      provider: identity.provider ?? "unknown",
+      blocked_email: identity.email ?? "unknown",
+    },
+    extra: {
+      provider_account_id: identity.oauthId ?? null,
+      ...(await getRequestObservability()),
+    },
+  });
+}
 
 export const { handlers, auth, signIn, signOut } = NextAuth({
   debug: process.env.NODE_ENV !== "production",
@@ -126,6 +170,11 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
       // ce qui faisait classer des rejets blocklist ATTENDUS en « unexpected »
       // (fausses alertes error-level). resolveAuthErrorCode récupère le code
       // canonique depuis le message @auth/core en priorité, repli sur error.name.
+      // resolveAuthErrorCode rend un code DÉJÀ borné : le code @auth/core extrait
+      // du message (set fini du framework, ex. « adaptererror » = panne DB) ou,
+      // à défaut, error.name normalisé (« v » minifié -> « Unknown »). On le pose
+      // tel quel : le re-normaliser écraserait les vraies pannes infra sous
+      // « Unknown » et les rendrait intriables.
       const code = resolveAuthErrorCode(error);
       const kind = classifyAuthError(code);
       // Les erreurs "attendues dans le flow utilisateur" (token expiré,
@@ -135,14 +184,16 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         level: kind === "expected_user_flow" ? "warning" : "error",
         tags: {
           context: "auth",
-          // Tag normalisé pour borner la cardinalité Sentry (un name minifié ou
-          // arbitraire retombe sous « Unknown ») ; le code brut reste en extra.
-          error_code: normalizeAuthErrorCode(code),
+          error_code: code,
           auth_error_kind: kind,
         },
         // Le user-agent distingue un token expiré détonné par un scanner
         // email d'un vrai clic humain tardif (incident réseau d'administration).
-        extra: { raw_error_code: code, ...(await getRequestObservability()) },
+        // raw_error_name = nom brut (souvent minifié) gardé pour le débogage.
+        extra: {
+          raw_error_name: error?.name ?? null,
+          ...(await getRequestObservability()),
+        },
       });
     },
     async warn(code) {
@@ -190,31 +241,11 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         account?.providerAccountId
       );
       if (blockMatch) {
-        // Capture délibérée AVANT le `return false`. L'AccessDenied qui en
-        // découle est anonyme (le hook `logger.error` ne reçoit que l'Error,
-        // sans identité). On journalise donc ICI qui est bloqué et pourquoi,
-        // dans le titre + les tags (les seuls champs que les notifs Sentry
-        // affichent), pour éviter d'aller fouiller les logs. Niveau warning :
-        // déclenche la règle « new issue » (notif email/Slack) sans repasser
-        // en high-priority. Tag `context: auth` => conservé par le beforeSend.
-        Sentry.captureMessage(
-          `auth: tentative bloquée — ${user.email ?? "(sans email)"} [${blockMatch}]`,
-          {
-            level: "warning",
-            tags: {
-              context: "auth",
-              auth_event: "sign_in_blocked",
-              blocked_match: blockMatch,
-              email_domain: user.email?.split("@")[1] ?? "unknown",
-              provider: account?.provider ?? "unknown",
-            },
-            extra: {
-              blocked_email: user.email ?? null,
-              provider_account_id: account?.providerAccountId ?? null,
-              ...(await getRequestObservability()),
-            },
-          }
-        );
+        await reportRejectedSignIn(blockMatch, {
+          email: user.email,
+          oauthId: account?.providerAccountId,
+          provider: account?.provider,
+        });
         return false;
       }
 
@@ -228,6 +259,10 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         user.email &&
         isDisposableEmailDomain(user.email)
       ) {
+        await reportRejectedSignIn("disposable", {
+          email: user.email,
+          provider: account.provider,
+        });
         return false;
       }
 

--- a/src/infrastructure/auth/auth.config.ts
+++ b/src/infrastructure/auth/auth.config.ts
@@ -13,8 +13,9 @@ import { isUploadedUrl } from "@/lib/blob";
 import { prismaUserRepository } from "@/infrastructure/repositories/prisma-user-repository";
 import { detectLocaleForMagicLink } from "@/lib/auth/magic-link-url";
 import {
-  authErrorCodeFromMessage,
   classifyAuthError,
+  normalizeAuthErrorCode,
+  resolveAuthErrorCode,
 } from "@/lib/auth/error-kinds";
 import { getRequestObservability } from "@/lib/auth/request-observability";
 import { captureServerEvent } from "@/lib/posthog-server";
@@ -123,10 +124,9 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
       console.error("[AUTH ERROR]", error);
       // `error.name` est minifié dans le bundle de prod (« AccessDenied » -> « v »),
       // ce qui faisait classer des rejets blocklist ATTENDUS en « unexpected »
-      // (fausses alertes error-level). On récupère donc le code canonique depuis
-      // le message @auth/core en priorité, et on retombe sur `error.name` sinon.
-      const code =
-        authErrorCodeFromMessage(error?.message) ?? error?.name ?? "Unknown";
+      // (fausses alertes error-level). resolveAuthErrorCode récupère le code
+      // canonique depuis le message @auth/core en priorité, repli sur error.name.
+      const code = resolveAuthErrorCode(error);
       const kind = classifyAuthError(code);
       // Les erreurs "attendues dans le flow utilisateur" (token expiré,
       // prefetch scanner, refus OAuth) restent capturées mais en niveau
@@ -135,12 +135,14 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         level: kind === "expected_user_flow" ? "warning" : "error",
         tags: {
           context: "auth",
-          error_code: code,
+          // Tag normalisé pour borner la cardinalité Sentry (un name minifié ou
+          // arbitraire retombe sous « Unknown ») ; le code brut reste en extra.
+          error_code: normalizeAuthErrorCode(code),
           auth_error_kind: kind,
         },
         // Le user-agent distingue un token expiré détonné par un scanner
         // email d'un vrai clic humain tardif (incident réseau d'administration).
-        extra: await getRequestObservability(),
+        extra: { raw_error_code: code, ...(await getRequestObservability()) },
       });
     },
     async warn(code) {

--- a/src/infrastructure/auth/auth.config.ts
+++ b/src/infrastructure/auth/auth.config.ts
@@ -12,7 +12,10 @@ import { MagicLinkEmail } from "@/infrastructure/services/email/templates/magic-
 import { isUploadedUrl } from "@/lib/blob";
 import { prismaUserRepository } from "@/infrastructure/repositories/prisma-user-repository";
 import { detectLocaleForMagicLink } from "@/lib/auth/magic-link-url";
-import { classifyAuthError } from "@/lib/auth/error-kinds";
+import {
+  authErrorCodeFromMessage,
+  classifyAuthError,
+} from "@/lib/auth/error-kinds";
 import { getRequestObservability } from "@/lib/auth/request-observability";
 import { captureServerEvent } from "@/lib/posthog-server";
 import { createReusableVerificationToken } from "@/infrastructure/auth/reusable-verification-token";
@@ -118,7 +121,12 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
   logger: {
     async error(error) {
       console.error("[AUTH ERROR]", error);
-      const code = error?.name ?? "Unknown";
+      // `error.name` est minifié dans le bundle de prod (« AccessDenied » -> « v »),
+      // ce qui faisait classer des rejets blocklist ATTENDUS en « unexpected »
+      // (fausses alertes error-level). On récupère donc le code canonique depuis
+      // le message @auth/core en priorité, et on retombe sur `error.name` sinon.
+      const code =
+        authErrorCodeFromMessage(error?.message) ?? error?.name ?? "Unknown";
       const kind = classifyAuthError(code);
       // Les erreurs "attendues dans le flow utilisateur" (token expiré,
       // prefetch scanner, refus OAuth) restent capturées mais en niveau

--- a/src/infrastructure/auth/auth.config.ts
+++ b/src/infrastructure/auth/auth.config.ts
@@ -20,7 +20,7 @@ import {
 import { getRequestObservability } from "@/lib/auth/request-observability";
 import { captureServerEvent } from "@/lib/posthog-server";
 import { createReusableVerificationToken } from "@/infrastructure/auth/reusable-verification-token";
-import { isBlockedSignIn } from "@/infrastructure/auth/dynamic-blocklist";
+import { checkBlockedSignIn } from "@/infrastructure/auth/dynamic-blocklist";
 import { isDisposableEmailDomain } from "@/lib/email/disposable-domains";
 
 // Validité du magic link. On le rend volontairement court (vs 24h par défaut
@@ -185,7 +185,36 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
     async signIn({ user, account, profile }) {
       // Anti-abus : refuse la connexion des acteurs malveillants connus
       // (identité OAuth ou email blocklistés), avant toute autre logique.
-      if (await isBlockedSignIn(user.email, account?.providerAccountId)) {
+      const blockMatch = await checkBlockedSignIn(
+        user.email,
+        account?.providerAccountId
+      );
+      if (blockMatch) {
+        // Capture délibérée AVANT le `return false`. L'AccessDenied qui en
+        // découle est anonyme (le hook `logger.error` ne reçoit que l'Error,
+        // sans identité). On journalise donc ICI qui est bloqué et pourquoi,
+        // dans le titre + les tags (les seuls champs que les notifs Sentry
+        // affichent), pour éviter d'aller fouiller les logs. Niveau warning :
+        // déclenche la règle « new issue » (notif email/Slack) sans repasser
+        // en high-priority. Tag `context: auth` => conservé par le beforeSend.
+        Sentry.captureMessage(
+          `auth: tentative bloquée — ${user.email ?? "(sans email)"} [${blockMatch}]`,
+          {
+            level: "warning",
+            tags: {
+              context: "auth",
+              auth_event: "sign_in_blocked",
+              blocked_match: blockMatch,
+              email_domain: user.email?.split("@")[1] ?? "unknown",
+              provider: account?.provider ?? "unknown",
+            },
+            extra: {
+              blocked_email: user.email ?? null,
+              provider_account_id: account?.providerAccountId ?? null,
+              ...(await getRequestObservability()),
+            },
+          }
+        );
         return false;
       }
 

--- a/src/infrastructure/auth/dynamic-blocklist.ts
+++ b/src/infrastructure/auth/dynamic-blocklist.ts
@@ -10,7 +10,7 @@
  * lock-out global (fail-open).
  *
  * Périmètre des entrées dynamiques (toutes appliquées à TOUS les providers,
- * magic link ET OAuth, via `isBlockedSignIn`) :
+ * magic link ET OAuth, via `checkBlockedSignIn`) :
  *  - `emails`   : adresses exactes
  *  - `oauthIds` : `providerAccountId`
  *  - `domains`  : domaines (suffix-walk, couvre les sous-domaines)
@@ -125,20 +125,10 @@ export function matchIdentityReason(
 }
 
 /**
- * Variante booléenne de `matchIdentityReason` (email OU oauth présent).
- */
-export function matchesIdentityBlocklist(
-  data: DynamicBlocklist,
-  identity: { email?: string | null; oauthId?: string | null }
-): boolean {
-  return matchIdentityReason(data, identity) !== null;
-}
-
-/**
  * Bloqué au sign-in (tous providers) : baseline statique OU surcouche dynamique
  * (email, providerAccountId, ou domaine via suffix-walk). Renvoie la raison du
  * blocage (`BlockMatch`) ou `null` si l'acteur passe. Une seule lecture Edge
- * Config, partagée avec `isBlockedSignIn`.
+ * Config.
  */
 export async function checkBlockedSignIn(
   email?: string | null,
@@ -150,15 +140,4 @@ export async function checkBlockedSignIn(
   if (identityReason) return identityReason;
   if (email && matchesDomainSuffix(email, dynamic.domains)) return "domain";
   return null;
-}
-
-/**
- * Variante booléenne de `checkBlockedSignIn`, pour les appelants qui n'ont
- * besoin que de savoir si l'acteur est bloqué.
- */
-export async function isBlockedSignIn(
-  email?: string | null,
-  oauthId?: string | null
-): Promise<boolean> {
-  return (await checkBlockedSignIn(email, oauthId)) !== null;
 }

--- a/src/infrastructure/auth/dynamic-blocklist.ts
+++ b/src/infrastructure/auth/dynamic-blocklist.ts
@@ -98,35 +98,67 @@ async function readDynamic(): Promise<DynamicBlocklist> {
 }
 
 /**
- * Matching pur de l'identité (email + OAuth id) contre la surcouche dynamique.
- * Le matching domaine n'est PAS traité ici (délégué à `matchesDomainSuffix`).
- * Testable sans IO.
+ * Quelle liste a provoqué le blocage. Sert à journaliser un rejet de façon
+ * actionnable (la notif Sentry indique POURQUOI l'acteur est bloqué).
+ *  - `static` : baseline statique du code (`sign-in-blocklist.ts`)
+ *  - `email` / `oauth` / `domain` : surcouche dynamique Edge Config
+ */
+export type BlockMatch = "static" | "email" | "oauth" | "domain";
+
+/**
+ * Matching pur de l'identité (email + OAuth id) contre la surcouche dynamique,
+ * en renvoyant LAQUELLE a matché (ou `null`). Le matching domaine n'est PAS
+ * traité ici (délégué à `matchesDomainSuffix`). Testable sans IO.
+ */
+export function matchIdentityReason(
+  data: DynamicBlocklist,
+  identity: { email?: string | null; oauthId?: string | null }
+): "email" | "oauth" | null {
+  const email = identity.email?.trim().toLowerCase();
+  if (email && data.emails.some((e) => e.trim().toLowerCase() === email)) {
+    return "email";
+  }
+  if (identity.oauthId && data.oauthIds.includes(identity.oauthId)) {
+    return "oauth";
+  }
+  return null;
+}
+
+/**
+ * Variante booléenne de `matchIdentityReason` (email OU oauth présent).
  */
 export function matchesIdentityBlocklist(
   data: DynamicBlocklist,
   identity: { email?: string | null; oauthId?: string | null }
 ): boolean {
-  const email = identity.email?.trim().toLowerCase();
-  if (email && data.emails.some((e) => e.trim().toLowerCase() === email)) {
-    return true;
-  }
-  if (identity.oauthId && data.oauthIds.includes(identity.oauthId)) {
-    return true;
-  }
-  return false;
+  return matchIdentityReason(data, identity) !== null;
 }
 
 /**
  * Bloqué au sign-in (tous providers) : baseline statique OU surcouche dynamique
- * (email, providerAccountId, ou domaine via suffix-walk).
+ * (email, providerAccountId, ou domaine via suffix-walk). Renvoie la raison du
+ * blocage (`BlockMatch`) ou `null` si l'acteur passe. Une seule lecture Edge
+ * Config, partagée avec `isBlockedSignIn`.
+ */
+export async function checkBlockedSignIn(
+  email?: string | null,
+  oauthId?: string | null
+): Promise<BlockMatch | null> {
+  if (isStaticBlockedSignIn(email, oauthId)) return "static";
+  const dynamic = await readDynamic();
+  const identityReason = matchIdentityReason(dynamic, { email, oauthId });
+  if (identityReason) return identityReason;
+  if (email && matchesDomainSuffix(email, dynamic.domains)) return "domain";
+  return null;
+}
+
+/**
+ * Variante booléenne de `checkBlockedSignIn`, pour les appelants qui n'ont
+ * besoin que de savoir si l'acteur est bloqué.
  */
 export async function isBlockedSignIn(
   email?: string | null,
   oauthId?: string | null
 ): Promise<boolean> {
-  if (isStaticBlockedSignIn(email, oauthId)) return true;
-  const dynamic = await readDynamic();
-  if (matchesIdentityBlocklist(dynamic, { email, oauthId })) return true;
-  if (email && matchesDomainSuffix(email, dynamic.domains)) return true;
-  return false;
+  return (await checkBlockedSignIn(email, oauthId)) !== null;
 }

--- a/src/lib/__tests__/sentry-before-send.test.ts
+++ b/src/lib/__tests__/sentry-before-send.test.ts
@@ -22,12 +22,31 @@ describe("dropExpectedAuthRejections", () => {
     });
   });
 
-  describe("given une capture délibérée taggée context=auth", () => {
-    it("should la conserver même si le message matche (observabilité préservée)", () => {
+  describe("given une exception AccessDenied taggée context=auth (re-capture logger.error)", () => {
+    it("should la droper : doublon du captureMessage de rejet (avec identité)", () => {
       const event = exceptionEvent(ACCESS_DENIED, {
         level: "warning",
         tags: { context: "auth", error_code: "AccessDenied" },
       });
+      expect(dropExpectedAuthRejections(event)).toBeNull();
+    });
+  });
+
+  describe("given une capture délibérée taggée context=auth", () => {
+    it("should conserver une Verification context=auth (signal d'abus préservé)", () => {
+      const event = exceptionEvent(VERIFICATION, {
+        level: "warning",
+        tags: { context: "auth", error_code: "Verification" },
+      });
+      expect(dropExpectedAuthRejections(event)).toBe(event);
+    });
+
+    it("should conserver le captureMessage de rejet (sans exception, tag sign_in_blocked)", () => {
+      const event = {
+        level: "warning",
+        message: "auth: connexion bloquée [domain] nms.asia",
+        tags: { context: "auth", auth_event: "sign_in_blocked" },
+      } as unknown as ErrorEvent;
       expect(dropExpectedAuthRejections(event)).toBe(event);
     });
 

--- a/src/lib/auth/__tests__/error-kinds.test.ts
+++ b/src/lib/auth/__tests__/error-kinds.test.ts
@@ -96,9 +96,19 @@ describe("authErrorCodeFromMessage", () => {
     });
   });
 
-  describe("given un message sans hash @auth/core connu", () => {
+  describe("given un message @auth/core dont le hash n'est pas dans la map", () => {
+    // Préserve le code exact (panne infra triable) plutôt que de le perdre.
     it.each([
-      "errors.authjs.dev#somethingunknown",
+      ["AdapterError. Read more at https://errors.authjs.dev#adaptererror", "adaptererror"],
+      ["Read more at https://errors.authjs.dev#jwtsessionerror", "jwtsessionerror"],
+      ["errors.authjs.dev#somethingunknown", "somethingunknown"],
+    ])("should renvoyer le hash brut pour %s", (message, expected) => {
+      expect(authErrorCodeFromMessage(message)).toBe(expected);
+    });
+  });
+
+  describe("given un message sans hash @auth/core", () => {
+    it.each([
       "TypeError: cannot read properties of undefined",
       "Database connection failed",
       "",
@@ -132,10 +142,21 @@ describe("resolveAuthErrorCode", () => {
     );
   });
 
-  it("should retomber sur error.name si le message ne porte pas de hash connu", () => {
-    const error = { name: "AdapterError", message: "Database connection failed" };
-    expect(resolveAuthErrorCode(error)).toBe("AdapterError");
+  // Régression (review #2) : une vraie panne infra (#adaptererror) ne doit PAS
+  // se collapser sous « Unknown » ; on garde le code exact, classé unexpected.
+  it("should préserver le code d'une panne infra @auth/core", () => {
+    const error = {
+      name: "v",
+      message: "AdapterError. Read more at https://errors.authjs.dev#adaptererror",
+    };
+    expect(resolveAuthErrorCode(error)).toBe("adaptererror");
     expect(classifyAuthError(resolveAuthErrorCode(error))).toBe("unexpected");
+  });
+
+  it("should normaliser le repli sur error.name minifié sous Unknown (cardinalité)", () => {
+    // Pas de hash @auth/core dans le message -> repli normalisé sur error.name.
+    const error = { name: "v", message: "boom" };
+    expect(resolveAuthErrorCode(error)).toBe("Unknown");
   });
 
   it.each([{}, null, undefined])(

--- a/src/lib/auth/__tests__/error-kinds.test.ts
+++ b/src/lib/auth/__tests__/error-kinds.test.ts
@@ -4,6 +4,7 @@ import {
   classifyAuthError,
   isExpectedAuthRejectionMessage,
   normalizeAuthErrorCode,
+  resolveAuthErrorCode,
 } from "@/lib/auth/error-kinds";
 
 describe("classifyAuthError", () => {
@@ -110,19 +111,39 @@ describe("authErrorCodeFromMessage", () => {
     });
   });
 
+});
+
+// Exerce le VRAI chemin de résolution utilisé par le logger d'auth.config
+// (pas une réimplémentation du fallback) : un changement d'ordre de priorité
+// dans resolveAuthErrorCode casse ces tests.
+describe("resolveAuthErrorCode", () => {
   // Régression : en prod, `error.name` est minifié (« AccessDenied » -> « v »),
-  // mais le message porte toujours le code canonique. La classification doit
-  // donc s'appuyer sur le message pour éviter les fausses alertes error-level.
-  describe("given un name minifié mais un message canonique (bundle prod)", () => {
-    it("should reclasser un rejet AccessDenied en expected_user_flow", () => {
-      const minifiedName = "v";
-      const message =
-        "AccessDenied. Read more at https://errors.authjs.dev#accessdenied";
-      const code = authErrorCodeFromMessage(message) ?? minifiedName;
-      expect(code).toBe("AccessDenied");
-      expect(classifyAuthError(code)).toBe("expected_user_flow");
-    });
+  // mais le message porte toujours le code canonique. La résolution doit donc
+  // privilégier le message pour éviter les fausses alertes error-level.
+  it("should privilégier le code du message quand error.name est minifié", () => {
+    const error = {
+      name: "v",
+      message:
+        "AccessDenied. Read more at https://errors.authjs.dev#accessdenied",
+    };
+    expect(resolveAuthErrorCode(error)).toBe("AccessDenied");
+    expect(classifyAuthError(resolveAuthErrorCode(error))).toBe(
+      "expected_user_flow"
+    );
   });
+
+  it("should retomber sur error.name si le message ne porte pas de hash connu", () => {
+    const error = { name: "AdapterError", message: "Database connection failed" };
+    expect(resolveAuthErrorCode(error)).toBe("AdapterError");
+    expect(classifyAuthError(resolveAuthErrorCode(error))).toBe("unexpected");
+  });
+
+  it.each([{}, null, undefined])(
+    "should renvoyer Unknown sans name ni message exploitable (%o)",
+    (error) => {
+      expect(resolveAuthErrorCode(error)).toBe("Unknown");
+    }
+  );
 });
 
 describe("isExpectedAuthRejectionMessage", () => {

--- a/src/lib/auth/__tests__/error-kinds.test.ts
+++ b/src/lib/auth/__tests__/error-kinds.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   authErrorCodeFromMessage,
   classifyAuthError,
-  isExpectedAuthRejectionMessage,
+  isAlwaysDuplicateRejectionCode,
   normalizeAuthErrorCode,
   resolveAuthErrorCode,
 } from "@/lib/auth/error-kinds";
@@ -167,30 +167,15 @@ describe("resolveAuthErrorCode", () => {
   );
 });
 
-describe("isExpectedAuthRejectionMessage", () => {
-  describe("given un message d'exception @auth/core d'un rejet attendu", () => {
-    it.each([
-      "AccessDenied. Read more at https://errors.authjs.dev#accessdenied",
-      "Verification. Read more at https://errors.authjs.dev#verification",
-      "Read more at HTTPS://ERRORS.AUTHJS.DEV#ACCESSDENIED", // insensible à la casse
-    ])("should reconnaître %s", (message) => {
-      expect(isExpectedAuthRejectionMessage(message)).toBe(true);
-    });
+describe("isAlwaysDuplicateRejectionCode", () => {
+  it("should reconnaître AccessDenied (doublon d'une capture délibérée)", () => {
+    expect(isAlwaysDuplicateRejectionCode("AccessDenied")).toBe(true);
   });
 
-  describe("given un message d'erreur non attendu ou hors auth", () => {
-    it.each([
-      "Configuration. Read more at https://errors.authjs.dev#configuration",
-      "OAuthCallbackError. Read more at https://errors.authjs.dev#oauthcallbackerror",
-      "TypeError: cannot read properties of undefined",
-      "Database connection failed",
-      "",
-    ])("should ne pas reconnaître %s", (message) => {
-      expect(isExpectedAuthRejectionMessage(message)).toBe(false);
-    });
-
-    it.each([null, undefined])("should gérer %s sans lever", (message) => {
-      expect(isExpectedAuthRejectionMessage(message)).toBe(false);
-    });
-  });
+  it.each(["Verification", "adaptererror", "Unknown", null, undefined])(
+    "should renvoyer false pour %s",
+    (code) => {
+      expect(isAlwaysDuplicateRejectionCode(code)).toBe(false);
+    }
+  );
 });

--- a/src/lib/auth/__tests__/error-kinds.test.ts
+++ b/src/lib/auth/__tests__/error-kinds.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  authErrorCodeFromMessage,
   classifyAuthError,
   isExpectedAuthRejectionMessage,
   normalizeAuthErrorCode,
@@ -78,6 +79,48 @@ describe("normalizeAuthErrorCode", () => {
 
     it("should return Unknown for undefined", () => {
       expect(normalizeAuthErrorCode(undefined)).toBe("Unknown");
+    });
+  });
+});
+
+describe("authErrorCodeFromMessage", () => {
+  describe("given un message @auth/core portant un hash de code connu", () => {
+    it.each([
+      ["AccessDenied. Read more at https://errors.authjs.dev#accessdenied", "AccessDenied"],
+      ["Verification. Read more at https://errors.authjs.dev#verification", "Verification"],
+      ["Configuration. Read more at https://errors.authjs.dev#configuration", "Configuration"],
+      ["Read more at HTTPS://ERRORS.AUTHJS.DEV#ACCESSDENIED", "AccessDenied"], // insensible à la casse
+    ])("should extraire le code canonique de %s", (message, expected) => {
+      expect(authErrorCodeFromMessage(message)).toBe(expected);
+    });
+  });
+
+  describe("given un message sans hash @auth/core connu", () => {
+    it.each([
+      "errors.authjs.dev#somethingunknown",
+      "TypeError: cannot read properties of undefined",
+      "Database connection failed",
+      "",
+    ])("should renvoyer undefined pour %s", (message) => {
+      expect(authErrorCodeFromMessage(message)).toBeUndefined();
+    });
+
+    it.each([null, undefined])("should gérer %s sans lever", (message) => {
+      expect(authErrorCodeFromMessage(message)).toBeUndefined();
+    });
+  });
+
+  // Régression : en prod, `error.name` est minifié (« AccessDenied » -> « v »),
+  // mais le message porte toujours le code canonique. La classification doit
+  // donc s'appuyer sur le message pour éviter les fausses alertes error-level.
+  describe("given un name minifié mais un message canonique (bundle prod)", () => {
+    it("should reclasser un rejet AccessDenied en expected_user_flow", () => {
+      const minifiedName = "v";
+      const message =
+        "AccessDenied. Read more at https://errors.authjs.dev#accessdenied";
+      const code = authErrorCodeFromMessage(message) ?? minifiedName;
+      expect(code).toBe("AccessDenied");
+      expect(classifyAuthError(code)).toBe("expected_user_flow");
     });
   });
 });

--- a/src/lib/auth/error-kinds.ts
+++ b/src/lib/auth/error-kinds.ts
@@ -38,10 +38,28 @@ export function classifyAuthError(code: string | null | undefined): AuthErrorKin
   return EXPECTED_AUTH_ERROR_CODES.has(normalized) ? "expected_user_flow" : "unexpected";
 }
 
-// Hash des codes attendus dans l'URL d'erreur @auth/core (ex. "#accessdenied").
-const EXPECTED_AUTHJS_HASHES = new Set(
-  [...EXPECTED_AUTH_ERROR_CODES].map((code) => code.toLowerCase())
+// Reverse-map du hash @auth/core (ex. "#accessdenied") vers le code canonique
+// ("AccessDenied"). Permet de récupérer le vrai code quand `error.name` est
+// minifié dans le bundle de prod (ex. "v") et ne correspond plus au code Auth.js.
+const CANONICAL_CODE_BY_HASH = new Map(
+  [...KNOWN_AUTH_ERROR_CODES].map((code) => [code.toLowerCase(), code])
 );
+
+/**
+ * Récupère le code d'erreur Auth.js canonique depuis le message `@auth/core`
+ * (« … errors.authjs.dev#accessdenied » -> "AccessDenied").
+ *
+ * Robuste à la minification du bundle de prod, où `error.name` perd sa valeur
+ * (« AccessDenied » devient « v »). Retourne `undefined` si le message ne porte
+ * pas de hash connu — l'appelant retombe alors sur `error.name`.
+ */
+export function authErrorCodeFromMessage(
+  message: string | null | undefined
+): string | undefined {
+  if (!message) return undefined;
+  const hash = message.toLowerCase().match(/errors\.authjs\.dev#([a-z]+)/)?.[1];
+  return hash ? CANONICAL_CODE_BY_HASH.get(hash) : undefined;
+}
 
 /**
  * Détecte si un message d'exception correspond à un rejet d'authentification
@@ -56,7 +74,6 @@ const EXPECTED_AUTHJS_HASHES = new Set(
 export function isExpectedAuthRejectionMessage(
   message: string | null | undefined
 ): boolean {
-  if (!message) return false;
-  const hash = message.toLowerCase().match(/errors\.authjs\.dev#([a-z]+)/)?.[1];
-  return hash !== undefined && EXPECTED_AUTHJS_HASHES.has(hash);
+  const code = authErrorCodeFromMessage(message);
+  return code !== undefined && classifyAuthError(code) === "expected_user_flow";
 }

--- a/src/lib/auth/error-kinds.ts
+++ b/src/lib/auth/error-kinds.ts
@@ -20,9 +20,14 @@ const KNOWN_AUTH_ERROR_CODES = new Set([
   "Default",
 ]);
 
+/** Retire l'info après le `:` d'un code Auth.js (« Verification: token expired »). */
+function stripCodePrefix(code: string): string {
+  return code.split(":")[0]?.trim() ?? "";
+}
+
 export function normalizeAuthErrorCode(code: string | null | undefined): string {
   if (!code) return "Unknown";
-  const normalized = code.split(":")[0]?.trim() ?? "";
+  const normalized = stripCodePrefix(code);
   return KNOWN_AUTH_ERROR_CODES.has(normalized) ? normalized : "Unknown";
 }
 
@@ -34,8 +39,9 @@ export function normalizeAuthErrorCode(code: string | null | undefined): string 
  */
 export function classifyAuthError(code: string | null | undefined): AuthErrorKind {
   if (!code) return "unexpected";
-  const normalized = code.split(":")[0]?.trim() ?? "";
-  return EXPECTED_AUTH_ERROR_CODES.has(normalized) ? "expected_user_flow" : "unexpected";
+  return EXPECTED_AUTH_ERROR_CODES.has(stripCodePrefix(code))
+    ? "expected_user_flow"
+    : "unexpected";
 }
 
 // Reverse-map du hash @auth/core (ex. "#accessdenied") vers le code canonique
@@ -72,8 +78,8 @@ export function authErrorCodeFromMessage(
  * prod), avec repli sur `error.name` puis « Unknown ».
  *
  * Centralise le fallback pour qu'il soit testable directement (le callsite ne
- * réimplémente plus l'ordre de priorité). Le résultat doit encore passer par
- * `normalizeAuthErrorCode` avant d'alimenter un tag Sentry (cardinalité bornée).
+ * réimplémente plus l'ordre de priorité). Le résultat est DÉJÀ borné (code
+ * @auth/core du set fini, ou error.name normalisé) : pas de re-normalisation.
  */
 export function resolveAuthErrorCode(
   error: { name?: string | null; message?: string | null } | null | undefined
@@ -88,18 +94,20 @@ export function resolveAuthErrorCode(
 }
 
 /**
- * Détecte si un message d'exception correspond à un rejet d'authentification
- * ATTENDU levé par `@auth/core` (ex. « AccessDenied. Read more at
- * https://errors.authjs.dev#accessdenied »).
+ * Codes dont l'exception auto-captée (SDK ou hook logger.error) est TOUJOURS un
+ * doublon d'une capture délibérée portant l'identité (`reportRejectedSignIn`),
+ * donc à droper même si taggée `context: auth`.
  *
- * Sert au `beforeSend` de Sentry à droper l'exception error-level auto-captée
- * par le SDK sur les routes `/api/auth/*` : ces refus (blocklist, token expiré)
- * sont déjà observés via le `captureMessage` warning de la page `/auth/error`.
- * On supprime le doublon error-level, pas l'observabilité.
+ * `AccessDenied` : seul moyen pour `@auth/core` de signaler un refus du callback
+ * signIn (`return false`), et nos deux seuls `return false` (blocklist + domaine
+ * jetable) journalisent l'identité via `reportRejectedSignIn`. Source unique de
+ * vérité ici plutôt qu'un littéral disséminé dans le `beforeSend`.
  */
-export function isExpectedAuthRejectionMessage(
-  message: string | null | undefined
+const ALWAYS_DUPLICATE_REJECTION_CODES = new Set(["AccessDenied"]);
+
+/** Le code (issu de `authErrorCodeFromMessage`) est-il un doublon à toujours droper ? */
+export function isAlwaysDuplicateRejectionCode(
+  code: string | null | undefined
 ): boolean {
-  const code = authErrorCodeFromMessage(message);
-  return code !== undefined && classifyAuthError(code) === "expected_user_flow";
+  return code !== undefined && code !== null && ALWAYS_DUPLICATE_REJECTION_CODES.has(code);
 }

--- a/src/lib/auth/error-kinds.ts
+++ b/src/lib/auth/error-kinds.ts
@@ -58,7 +58,12 @@ export function authErrorCodeFromMessage(
 ): string | undefined {
   if (!message) return undefined;
   const hash = message.toLowerCase().match(/errors\.authjs\.dev#([a-z]+)/)?.[1];
-  return hash ? CANONICAL_CODE_BY_HASH.get(hash) : undefined;
+  if (!hash) return undefined;
+  // Code canonique si connu (« accessdenied » -> « AccessDenied »), sinon le
+  // hash brut : il identifie quand même précisément l'erreur @auth/core (ex.
+  // « adaptererror » = panne DB) et reste borné au set fini du framework. Sans
+  // ça, ces pannes infra retombaient sur error.name minifié puis « Unknown ».
+  return CANONICAL_CODE_BY_HASH.get(hash) ?? hash;
 }
 
 /**
@@ -73,7 +78,13 @@ export function authErrorCodeFromMessage(
 export function resolveAuthErrorCode(
   error: { name?: string | null; message?: string | null } | null | undefined
 ): string {
-  return authErrorCodeFromMessage(error?.message) ?? error?.name ?? "Unknown";
+  // Code du message @auth/core en priorité (fiable, borné). À défaut, on retombe
+  // sur `error.name` en le NORMALISANT : minifié en prod (« v ») ou nom arbitraire
+  // d'une exception non-@auth/core, il retombe sous « Unknown » (cardinalité bornée).
+  return (
+    authErrorCodeFromMessage(error?.message) ??
+    normalizeAuthErrorCode(error?.name)
+  );
 }
 
 /**

--- a/src/lib/auth/error-kinds.ts
+++ b/src/lib/auth/error-kinds.ts
@@ -62,6 +62,21 @@ export function authErrorCodeFromMessage(
 }
 
 /**
+ * Code d'erreur effectif pour une exception Auth.js : le code canonique tiré du
+ * message `@auth/core` en priorité (robuste à la minification de `error.name` en
+ * prod), avec repli sur `error.name` puis « Unknown ».
+ *
+ * Centralise le fallback pour qu'il soit testable directement (le callsite ne
+ * réimplémente plus l'ordre de priorité). Le résultat doit encore passer par
+ * `normalizeAuthErrorCode` avant d'alimenter un tag Sentry (cardinalité bornée).
+ */
+export function resolveAuthErrorCode(
+  error: { name?: string | null; message?: string | null } | null | undefined
+): string {
+  return authErrorCodeFromMessage(error?.message) ?? error?.name ?? "Unknown";
+}
+
+/**
  * Détecte si un message d'exception correspond à un rejet d'authentification
  * ATTENDU levé par `@auth/core` (ex. « AccessDenied. Read more at
  * https://errors.authjs.dev#accessdenied »).

--- a/src/lib/sentry-before-send.ts
+++ b/src/lib/sentry-before-send.ts
@@ -2,7 +2,8 @@ import type { ErrorEvent } from "@sentry/nextjs";
 
 import {
   authErrorCodeFromMessage,
-  isExpectedAuthRejectionMessage,
+  classifyAuthError,
+  isAlwaysDuplicateRejectionCode,
 } from "@/lib/auth/error-kinds";
 
 /** Tag posé par NOS captures d'auth délibérées (logger auth + page /auth/error). */
@@ -38,22 +39,22 @@ const DELIBERATE_AUTH_CONTEXT = "auth";
 export function dropExpectedAuthRejections(
   event: ErrorEvent
 ): ErrorEvent | null {
-  const values = event.exception?.values;
+  // Code @auth/core de chaque exception, calculé UNE fois (hot path : ce hook
+  // tourne sur chaque erreur captée, en majorité non-auth).
+  const codes = event.exception?.values?.map((v) =>
+    authErrorCodeFromMessage(v.value)
+  );
 
   // (1) Exception AccessDenied (SDK ou logger.error) → doublon du captureMessage
-  // délibéré de rejet. Dropée quel que soit le tag.
-  if (
-    values?.some((v) => authErrorCodeFromMessage(v.value) === "AccessDenied")
-  ) {
-    return null;
-  }
+  // délibéré de rejet (avec identité). Dropée quel que soit le tag.
+  if (codes?.some(isAlwaysDuplicateRejectionCode)) return null;
 
   // (2) Capture délibérée (taggée context=auth) → conservée : captureMessage de
   // rejet/erreur-page et Verification context=auth (signal d'abus).
   if (event.tags?.context === DELIBERATE_AUTH_CONTEXT) return event;
 
   // (3) Autre rejet attendu auto-capté par le SDK (Verification sans tag) → doublon.
-  if (values?.some((value) => isExpectedAuthRejectionMessage(value.value))) {
+  if (codes?.some((c) => classifyAuthError(c) === "expected_user_flow")) {
     return null;
   }
   return event;

--- a/src/lib/sentry-before-send.ts
+++ b/src/lib/sentry-before-send.ts
@@ -1,6 +1,9 @@
 import type { ErrorEvent } from "@sentry/nextjs";
 
-import { isExpectedAuthRejectionMessage } from "@/lib/auth/error-kinds";
+import {
+  authErrorCodeFromMessage,
+  isExpectedAuthRejectionMessage,
+} from "@/lib/auth/error-kinds";
 
 /** Tag posé par NOS captures d'auth délibérées (logger auth + page /auth/error). */
 const DELIBERATE_AUTH_CONTEXT = "auth";
@@ -8,17 +11,23 @@ const DELIBERATE_AUTH_CONTEXT = "auth";
 /**
  * `beforeSend` Sentry partagé (server + edge).
  *
- * Objectif unique : supprimer le DOUBLON error-level que le SDK auto-capte
- * quand `@auth/core` lève un rejet d'authentification ATTENDU (AccessDenied via
- * blocklist, Verification d'un token expiré…) sur une route `/api/auth/*`. Avec
- * la blocklist active, ces refus généraient de fausses alertes high-priority.
+ * Supprime les DOUBLONS d'exception auto-captés quand `@auth/core` lève un rejet
+ * d'authentification ATTENDU sur une route `/api/auth/*`. Sans ça, ces refus
+ * généraient de fausses alertes high-priority.
+ *
+ * Deux cas dropés :
+ *  1. Toute exception **AccessDenied** (auto-capture brute du SDK OU re-capture
+ *     du hook `logger.error`), car un AccessDenied ne vient QUE d'un `return
+ *     false` du callback signIn (blocklist / domaine jetable) — désormais capté
+ *     délibérément AVEC identité par `reportRejectedSignIn`. L'exception anonyme
+ *     est donc un pur doublon, qu'elle porte ou non le tag `context: auth`.
+ *  2. Les autres rejets attendus auto-captés par le SDK (ex. Verification d'un
+ *     token expiré) SANS tag délibéré.
  *
  * On ne touche JAMAIS à l'observabilité voulue : nos captures délibérées
- * (`logger.error` d'auth.config + `captureMessage` de /auth/error) portent le
- * tag `context: "auth"` et sont en niveau warning. Elles passent telles quelles
- * — ce sont elles qui gardent la trace (user-agent, code) et le signal d'abus
- * (pic de Verification falsifiés). Seule l'exception SANS ce tag (l'auto-capture
- * brute du SDK) est dropée.
+ * (`captureMessage` de rejet et de /auth/error, Verification taggée context=auth)
+ * sont conservées — ce sont elles qui gardent l'identité, la trace et le signal
+ * d'abus (pic de Verification falsifiés).
  *
  * Détection par le message `@auth/core` (`errors.authjs.dev#<code>`) faute de
  * code structuré sur l'auto-capture. Mode d'échec volontairement sûr : si un
@@ -29,10 +38,21 @@ const DELIBERATE_AUTH_CONTEXT = "auth";
 export function dropExpectedAuthRejections(
   event: ErrorEvent
 ): ErrorEvent | null {
-  // Capture délibérée (taggée context=auth) → toujours conservée.
+  const values = event.exception?.values;
+
+  // (1) Exception AccessDenied (SDK ou logger.error) → doublon du captureMessage
+  // délibéré de rejet. Dropée quel que soit le tag.
+  if (
+    values?.some((v) => authErrorCodeFromMessage(v.value) === "AccessDenied")
+  ) {
+    return null;
+  }
+
+  // (2) Capture délibérée (taggée context=auth) → conservée : captureMessage de
+  // rejet/erreur-page et Verification context=auth (signal d'abus).
   if (event.tags?.context === DELIBERATE_AUTH_CONTEXT) return event;
 
-  const values = event.exception?.values;
+  // (3) Autre rejet attendu auto-capté par le SDK (Verification sans tag) → doublon.
   if (values?.some((value) => isExpectedAuthRejectionMessage(value.value))) {
     return null;
   }


### PR DESCRIPTION
## Contexte

Sentry **THE-PLAYGROUND-20** : un rejet `AccessDenied` **attendu** (blocklist refusant un magic-link) remontait en **fausse alerte error-level high-priority**.

Cause : en prod, le bundle **minifie `error.name`** (« AccessDenied » devient « v »). Le classifieur s'appuyait sur `error.name` → code non reconnu → classé `unexpected` → niveau `error`.

Croisement PostHog : l'acteur (bloqué) retentait le magic-link en **proxy hopping** (Sioux City → Cottontown → Benton Harbor en 16 min). Le blocage a tenu, l'alerte rouge était un pur faux positif.

## Ce que fait la PR

**1. Classification robuste à la minification**
- `authErrorCodeFromMessage()` récupère le code depuis le message `@auth/core` (`errors.authjs.dev#accessdenied`), insensible à la minification. Préserve aussi le code réel des pannes infra (`adaptererror`…) au lieu de les noyer sous « Unknown ».
- `resolveAuthErrorCode()` : message en priorité, repli `error.name` normalisé. Les rejets blocklist retombent en `warning`.

**2. Journalisation de l'identité bloquée dans la notif Sentry**
- Au point de blocage (callback signIn), `reportRejectedSignIn()` capte délibérément **qui** est bloqué et **pourquoi** : email + domaine + provider + raison (`static`/`email`/`oauth`/`domain`/`disposable`), dans le titre et les tags (seuls champs affichés par les notifs email/Slack). Plus besoin de fouiller les logs.
- `fingerprint` borné `(raison, domaine normalisé)` : un scanner qui fait tourner les adresses ne crée qu'**une issue par domaine**, pas une avalanche. Niveau `warning` → règle « new issue » (notif) sans high-priority.
- `checkBlockedSignIn()` renvoie la raison du blocage ; helper partagé entre les deux portes de rejet (blocklist + domaine jetable).

**3. Nettoyage du `beforeSend`**
- Droppe le doublon `AccessDenied` auto-capté (le `captureMessage` délibéré avec identité suffit), via un prédicat centralisé `isAlwaysDuplicateRejectionCode` (source unique de vérité). Calcul du code en une seule passe sur le hot path.

## Garde-fou

Mode d'échec sûr : si un futur `@auth/core` reformule ses messages, l'extraction cesse de matcher et ces erreurs **réapparaissent** (bruit visible), au lieu d'être masquées.

## Tests

77 tests verts (`error-kinds`, `dynamic-blocklist`, `sentry-before-send`), typecheck clean. Couvre la régression « name minifié + message canonique », les raisons de blocage, le fail-open Edge Config, et le drop/keep du `beforeSend`.

## Review

3 passes `/code-review` high effort, findings traités à chaque tour (cardinalité des tags, avalanche de notifs, double event, normalisation du domaine, DRY, code mort).

🤖 Generated with [Claude Code](https://claude.com/claude-code)