### PR TITLE
fix(og): pose Content-Length pour réparer les aperçus de lien sur Slack

### DIFF
--- a/src/lib/og/__tests__/render.test.ts
+++ b/src/lib/og/__tests__/render.test.ts
@@ -45,6 +45,10 @@ describe("renderOgImage", () => {
 
       expect(res.headers.get("content-type")).toBe("image/jpeg");
       expect(res.headers.get("cache-control")).toContain("stale-while-revalidate");
+      // Content-Length explicite : requis par le proxy d'image de Slack.
+      const len = Number(res.headers.get("content-length"));
+      const body = new Uint8Array(await res.arrayBuffer());
+      expect(len).toBe(body.byteLength);
     });
 
     it("produit un corps réellement encodé en JPEG (magic bytes FF D8 FF)", async () => {

--- a/src/lib/og/render.ts
+++ b/src/lib/og/render.ts
@@ -23,6 +23,11 @@ const CACHE_CONTROL = "public, max-age=3600, stale-while-revalidate=86400";
  * Si le re-encodage échoue, on sert le PNG brut plutôt qu'un aperçu vide :
  * une image lourde reste préférable à pas d'image du tout.
  *
+ * On pose explicitement `Content-Length` : sans lui, Vercel sert la réponse en
+ * chunked et le proxy d'image de Slack (Slack-ImgProxy) refuse l'image (aperçu
+ * vide), là où WhatsApp et un fetch direct s'en passent. next/og le posait
+ * nativement ; notre Response custom doit le restaurer.
+ *
  * Toute route opengraph-image doit exporter `contentType = "image/jpeg"`.
  */
 export async function renderOgImage(
@@ -41,6 +46,7 @@ export async function renderOgImage(
     return new Response(new Uint8Array(jpeg), {
       headers: {
         "content-type": "image/jpeg",
+        "content-length": String(jpeg.byteLength),
         "cache-control": CACHE_CONTROL,
       },
     });
@@ -48,6 +54,7 @@ export async function renderOgImage(
     return new Response(new Uint8Array(pngBuffer), {
       headers: {
         "content-type": "image/png",
+        "content-length": String(pngBuffer.byteLength),
         "cache-control": CACHE_CONTROL,
       },
     });


### PR DESCRIPTION
## Problème

Après la PR #584 (passage des images OG en JPEG, qui a réglé WhatsApp), **Slack n'affichait toujours pas l'image** sur les pages event — y compris pour des liens jamais partagés (donc hors cache) et sur plusieurs espaces Slack.

## Cause

Le helper `renderOgImage` renvoie une `Response` custom, que Vercel sert en **chunked, sans `Content-Length`**. Le **proxy d'image de Slack** (`Slack-ImgProxy`) refuse une image sans `Content-Length` et n'affiche aucun aperçu, là où WhatsApp et les fetch directs (simulateurs de preview) s'en passent.

Preuve par élimination :
- `icon.tsx` (un `ImageResponse` next/og **non modifié**) → **a un `Content-Length`**.
- Notre `og:image` (Response custom) → **aucun `Content-Length`**.
- Le simulateur d'unfurl Slack + WhatsApp affichent bien l'image (fetch direct) ; seul le proxy Slack échoue.

C'est une **régression introduite par #584** : `next/og` posait ce header nativement, notre wrapper l'a fait sauter.

## Correction

Pose explicite de `Content-Length` (chemin JPEG **et** fallback PNG). Vérifié en local : header présent, fin du chunked.

## Les deux couches du bug

1. **Poids** (PNG 0,5-3,9 Mo > limite WhatsApp) → réglé par #584.
2. **`Content-Length` manquant** (régression de #584) → cette PR, débloque Slack.

## Tests & vérifs

- Test unitaire étendu : assertion que `Content-Length` = taille réelle du corps.
- `typecheck` ✓, `/code-review` high ✓ (aucun finding).
- Pas de changement de schema Prisma.

🤖 Generated with [Claude Code](https://claude.com/claude-code)