### PR TITLE
feat(admin): boutons de blocage permanents sur la fiche utilisateur

### DIFF
--- a/src/app/[locale]/(routes)/admin/users/[id]/audit-panel.tsx
+++ b/src/app/[locale]/(routes)/admin/users/[id]/audit-panel.tsx
@@ -188,9 +188,11 @@ function BlockActions({ targets }: { targets: AuditTargets }) {
 export function AdminUserAuditPanel({
   userId,
   email,
+  initialTargets,
 }: {
   userId: string;
   email: string;
+  initialTargets: AuditTargets;
 }) {
   const t = useTranslations("Admin.audit");
   const [pending, start] = useTransition();
@@ -221,55 +223,55 @@ export function AdminUserAuditPanel({
           {pending ? t("running") : report ? t("rerun") : t("run")}
         </Button>
       </CardHeader>
-      {(report || failed) && (
-        <CardContent className="space-y-2.5 p-5 pt-0 text-sm">
-          {failed && <p className="text-destructive">{t("error")}</p>}
-          {report && (
-            <>
-              <Badge
-                className={`${VERDICT_CLASS[report.verdictLean]} px-3 py-1 text-sm`}
-              >
-                {t(`verdict.${report.verdictLean}`)}
-              </Badge>
-              <p className="leading-snug">
-                <span className="font-medium">{t("identity")} : </span>
-                {report.identitySummary}
+      <CardContent className="space-y-2.5 p-5 pt-0 text-sm">
+        {failed && <p className="text-destructive">{t("error")}</p>}
+        {report && (
+          <>
+            <Badge
+              className={`${VERDICT_CLASS[report.verdictLean]} px-3 py-1 text-sm`}
+            >
+              {t(`verdict.${report.verdictLean}`)}
+            </Badge>
+            <p className="leading-snug">
+              <span className="font-medium">{t("identity")} : </span>
+              {report.identitySummary}
+            </p>
+            <p className="leading-snug">
+              <span className="font-medium">{t("content")} : </span>
+              {report.contentSummary || "—"}
+            </p>
+            <p className="leading-snug">
+              <span className="font-medium">{t("behavior")} : </span>
+              {report.behaviorSummary || "—"}
+            </p>
+            <div className="grid gap-2 sm:grid-cols-2">
+              <SignalBox
+                title={t("for")}
+                items={report.signalsFor}
+                tone="danger"
+              />
+              <SignalBox
+                title={t("against")}
+                items={report.signalsAgainst}
+                tone="success"
+              />
+            </div>
+            <p className="leading-snug">
+              <span className="font-medium">{t("reco")} : </span>
+              {report.recommendation}
+            </p>
+            {report.usage && (
+              <p className="text-xs text-muted-foreground">
+                {report.usage.model} · {report.usage.inputTokens}+
+                {report.usage.outputTokens} tok
               </p>
-              <p className="leading-snug">
-                <span className="font-medium">{t("content")} : </span>
-                {report.contentSummary || "—"}
-              </p>
-              <p className="leading-snug">
-                <span className="font-medium">{t("behavior")} : </span>
-                {report.behaviorSummary || "—"}
-              </p>
-              <div className="grid gap-2 sm:grid-cols-2">
-                <SignalBox
-                  title={t("for")}
-                  items={report.signalsFor}
-                  tone="danger"
-                />
-                <SignalBox
-                  title={t("against")}
-                  items={report.signalsAgainst}
-                  tone="success"
-                />
-              </div>
-              <p className="leading-snug">
-                <span className="font-medium">{t("reco")} : </span>
-                {report.recommendation}
-              </p>
-              {targets && <BlockActions targets={targets} />}
-              {report.usage && (
-                <p className="text-xs text-muted-foreground">
-                  {report.usage.model} · {report.usage.inputTokens}+
-                  {report.usage.outputTokens} tok
-                </p>
-              )}
-            </>
-          )}
-        </CardContent>
-      )}
+            )}
+          </>
+        )}
+        {/* Boutons de blocage TOUJOURS visibles. Après un audit, on prend les
+            cibles fraîchement renvoyées ; sinon celles calculées au rendu. */}
+        <BlockActions targets={targets ?? initialTargets} />
+      </CardContent>
     </Card>
   );
 }

--- a/src/app/[locale]/(routes)/admin/users/[id]/page.tsx
+++ b/src/app/[locale]/(routes)/admin/users/[id]/page.tsx
@@ -30,13 +30,15 @@ export default async function AdminUserDetailPage({ params }: Props) {
   const t = await getTranslations("Admin");
   const tRole = await getTranslations("Dashboard.role");
   const locale = await getLocale();
-  const user = await prismaAdminRepository.findUserById(id);
+  // Les deux ne dépendent que de `id` → en parallèle (pas de round-trip en
+  // série). buildBlockTargets calcule les cibles de blocage au rendu pour
+  // afficher les boutons en permanence (pas seulement après un audit).
+  const [user, blockTargets] = await Promise.all([
+    prismaAdminRepository.findUserById(id),
+    buildBlockTargets(id),
+  ]);
 
   if (!user) notFound();
-
-  // Cibles de blocage calculées au rendu pour afficher les boutons en
-  // permanence (pas seulement après un audit).
-  const blockTargets = await buildBlockTargets(user.id);
 
   const displayName = [user.firstName, user.lastName].filter(Boolean).join(" ") || "—";
 

--- a/src/app/[locale]/(routes)/admin/users/[id]/page.tsx
+++ b/src/app/[locale]/(routes)/admin/users/[id]/page.tsx
@@ -3,6 +3,7 @@ import { getLocale, getTranslations } from "next-intl/server";
 import Link from "next/link";
 import { ExternalLink } from "lucide-react";
 import { prismaAdminRepository } from "@/infrastructure/repositories";
+import { buildBlockTargets } from "@/infrastructure/services/audit/block-targets";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -32,6 +33,10 @@ export default async function AdminUserDetailPage({ params }: Props) {
   const user = await prismaAdminRepository.findUserById(id);
 
   if (!user) notFound();
+
+  // Cibles de blocage calculées au rendu pour afficher les boutons en
+  // permanence (pas seulement après un audit).
+  const blockTargets = await buildBlockTargets(user.id);
 
   const displayName = [user.firstName, user.lastName].filter(Boolean).join(" ") || "—";
 
@@ -159,7 +164,11 @@ export default async function AdminUserDetailPage({ params }: Props) {
         </CardContent>
       </Card>
 
-      <AdminUserAuditPanel userId={user.id} email={user.email} />
+      <AdminUserAuditPanel
+        userId={user.id}
+        email={user.email}
+        initialTargets={blockTargets}
+      />
 
       <Card>
         <CardHeader>

--- a/src/infrastructure/services/audit/__tests__/block-targets.test.ts
+++ b/src/infrastructure/services/audit/__tests__/block-targets.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { toAuditTargets } from "@/infrastructure/services/audit/block-targets";
+
+describe("toAuditTargets", () => {
+  describe("given un vrai domaine", () => {
+    it("renvoie email, domaine, oauthIds et statut bloqué", () => {
+      expect(
+        toAuditTargets({
+          email: "spam@nms.asia",
+          oauthIds: ["g-123", "gh-456"],
+          emailDomain: "nms.asia",
+          blocked: false,
+        })
+      ).toEqual({
+        email: "spam@nms.asia",
+        domain: "nms.asia",
+        oauthIds: ["g-123", "gh-456"],
+        alreadyBlocked: false,
+      });
+    });
+  });
+
+  describe("given un domaine non résolu", () => {
+    it("ne propose pas « unknown » comme cible de domaine", () => {
+      expect(
+        toAuditTargets({
+          email: "x@y",
+          oauthIds: [],
+          emailDomain: "unknown",
+          blocked: false,
+        }).domain
+      ).toBeNull();
+    });
+
+    it("ne propose pas un domaine vide comme cible", () => {
+      expect(
+        toAuditTargets({
+          email: "x@y",
+          oauthIds: [],
+          emailDomain: "",
+          blocked: false,
+        }).domain
+      ).toBeNull();
+    });
+  });
+
+  describe("given un compte déjà bloqué", () => {
+    it("remonte alreadyBlocked = true", () => {
+      expect(
+        toAuditTargets({
+          email: "a@b.com",
+          oauthIds: [],
+          emailDomain: "b.com",
+          blocked: true,
+        }).alreadyBlocked
+      ).toBe(true);
+    });
+  });
+});

--- a/src/infrastructure/services/audit/audit-user.ts
+++ b/src/infrastructure/services/audit/audit-user.ts
@@ -2,6 +2,7 @@ import Anthropic from "@anthropic-ai/sdk";
 
 import { gatherUserAuditData } from "./gather-user-audit-data";
 import { buildAuditPrompt } from "./build-audit-prompt";
+import { NO_TARGETS, toAuditTargets } from "./block-targets";
 import type {
   AuditDossier,
   AuditOutcome,
@@ -10,24 +11,15 @@ import type {
   AuditVerdictLean,
 } from "./types";
 
-const NO_TARGETS: AuditTargets = {
-  email: null,
-  domain: null,
-  oauthIds: [],
-  alreadyBlocked: false,
-};
-
 /** Cibles de blocage déduites du dossier (le blocage reste une action humaine). */
 function targetsFromDossier(dossier: AuditDossier): AuditTargets {
   if (!dossier.found || !dossier.account) return NO_TARGETS;
-  const domain = dossier.derived?.emailDomain;
-  return {
+  return toAuditTargets({
     email: dossier.account.email,
-    // null si pas de vrai domaine ("unknown" ne doit pas devenir une cible).
-    domain: domain && domain !== "unknown" ? domain : null,
     oauthIds: dossier.account.providers.map((p) => p.providerAccountId),
-    alreadyBlocked: dossier.derived?.blocked ?? false,
-  };
+    emailDomain: dossier.derived?.emailDomain ?? "unknown",
+    blocked: dossier.derived?.blocked ?? false,
+  });
 }
 
 // Modèle par défaut selon l'environnement : Opus en prod (meilleure finesse,

--- a/src/infrastructure/services/audit/block-targets.ts
+++ b/src/infrastructure/services/audit/block-targets.ts
@@ -1,0 +1,61 @@
+import { prisma } from "@/infrastructure/db/prisma";
+import { extractDomain } from "@/lib/email/disposable-domains";
+import { checkBlockedSignIn } from "@/infrastructure/auth/dynamic-blocklist";
+import type { AuditTargets } from "./types";
+
+/** Aucune cible (compte introuvable). */
+export const NO_TARGETS: AuditTargets = {
+  email: null,
+  domain: null,
+  oauthIds: [],
+  alreadyBlocked: false,
+};
+
+/**
+ * Mapping pur vers les cibles de blocage. Source UNIQUE partagée par l'audit LLM
+ * (`targetsFromDossier`) et la fiche admin (`buildBlockTargets`), pour que les
+ * deux proposent exactement les mêmes cibles.
+ */
+export function toAuditTargets(input: {
+  email: string;
+  oauthIds: string[];
+  emailDomain: string; // brut, peut valoir "unknown"
+  blocked: boolean;
+}): AuditTargets {
+  return {
+    email: input.email,
+    // null si pas de vrai domaine ("unknown" ne doit pas devenir une cible).
+    domain:
+      input.emailDomain && input.emailDomain !== "unknown"
+        ? input.emailDomain
+        : null,
+    oauthIds: input.oauthIds,
+    alreadyBlocked: input.blocked,
+  };
+}
+
+/**
+ * Cibles de blocage d'un compte, calculées SANS audit LLM : permet d'afficher
+ * les boutons de blocage en permanence sur la fiche admin (et pas seulement
+ * après un audit). DB (email + oauthIds) + lecture blocklist, aucune dépendance
+ * PostHog. Renvoie {@link NO_TARGETS} si le compte est introuvable.
+ */
+export async function buildBlockTargets(userId: string): Promise<AuditTargets> {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { email: true, accounts: { select: { providerAccountId: true } } },
+  });
+  if (!user) return NO_TARGETS;
+
+  const oauthIds = user.accounts.map((a) => a.providerAccountId);
+  // checkBlockedSignIn vérifie email + oauthId + domaine ; on passe le 1er
+  // oauthId (cohérent avec le dossier d'audit). Le blocage cible tous les oauthIds.
+  const blockedReason = await checkBlockedSignIn(user.email, oauthIds[0]);
+
+  return toAuditTargets({
+    email: user.email,
+    oauthIds,
+    emailDomain: extractDomain(user.email) ?? "unknown",
+    blocked: blockedReason !== null,
+  });
+}


### PR DESCRIPTION
## Contexte

Dans la section **Audit anti-spam** de la fiche utilisateur admin, les boutons « Bloquer ce compte / le domaine » n'apparaissaient **qu'après** un audit IA. On veut pouvoir bloquer à tout moment, sans lancer d'audit.

## Ce que fait la PR

Affiche les boutons de blocage (compte / domaine) **en permanence** dans le panel, indépendamment de l'audit. L'audit reste disponible et, quand il tourne, ses cibles fraîches priment.

- **`buildBlockTargets(userId)`** : calcule les cibles (email, domaine, oauthIds, `alreadyBlocked`) au rendu de la page, sans PostHog ni LLM (DB + lecture blocklist).
- **`toAuditTargets`** : mapper pur partagé = **source unique** des cibles entre l'audit LLM et la fiche admin (pas de divergence) + tests unitaires.
- **`audit-panel`** : `BlockActions` rendu en permanence (`targets ?? initialTargets`).
- Si le compte est **déjà bloqué**, badge « déjà bloqué » au lieu des boutons (comportement conservé).

## Code-review

Workflow high effort exécuté. Corrigé : parallélisation `findUserById` + `buildBlockTargets` (`Promise.all`). Findings restants écartés avec justification (revalidation post-blocage = idempotent + feedback par bouton ; requête dupliquée = concurrente, dédup non justifiée vu le ripple hexagonal ; lecture Edge Config bornée admin-only).

## Notes

- L'écriture en blocklist ne s'exécute **qu'en prod** (`addToBlocklist` guardé `VERCEL_ENV=production`).
- Pas de changement de schema, pas d'i18n (clés existantes), comportement mobile inchangé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)