### PR TITLE
fix(og): retire Content-Length pour réparer l'aperçu Slack (Range tronqué)

### DIFF
--- a/src/lib/og/__tests__/render.test.ts
+++ b/src/lib/og/__tests__/render.test.ts
@@ -45,10 +45,9 @@ describe("renderOgImage", () => {
 
       expect(res.headers.get("content-type")).toBe("image/jpeg");
       expect(res.headers.get("cache-control")).toContain("stale-while-revalidate");
-      // Content-Length explicite : requis par le proxy d'image de Slack.
-      const len = Number(res.headers.get("content-length"));
-      const body = new Uint8Array(await res.arrayBuffer());
-      expect(len).toBe(body.byteLength);
+      // Garde anti-régression : surtout PAS de Content-Length, sinon le CDN
+      // Vercel tronque la réponse aux 32 Ko du Range de Slack (cf. render.ts).
+      expect(res.headers.get("content-length")).toBeNull();
     });
 
     it("produit un corps réellement encodé en JPEG (magic bytes FF D8 FF)", async () => {

--- a/src/lib/og/render.ts
+++ b/src/lib/og/render.ts
@@ -23,10 +23,14 @@ const CACHE_CONTROL = "public, max-age=3600, stale-while-revalidate=86400";
  * Si le re-encodage échoue, on sert le PNG brut plutôt qu'un aperçu vide :
  * une image lourde reste préférable à pas d'image du tout.
  *
- * On pose explicitement `Content-Length` : sans lui, Vercel sert la réponse en
- * chunked et le proxy d'image de Slack (Slack-ImgProxy) refuse l'image (aperçu
- * vide), là où WhatsApp et un fetch direct s'en passent. next/og le posait
- * nativement ; notre Response custom doit le restaurer.
+ * NE PAS poser de `Content-Length`. Le proxy d'image de Slack récupère l'image
+ * avec `Range: bytes=0-32768` (32 Ko, le plus strict des crawlers). Si la
+ * réponse porte un Content-Length, le CDN Vercel honore le Range et renvoie un
+ * `200` (et non un `206`) tronqué aux 32 premiers Ko : Slack croit tenir
+ * l'image entière mais n'en a qu'un tiers → aperçu vide pour toute image
+ * > 32 Ko (typiquement dès qu'il y a une cover). Sans Content-Length, le CDN ne
+ * peut pas tronquer et sert le corps complet en 200, que Slack consomme bien
+ * (comme WhatsApp et les fetch directs).
  *
  * Toute route opengraph-image doit exporter `contentType = "image/jpeg"`.
  */
@@ -46,7 +50,6 @@ export async function renderOgImage(
     return new Response(new Uint8Array(jpeg), {
       headers: {
         "content-type": "image/jpeg",
-        "content-length": String(jpeg.byteLength),
         "cache-control": CACHE_CONTROL,
       },
     });
@@ -54,7 +57,6 @@ export async function renderOgImage(
     return new Response(new Uint8Array(pngBuffer), {
       headers: {
         "content-type": "image/png",
-        "content-length": String(pngBuffer.byteLength),
         "cache-control": CACHE_CONTROL,
       },
     });


### PR DESCRIPTION
## Cause (confirmée)

Le proxy d'image de Slack récupère l'`og:image` avec `Range: bytes=0-32768` — il ne demande que les **32 premiers Ko** (Slack est le plus strict : FB 512 Ko, Twitter ~1 Mo, LinkedIn 3 Mo).

Avec un `Content-Length` sur la réponse (introduit par #585), le CDN Vercel honore le Range et renvoie un **`200` tronqué** (et non un `206`) aux 32 premiers Ko :

```
Range: bytes=0-32768  →  200 OK + content-range: 0-32768/98838 + 33 Ko sur 99
```

Slack croit tenir l'image entière mais n'en a qu'un tiers → **aperçu vide** dès que l'image dépasse 32 Ko (toute page avec cover). Les images < 32 Ko (gradients sans cover) passaient → faux constat initial « communauté marche, event non ».

WhatsApp et les simulateurs d'unfurl n'envoient **pas** de Range → reçoivent l'image entière → l'affichent.

## Correction

Retrait du `Content-Length` (fausse piste de #585). Sans lui, le CDN ne peut pas tronquer et sert le **corps complet en 200**, que Slack consomme correctement. Commentaire explicite dans `render.ts` pour ne pas le réintroduire, + test inversé en garde anti-régression.

## Validation

- `typecheck` ✓, tests ✓.
- **À valider sur la preview Vercel** (curl Range → corps complet attendu) avant merge prod.
- Pas de changement de schema Prisma.

🤖 Generated with [Claude Code](https://claude.com/claude-code)