### PR TITLE
feat(auth): trace les sign-in bloqués dans PostHog

### DIFF
--- a/src/infrastructure/auth/auth.config.ts
+++ b/src/infrastructure/auth/auth.config.ts
@@ -16,6 +16,7 @@ import { classifyAuthError, resolveAuthErrorCode } from "@/lib/auth/error-kinds"
 import { getRequestObservability } from "@/lib/auth/request-observability";
 import { after } from "next/server";
 import { captureServerEvent, getPosthogDistinctId } from "@/lib/posthog-server";
+import { resolveBlockedSignInDistinctId } from "@/lib/auth/blocked-sign-in";
 import { createReusableVerificationToken } from "@/infrastructure/auth/reusable-verification-token";
 import {
   checkBlockedSignIn,
@@ -108,12 +109,7 @@ async function reportRejectedSignIn(
     const distinctId = await getPosthogDistinctId();
     after(() =>
       captureServerEvent(
-        // Vrai navigateur → on relie à sa person/parcours via le cookie. Sinon
-        // (bot, hit direct, client PostHog bloqué) on regroupe par DOMAINE, pas
-        // par email : un scanner qui fait tourner les adresses ne crée qu'une
-        // person par domaine (même borne que le fingerprint Sentry), et aucun
-        // email brut ne devient un identifiant.
-        distinctId ?? `blocked:${emailDomain}`,
+        resolveBlockedSignInDistinctId(distinctId, emailDomain),
         "sign_in_blocked",
         {
           blocked_reason: reason,
@@ -259,7 +255,10 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         ...requestContext,
         provider: account?.provider ?? "unknown",
         is_new_user: isNewUser ?? false,
-        email_domain: user.email?.split("@")[1] ?? "unknown",
+        // extractDomain (normalisé) et non split('@') : cohérence avec l'event
+        // sign_in_blocked pour que les breakdowns/funnels croisés par domaine
+        // matchent (sinon « Gmail.com » ≠ « gmail.com » entre les deux events).
+        email_domain: (user.email ? extractDomain(user.email) : null) ?? "unknown",
         // Renseigne l'email/nom sur la person dès le serveur : si le client
         // PostHog est bloqué (ad-blocker, ITP), la person reste retrouvable
         // par email au lieu de devenir un profil anonyme introuvable.

--- a/src/infrastructure/auth/auth.config.ts
+++ b/src/infrastructure/auth/auth.config.ts
@@ -14,7 +14,8 @@ import { prismaUserRepository } from "@/infrastructure/repositories/prisma-user-
 import { detectLocaleForMagicLink } from "@/lib/auth/magic-link-url";
 import { classifyAuthError, resolveAuthErrorCode } from "@/lib/auth/error-kinds";
 import { getRequestObservability } from "@/lib/auth/request-observability";
-import { captureServerEvent } from "@/lib/posthog-server";
+import { after } from "next/server";
+import { captureServerEvent, getPosthogDistinctId } from "@/lib/posthog-server";
 import { createReusableVerificationToken } from "@/infrastructure/auth/reusable-verification-token";
 import {
   checkBlockedSignIn,
@@ -78,6 +79,7 @@ async function reportRejectedSignIn(
   // « evil.com » fingerprinteraient en 2 issues distinctes => avalanche.
   const emailDomain =
     (identity.email ? extractDomain(identity.email) : null) ?? "unknown";
+  const observability = await getRequestObservability();
   Sentry.captureMessage(`auth: connexion bloquée [${reason}] ${emailDomain}`, {
     level: "warning",
     fingerprint: ["auth-sign-in-blocked", reason, emailDomain],
@@ -91,9 +93,39 @@ async function reportRejectedSignIn(
     },
     extra: {
       provider_account_id: identity.oauthId ?? null,
-      ...(await getRequestObservability()),
+      ...observability,
     },
   });
+
+  // Miroir analytics du warning Sentry : le warning sert à l'ALERTE, cet event
+  // PostHog sert à la MESURE (volume de rejets, géo/parcours qui a précédé).
+  // Capté côté serveur pour couvrir aussi les hits directs sur l'endpoint (bots
+  // qui ne passent pas par le formulaire). `after` pour qu'il parte après la
+  // réponse malgré l'AccessDenied. Minimisation PII : seulement domaine + raison
+  // (pas l'email complet ni l'oauthId, qui restent dans Sentry pour l'alerte).
+  // Best-effort : ne doit JAMAIS casser le sign-in.
+  try {
+    const distinctId = await getPosthogDistinctId();
+    after(() =>
+      captureServerEvent(
+        // Vrai navigateur → on relie à sa person/parcours via le cookie. Sinon
+        // (bot, hit direct, client PostHog bloqué) on regroupe par DOMAINE, pas
+        // par email : un scanner qui fait tourner les adresses ne crée qu'une
+        // person par domaine (même borne que le fingerprint Sentry), et aucun
+        // email brut ne devient un identifiant.
+        distinctId ?? `blocked:${emailDomain}`,
+        "sign_in_blocked",
+        {
+          blocked_reason: reason,
+          email_domain: emailDomain,
+          provider: identity.provider ?? "unknown",
+          ...observability,
+        }
+      )
+    );
+  } catch (error) {
+    Sentry.captureException(error);
+  }
 }
 
 export const { handlers, auth, signIn, signOut } = NextAuth({

--- a/src/lib/auth/__tests__/blocked-sign-in.test.ts
+++ b/src/lib/auth/__tests__/blocked-sign-in.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveBlockedSignInDistinctId } from "@/lib/auth/blocked-sign-in";
+
+describe("resolveBlockedSignInDistinctId", () => {
+  describe("given un cookie PostHog présent (vrai navigateur)", () => {
+    it("relie le rejet à la person du navigateur", () => {
+      expect(resolveBlockedSignInDistinctId("01890-abc-person", "nms.asia")).toBe(
+        "01890-abc-person"
+      );
+    });
+  });
+
+  describe("given aucun cookie (bot, hit direct, client PostHog bloqué)", () => {
+    it("regroupe par domaine plutôt que par email", () => {
+      expect(resolveBlockedSignInDistinctId(null, "nms.asia")).toBe(
+        "blocked:nms.asia"
+      );
+    });
+
+    it("ne crée qu'une person par domaine quels que soient les localparts", () => {
+      // fj131744@ et fj131745@ d'un scanner sur le même domaine → même person.
+      const a = resolveBlockedSignInDistinctId(null, "nms.asia");
+      const b = resolveBlockedSignInDistinctId(null, "nms.asia");
+      expect(a).toBe(b);
+    });
+
+    it("retombe sur le domaine sentinelle quand le domaine est inconnu", () => {
+      expect(resolveBlockedSignInDistinctId(null, "unknown")).toBe(
+        "blocked:unknown"
+      );
+    });
+  });
+});

--- a/src/lib/auth/blocked-sign-in.ts
+++ b/src/lib/auth/blocked-sign-in.ts
@@ -1,0 +1,16 @@
+/**
+ * `distinct_id` PostHog d'un event `sign_in_blocked`.
+ *
+ * - Si on a le cookie PostHog du navigateur, on relie le rejet à la person et au
+ *   parcours réels (le `$pageview`/clic qui l'ont précédé).
+ * - Sinon (bot, hit direct sur l'endpoint, client PostHog bloqué), on regroupe
+ *   par DOMAINE : un scanner qui fait tourner les adresses ne crée qu'une person
+ *   par domaine (même borne que le fingerprint Sentry, anti-explosion de
+ *   cardinalité), et aucun email brut ne devient un identifiant.
+ */
+export function resolveBlockedSignInDistinctId(
+  cookieDistinctId: string | null,
+  emailDomain: string
+): string {
+  return cookieDistinctId ?? `blocked:${emailDomain}`;
+}


### PR DESCRIPTION
## Contexte

Un sign-in rejeté (blocklist ou domaine jetable) n'était journalisé que dans **Sentry** (warning, pour l'alerte). **Aucun event PostHog** n'était émis → impossible de mesurer le volume de rejets ni de relier un blocage au parcours qui l'a précédé. Constaté en investiguant THE-PLAYGROUND-21 (`fj131744@nms.asia`) : la session de test montrait le clic `sign_in_provider_clicked` puis... rien.

## Ce que fait la PR

Ajoute un event serveur **`sign_in_blocked`** dans `reportRejectedSignIn`, en miroir du warning Sentry et calqué sur `auth_sign_in` / `bot_detected` :

- **Côté serveur** → capte aussi les **hits directs** sur l'endpoint (bots qui ne passent pas par le formulaire).
- **`after()`** pour partir après la réponse malgré l'`AccessDenied`.
- **Propriétés** : `blocked_reason` (blocklist email/oauth/domaine ou `disposable`), `email_domain`, `provider`, `user_agent`, `referer`.
- **Minimisation PII** : pas d'email complet ni d'oauthId dans PostHog (ils restent dans Sentry pour l'alerte).
- **Anti-cardinalité** : `distinctId` = cookie navigateur si présent (relie au parcours), sinon **regroupé par domaine** — un scanner qui fait tourner les adresses ne crée qu'une person par domaine, même borne que le fingerprint Sentry. Logique extraite dans `resolveBlockedSignInDistinctId` + tests unitaires.

## Code-review

Workflow high effort exécuté. Findings confirmés corrigés :
- Normalisation `email_domain` alignée entre `auth_sign_in` et `sign_in_blocked` (`extractDomain`) pour des breakdowns/funnels PostHog croisés cohérents.
- Logique anti-cardinalité testée (contrat de tests CLAUDE.md).

## Notes

- Visible **uniquement en prod** (`captureServerEvent` no-op si `NODE_ENV !== "production"`) → validation de l'event après déploiement.
- Pas de changement de schema, pas d'i18n.

🤖 Generated with [Claude Code](https://claude.com/claude-code)