### PR TITLE
fix(admin): rafraîchit liste/fiche après blocage ou déblocage

### DIFF
--- a/src/app/actions/audit-user.ts
+++ b/src/app/actions/audit-user.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { revalidatePath } from "next/cache";
 import * as Sentry from "@sentry/nextjs";
 import { auth } from "@/infrastructure/auth/auth.config";
 import { isAdminUser } from "@/lib/admin-host-mode";
@@ -60,6 +61,17 @@ export type BlockActionResult = {
 };
 
 /**
+ * Invalide le Router Cache des pages admin users après une mutation de blocklist,
+ * pour que le badge « Bloqué » de la liste et la fiche reflètent l'état frais
+ * sans refresh manuel (sinon Next sert la liste navigée depuis son cache client).
+ * Même convention que les autres mutations admin (cf. admin.ts).
+ */
+function revalidateAdminUserPages() {
+  revalidatePath("/admin/users");
+  revalidatePath("/admin/users/[id]", "page");
+}
+
+/**
  * Ajoute des entrées à la blocklist anti-abus (action humaine explicite,
  * déclenchée depuis l'audit). Admin-only.
  */
@@ -72,6 +84,8 @@ export async function blockSignInAction(
 
   const status = await addToBlocklist(targets);
   if (status !== "applied") return { status, sessionsRevoked: null };
+
+  revalidateAdminUserPages();
 
   // Le blocage seul empêche de se reconnecter mais ne tue pas une session déjà
   // ouverte. On révoque donc les sessions actives. Un échec NE DOIT PAS être
@@ -101,5 +115,7 @@ export async function unblockSignInAction(
 ): Promise<{ status: BlocklistWriteResult | "unauthorized" }> {
   const session = await auth();
   if (!isAdminUser(session)) return { status: "unauthorized" };
-  return { status: await removeFromBlocklist(targets) };
+  const status = await removeFromBlocklist(targets);
+  if (status === "applied") revalidateAdminUserPages();
+  return { status };
 }


### PR DESCRIPTION
## Problème

Le badge « Bloqué » de la liste des users (et l'état de la fiche) restait **stale** après un blocage/déblocage : il fallait rafraîchir manuellement. Cause = le **Router Cache client de Next** sert la route navigée depuis son cache. Les actions bloquer/débloquer n'invalidaient pas le cache, contrairement aux autres mutations admin.

## Fix

`revalidatePath("/admin/users")` + `revalidatePath("/admin/users/[id]", "page")` sur blocage et déblocage **réussis** (`status === "applied"`). Même convention que `admin.ts` et `moment-attachments`.

## Notes

- 1 fichier, pas de schema, pas d'i18n.
- Validé en prod que la chaîne blocage/déblocage fonctionne ; ce fix corrige la fraîcheur d'affichage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)