### PR TITLE
chore(release): màj stats, prérequis Node et page Aide avant 2.16.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Architecture hexagonale (Ports & Adapters), TypeScript strict, tout déployé en
 | | |
 | --- | --- |
 | **2 000+** | commits |
-| **400+** | pull requests |
+| **500+** | pull requests |
 | **80+** | cas d'usage (domain usecases) |
 | **1 000+** | tests (unit + integration + E2E) |
 
@@ -101,7 +101,7 @@ src/
   types/           → Types TypeScript partagés (non domaine)
   i18n/            → Configuration next-intl (routing, request)
   content/         → Contenu statique (articles de blog en Markdown)
-  assets/          → Assets statiques (images, SVG)
+  assets/          → Polices et assets statiques
 ```
 
 Voir `CLAUDE.md` pour le contrat strict d'architecture et les règles de dépendance.
@@ -110,7 +110,7 @@ Voir `CLAUDE.md` pour le contrat strict d'architecture et les règles de dépend
 
 ### Prérequis
 
-- **Node.js** ≥ 24 LTS (aligné avec le runtime Vercel de production)
+- **Node.js** ≥ 22 LTS (version utilisée en CI et en production Vercel)
 - **pnpm** ≥ 10 (le projet déclare `pnpm@10.30.0` via `packageManager`) — `npm install -g pnpm`
 - **PostgreSQL** : un compte gratuit [Neon](https://neon.tech) ou un Postgres local
 - **Compte Resend** (gratuit, 100 emails/jour) : [resend.com](https://resend.com) — pour le magic link et les autres emails

--- a/messages/en.json
+++ b/messages/en.json
@@ -1778,7 +1778,7 @@
       },
       "comments": {
         "title": "Comments",
-        "intro": "Each event has a <strong>comment thread</strong>. You can ask questions, share your excitement, or chat with other attendees. Comments are visible to all registered members and the organizer.",
+        "intro": "Each event has a <strong>comment thread</strong>. You can ask questions, share your excitement, or chat with other attendees. Comments are visible to all registered members and the organizer. For new accounts, a comment may go through a brief review before being published.",
         "photosLabel": "Photos in comments:",
         "photos1": "You can <strong>add up to 3 photos</strong> to each comment (JPG, PNG, WebP)",
         "photos2": "Large photos are <strong>automatically compressed</strong> for fast upload, even from a phone",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1778,7 +1778,7 @@
       },
       "comments": {
         "title": "Les commentaires",
-        "intro": "Chaque événement dispose d'un <strong>fil de commentaires</strong>. Vous pouvez poser des questions, partager votre enthousiasme, ou échanger avec d'autres participants. Les commentaires sont visibles par tous les inscrits et par l'organisateur.",
+        "intro": "Chaque événement dispose d'un <strong>fil de commentaires</strong>. Vous pouvez poser des questions, partager votre enthousiasme, ou échanger avec d'autres participants. Les commentaires sont visibles par tous les inscrits et par l'organisateur. Pour les nouveaux comptes, un commentaire peut être soumis à une courte vérification avant publication.",
         "photosLabel": "Photos dans les commentaires :",
         "photos1": "Vous pouvez <strong>ajouter jusqu'à 3 photos</strong> à chaque commentaire (JPG, PNG, WebP)",
         "photos2": "Les photos volumineuses sont <strong>automatiquement compressées</strong> pour un envoi rapide, même depuis un téléphone",

--- a/src/app/[locale]/(routes)/(static)/about/page.tsx
+++ b/src/app/[locale]/(routes)/(static)/about/page.tsx
@@ -375,10 +375,10 @@ export default async function AboutPage() {
         </h2>
         <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
           {[
-            { value: "2 200+", label: isFr ? "commits" : "commits" },
-            { value: "470+", label: isFr ? "pull requests" : "pull requests" },
-            { value: "82", label: isFr ? "cas d'usage" : "use cases" },
-            { value: "1 280+", label: isFr ? "tests" : "tests" },
+            { value: "2 300+", label: isFr ? "commits" : "commits" },
+            { value: "500+", label: isFr ? "pull requests" : "pull requests" },
+            { value: "85", label: isFr ? "cas d'usage" : "use cases" },
+            { value: "1 480+", label: isFr ? "tests" : "tests" },
           ].map(({ value, label }) => (
             <div key={label} className="text-center">
               <p className="text-2xl font-extrabold tracking-tight bg-gradient-to-r from-pink-500 to-violet-500 bg-clip-text text-transparent">


### PR DESCRIPTION
Mises à jour pré-release (contenu uniquement) avant la 2.16.0 :

- **about** : stats à jour (2 300+ commits, 500+ PRs, 85 usecases, 1 480+ tests)
- **README** : PRs 500+, prérequis Node ≥ 22 LTS (aligné CI/Vercel), description `assets/`
- **page Aide (fr/en)** : mention de la validation des commentaires pour les nouveaux comptes

🤖 Generated with [Claude Code](https://claude.com/claude-code)