### PR TITLE
fix(changelog): redéploie la page /changelog quand CHANGELOG.md change

### DIFF
--- a/scripts/vercel-ignore.sh
+++ b/scripts/vercel-ignore.sh
@@ -10,8 +10,10 @@
 #   - Branche `staging` : toujours build
 #   - Branche `main` :
 #       - build si src/content/** a changé (posts blog qui impactent les routes)
-#       - skip si uniquement docs/scripts hors-build ont changé (CHANGELOG.md,
-#         spec/**, memory/**, *.md, .github/**, .gitignore, scripts/**)
+#       - build si CHANGELOG.md a changé (la page /changelog le lit à l'exécution
+#         depuis le filesystem du build → une édition doit redéployer)
+#       - skip si uniquement docs/scripts hors-build ont changé (spec/**,
+#         memory/**, *.md, .github/**, .gitignore, scripts/**)
 #       - build sinon
 #   - Autres branches : skip (les preview builds sont désactivés sauf staging)
 # ─────────────────────────────────────────────
@@ -30,8 +32,14 @@ if git diff --name-only HEAD~1 -- 'src/content/**' | grep -q .; then
   exit 1
 fi
 
+# La page /changelog rend CHANGELOG.md lu à l'exécution depuis le filesystem du
+# build : toute édition du changelog (release ou correction hors-bande) doit
+# déclencher un redéploiement, sinon la prod sert l'ancien fichier.
+if ! git diff --quiet HEAD~1 -- CHANGELOG.md; then
+  exit 1
+fi
+
 git diff --quiet HEAD~1 -- \
-  ':!CHANGELOG.md' \
   ':!spec/**' \
   ':!memory/**' \
   ':!*.md' \

--- a/src/app/[locale]/(routes)/(static)/changelog/page.tsx
+++ b/src/app/[locale]/(routes)/(static)/changelog/page.tsx
@@ -3,6 +3,9 @@ import { getLocale } from "next-intl/server";
 import { getChangelog } from "@/lib/parse-changelog";
 import { buildAlternates } from "@/lib/seo";
 
+// `getChangelog` lit CHANGELOG.md à l'exécution depuis le filesystem du build :
+// le contenu est figé au build, donc toute édition du changelog nécessite un
+// redéploiement (cf. le trigger CHANGELOG.md dans scripts/vercel-ignore.sh).
 export const dynamic = "force-dynamic";
 
 export async function generateMetadata(): Promise<Metadata> {


### PR DESCRIPTION
## Problème

La page `/changelog` lit `CHANGELOG.md` à l'exécution depuis le filesystem du build. L'`ignoreCommand` Vercel (`scripts/vercel-ignore.sh`) skippe les changements `CHANGELOG.md`-only sur main → une correction du changelog ne part jamais en prod. Conséquence : la section 2.16.0 nettoyée de son outillage anti-abus n'a pas été déployée, la prod sert encore la version avec la fuite.

## Fix

- **`scripts/vercel-ignore.sh`** : `CHANGELOG.md` déclenche désormais un build (comme `src/content/**`). Plus aucune édition de changelog ne reste bloquée.
- **`changelog/page.tsx`** : commentaire documentant le read runtime. Touche `src/` → le merge déclenche le build qui redéploie le `CHANGELOG.md` déjà nettoyé sur main.

## Effet

Le merge de cette PR déclenche un build prod → la page `/changelog` sert la 2.16.0 nettoyée. Aucun changement de schema Prisma.

🤖 Generated with [Claude Code](https://claude.com/claude-code)