### PR TITLE
chore(release): exclut l'outillage anti-abus du changelog public

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -201,13 +201,38 @@ gh release list --limit 3
 
 Afficher la nouvelle release et son tag (`the-playground-vX.Y.Z`).
 
+### Étape 11 — Scrub + synchroniser le corps du GitHub Release (OBLIGATOIRE)
+
+> ⚠️ **Le dépôt est PUBLIC. Le changelog ne doit JAMAIS divulguer l'outillage admin / modération / anti-abus.** Le détail de la règle (quoi exclure) est dans la mémoire `feedback_changelog_no_admin_disclosure.md`.
+
+Deux surfaces, pas une :
+
+1. **`CHANGELOG.md`** (humanisé par le workflow, rendu sur `/changelog`). Le script `scripts/humanize-changelog.ts` est censé déjà exclure l'anti-abus, mais **vérifier** la section de la nouvelle version :
+
+```bash
+sed -n "/## \[X.Y.Z\]/,/## \[/p" CHANGELOG.md | grep -iE "admin|blocage|bloqué|modération|anti-spam|audit|révoc|validation des commentaires|moins de 24" && echo "⚠️ fuite anti-abus dans CHANGELOG.md — nettoyer + commit direct sur main" || echo "✅ CHANGELOG.md propre"
+```
+
+2. **Corps du GitHub Release** : Release Please le génère en **commits BRUTS** (jamais humanisé) → il liste les commits `admin:` verbatim. **Toujours le remplacer** par la section humanisée et nettoyée du `CHANGELOG.md` :
+
+```bash
+# Extraire la section humanisée nettoyée et la pousser comme notes du release
+sed -n "/## \[X.Y.Z\]/,/^## \[/p" CHANGELOG.md | sed '$d' > /tmp/release-notes.md
+gh release edit the-playground-vX.Y.Z --notes-file /tmp/release-notes.md
+# Vérifier qu'aucun terme sensible ne subsiste
+gh release view the-playground-vX.Y.Z --json body --jq .body | grep -iqE "admin|blocage|modération|anti-spam|audit|révoc" && echo "⚠️ termes sensibles encore présents" || echo "✅ release body propre"
+```
+
+Si une fuite est détectée dans `CHANGELOG.md`, la corriger (édition manuelle de la section, commit direct sur main car `*.md`) **avant** de resynchroniser le corps du release.
+
 ## Règles absolues
 
 - ❌ Ne jamais merger si le CI est rouge
 - ❌ Ne jamais pousser du code (fix, refactoring) sur la branche release-please — seuls les commits vides `ci: trigger CI checks` sont autorisés
 - ❌ Ne jamais sauter l'étape de vérification schema Prisma
 - ❌ Ne jamais créer de tag git manuellement
-- ❌ Ne jamais modifier `CHANGELOG.md` ou `package.json` version manuellement
+- ❌ Ne jamais bumper la version dans `CHANGELOG.md` ou `package.json` manuellement (laisser Release Please) — scrubber la prose d'une section déjà publiée pour retirer une fuite anti-abus reste autorisé (étape 11)
+- ❌ **Ne jamais divulguer l'outillage admin / modération / anti-abus dans le changelog public** (CHANGELOG.md ET corps du GitHub Release) — repo public, voir étape 11
 - ❌ Ne jamais utiliser `gh workflow run` pour redéclencher le CI (ne génère pas de PR checks)
 - ❌ Ne jamais chercher la PR par titre avec `--search` (les parenthèses cassent la recherche GitHub)
 - ✅ Toujours chercher la PR par branche avec `--head "release-please--branches--main--components--the-playground"`

--- a/scripts/humanize-changelog.ts
+++ b/scripts/humanize-changelog.ts
@@ -76,6 +76,15 @@ Orienté bénéfices utilisateur, vocabulaire naturel, pas de jargon technique.
 - Français uniquement
 - Omettre les entrées purement techniques (refactor, ci, chore, tests, infra) invisibles pour l'utilisateur
 
+## Confidentialité — ne JAMAIS divulguer l'outillage anti-abus
+
+Le dépôt et le changelog sont PUBLICS. Tu DOIS **omettre entièrement** toute entrée décrivant de l'outillage interne de modération, de sécurité ou d'anti-abus, car la divulguer aide les spammeurs à contourner les protections. À exclure systématiquement, sans exception :
+- Les outils d'administration / modération (audit de compte, détection de spam, blocage / déblocage de compte ou de domaine, révocation de sessions, badge « bloqué », console de modération des commentaires, file d'attente de validation).
+- Les garde-fous anti-abus visibles côté utilisateur mais qui révèlent la mécanique (ex. restrictions imposées aux comptes récents / de moins de 24h : contact des organisateurs grisé, mise en validation des commentaires).
+- Tout commit de scope `admin:`, et tout `security:` qui relève de la modération / du blocage / de la détection d'abus.
+
+Ces fonctionnalités existent mais restent **invisibles dans le changelog public**. Si, après exclusion, une section (Ajouté / Amélioré / Corrigé) devient vide, ne pas l'inclure. Si toute la version ne contient que de l'anti-abus, ne garder que les éventuelles entrées user-facing neutres et adapter le titre en conséquence.
+
 ## Terminologie obligatoire (FR)
 
 Le code source utilise des termes anglais techniques. Dans le changelog (texte user-facing en français), tu DOIS TOUJOURS utiliser les traductions suivantes :


### PR DESCRIPTION
## Contexte

La 2.16.0 a été publiée avec l'outillage de modération / anti-spam exposé publiquement (dépôt public). Les surfaces déjà corrigées à chaud : `CHANGELOG.md` sur main + corps du GitHub Release. Cette PR corrige la **cause systémique** pour que ça ne se reproduise pas.

## Changements

- **`scripts/humanize-changelog.ts`** : consigne de confidentialité dans le prompt. Le changelog public omet désormais l'outillage admin / modération / anti-abus (audit IA, blocage compte/domaine, révocation de sessions, console de modération, garde-fous <24h). Ces features existent mais restent invisibles publiquement.
- **`.claude/commands/release.md`** : nouvelle **étape 11** — scrub + synchronisation du corps du GitHub Release. Release Please le génère en commits bruts (jamais humanisé) et liste les `admin:` verbatim → il faut toujours le remplacer par la section humanisée nettoyée. Plus 2 règles absolues.

## Pourquoi

Repo public : divulguer le playbook anti-abus aide directement les spammeurs à contourner les protections. Même logique que la commande `/audit-user` local-only.

## Vérif

- Typecheck vert (après régénération du client Prisma local).
- Aucun changement de schema Prisma.

🤖 Generated with [Claude Code](https://claude.com/claude-code)