### PR TITLE
feat(quota): dédup des alertes quota Resend + palier 100

### DIFF
--- a/src/app/api/cron/check-resend-quota/route.ts
+++ b/src/app/api/cron/check-resend-quota/route.ts
@@ -95,16 +95,21 @@ async function handler(request: NextRequest) {
   if (tier) {
     const state = await readQuotaAlertState();
     if (shouldNotifyQuota(tier, todayUtc, state)) {
-      await notifySlackQuotaWarning(used, tier);
-      notified = true;
-      // Persiste le palier notifié pour ne pas re-pinger au prochain passage.
-      // Échec d'écriture => fail-open : on re-notifiera l'heure suivante (mieux
-      // qu'une alerte perdue), mais on le signale pour ne pas spammer en silence.
-      if ((await writeQuotaAlertState({ date: todayUtc, tier })) === "failed") {
-        Sentry.captureMessage(
-          `[cron] check-resend-quota: échec persistance état dédup (tier=${tier})`,
-          "warning"
-        );
+      // On ne persiste le palier que si l'alerte a été RÉELLEMENT délivrée :
+      // sinon (timeout / non-2xx / webhook absent) on laisse l'état intact pour
+      // re-tenter au prochain passage, plutôt que de figer un palier comme
+      // notifié et perdre définitivement l'alerte du jour (surtout le 100 =
+      // envois bloqués).
+      notified = await notifySlackQuotaWarning(used, tier);
+      if (notified) {
+        // Échec d'écriture => fail-open : on re-notifiera l'heure suivante (mieux
+        // qu'une alerte perdue), mais on le signale pour ne pas spammer en silence.
+        if ((await writeQuotaAlertState({ date: todayUtc, tier })) === "failed") {
+          Sentry.captureMessage(
+            `[cron] check-resend-quota: échec persistance état dédup (tier=${tier})`,
+            "warning"
+          );
+        }
       }
     }
   }

--- a/src/app/api/cron/check-resend-quota/route.ts
+++ b/src/app/api/cron/check-resend-quota/route.ts
@@ -1,13 +1,17 @@
 import * as Sentry from "@sentry/nextjs";
 import { NextRequest, NextResponse } from "next/server";
 import { notifySlackQuotaWarning } from "@/infrastructure/services/slack/slack-notification-service";
-import { countSentToday, quotaTier } from "@/lib/resend-quota";
+import {
+  readQuotaAlertState,
+  writeQuotaAlertState,
+} from "@/infrastructure/services/edge-config/resend-quota-state";
+import { countSentToday, quotaTier, shouldNotifyQuota } from "@/lib/resend-quota";
 
 /**
  * GET /api/cron/check-resend-quota
  *
  * Surveille le quota d'envoi quotidien Resend (plan gratuit : 100 emails/jour)
- * et alerte sur Slack dès qu'un palier (70 puis 90) est dépassé.
+ * et alerte sur Slack dès qu'un palier (70, 90 puis 100) est franchi.
  *
  * Lecture du compteur : on COMPTE les emails du jour via `GET /emails`, pas via
  * le header `x-resend-daily-quota` (qui n'est renvoyé que sur l'envoi, jamais en
@@ -15,9 +19,10 @@ import { countSentToday, quotaTier } from "@/lib/resend-quota";
  * au plus ancien, une seule page de 100 contient toujours tous les envois du jour.
  * Avantage : couvre TOUS les chemins d'envoi (magic links, transactionnel, batch).
  *
- * Sans persistance : ré-alerte à chaque passage tant qu'on reste au-dessus du
- * seuil (cadence basse côté Vercel Cron, cf. vercel.json). Le nombre envoyé dans
- * l'alerte est le compteur réel au moment de la notif.
+ * Dédup via Edge Config : on persiste le dernier palier notifié du jour
+ * (`resendQuotaAlert`) et on ne re-notifie qu'au FRANCHISSEMENT d'un palier
+ * supérieur (cf. `shouldNotifyQuota`). Reset implicite à minuit UTC par
+ * comparaison de date. Le nombre envoyé dans l'alerte est le compteur réel.
  *
  * Vercel Cron invoque en GET ; on expose aussi POST pour un déclenchement manuel.
  * Protection : header Authorization: Bearer CRON_SECRET (ajouté par Vercel).
@@ -86,10 +91,28 @@ async function handler(request: NextRequest) {
   }
 
   const tier = quotaTier(used);
-  if (tier) await notifySlackQuotaWarning(used, tier);
+  let notified = false;
+  if (tier) {
+    const state = await readQuotaAlertState();
+    if (shouldNotifyQuota(tier, todayUtc, state)) {
+      await notifySlackQuotaWarning(used, tier);
+      notified = true;
+      // Persiste le palier notifié pour ne pas re-pinger au prochain passage.
+      // Échec d'écriture => fail-open : on re-notifiera l'heure suivante (mieux
+      // qu'une alerte perdue), mais on le signale pour ne pas spammer en silence.
+      if ((await writeQuotaAlertState({ date: todayUtc, tier })) === "failed") {
+        Sentry.captureMessage(
+          `[cron] check-resend-quota: échec persistance état dédup (tier=${tier})`,
+          "warning"
+        );
+      }
+    }
+  }
 
-  console.log(`[check-resend-quota] used=${used}, tier=${tier ?? "none"}`);
-  return NextResponse.json({ ok: true, used, tier });
+  console.log(
+    `[check-resend-quota] used=${used}, tier=${tier ?? "none"}, notified=${notified}`
+  );
+  return NextResponse.json({ ok: true, used, tier, notified });
 }
 
 export async function GET(request: NextRequest) {

--- a/src/infrastructure/services/edge-config/edge-config-client.ts
+++ b/src/infrastructure/services/edge-config/edge-config-client.ts
@@ -1,0 +1,70 @@
+/**
+ * Client d'écriture/lecture Edge Config via l'API REST Vercel.
+ *
+ * Le SDK `@vercel/edge-config` ne sait que LIRE (et sert un snapshot répliqué,
+ * éventuellement consistant). Pour écrire, et pour relire la source de vérité
+ * sans lag de propagation (indispensable à une dédup read-after-write), on passe
+ * par l'API REST. Même mécanique que `audit/blocklist-admin.ts` et les scripts
+ * `maintenance-toggle.ts` / `blocklist-edit.ts`.
+ *
+ * Écriture **production uniquement** (guard symétrique avec sendSlack /
+ * safe-resend) : l'Edge Config est unique et partagé, on ne l'édite pas depuis
+ * local/preview/staging pour ne pas polluer l'état prod.
+ */
+const DEFAULT_EDGE_CONFIG_ID = "ecfg_290ik5kuib6seqd7pz7hkoibuhaf";
+const edgeConfigId = process.env.EDGE_CONFIG_ID ?? DEFAULT_EDGE_CONFIG_ID;
+const teamQuery = process.env.VERCEL_TEAM_ID
+  ? `?teamId=${process.env.VERCEL_TEAM_ID}`
+  : "";
+const base = `https://api.vercel.com/v1/edge-config/${edgeConfigId}`;
+
+/**
+ * Lit un item Edge Config (valeur fraîche via l'API REST). Renvoie `undefined`
+ * si la clé est absente, le token manquant, ou en cas d'erreur — fail-soft :
+ * l'appelant traite l'absence d'état comme « rien de connu ».
+ */
+export async function getEdgeConfigItem<T>(key: string): Promise<T | undefined> {
+  const token = process.env.VERCEL_TOKEN;
+  if (!token) return undefined;
+  try {
+    const res = await fetch(`${base}/item/${key}${teamQuery}`, {
+      headers: { Authorization: `Bearer ${token}` },
+      cache: "no-store",
+    });
+    if (!res.ok) return undefined; // 404 (clé absente) inclus
+    return ((await res.json()) as { value?: T }).value;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Résultat d'une écriture Edge Config :
+ * - `applied` : upsert écrit en prod.
+ * - `skipped` : hors production, écriture volontairement ignorée.
+ * - `failed`  : token manquant ou erreur d'écriture.
+ */
+export type EdgeConfigWriteResult = "applied" | "skipped" | "failed";
+
+/** Upsert idempotent d'un item Edge Config. Écriture prod uniquement. */
+export async function upsertEdgeConfigItem(
+  key: string,
+  value: unknown
+): Promise<EdgeConfigWriteResult> {
+  if (process.env.VERCEL_ENV !== "production") return "skipped";
+  const token = process.env.VERCEL_TOKEN;
+  if (!token) return "failed";
+  try {
+    const res = await fetch(`${base}/items${teamQuery}`, {
+      method: "PATCH",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ items: [{ operation: "upsert", key, value }] }),
+    });
+    return res.ok ? "applied" : "failed";
+  } catch {
+    return "failed";
+  }
+}

--- a/src/infrastructure/services/edge-config/resend-quota-state.ts
+++ b/src/infrastructure/services/edge-config/resend-quota-state.ts
@@ -1,0 +1,23 @@
+import type { QuotaAlertState } from "@/lib/resend-quota";
+import {
+  getEdgeConfigItem,
+  upsertEdgeConfigItem,
+  type EdgeConfigWriteResult,
+} from "./edge-config-client";
+
+/**
+ * État du dernier palier de quota Resend notifié, persisté dans Edge Config pour
+ * dédupliquer les alertes : on ne notifie qu'au franchissement d'un nouveau
+ * palier (cf. `shouldNotifyQuota`). Reset implicite par comparaison de date UTC.
+ */
+const RESEND_QUOTA_ALERT_KEY = "resendQuotaAlert";
+
+export function readQuotaAlertState(): Promise<QuotaAlertState | undefined> {
+  return getEdgeConfigItem<QuotaAlertState>(RESEND_QUOTA_ALERT_KEY);
+}
+
+export function writeQuotaAlertState(
+  state: QuotaAlertState
+): Promise<EdgeConfigWriteResult> {
+  return upsertEdgeConfigItem(RESEND_QUOTA_ALERT_KEY, state);
+}

--- a/src/infrastructure/services/slack/slack-notification-service.ts
+++ b/src/infrastructure/services/slack/slack-notification-service.ts
@@ -236,13 +236,21 @@ export async function notifySlackCommentPending(params: {
 
 export async function notifySlackQuotaWarning(
   used: number,
-  tier: number,
+  tier: 70 | 90 | 100,
 ): Promise<void> {
+  // 100 = plafond atteint (envois bloqués), pas un simple seuil franchi.
+  const reached = tier === 100;
+  const icon = reached ? "🚨" : "⚠️";
+  const headline = reached
+    ? `*${used}/100* emails envoyés aujourd'hui (plan gratuit).\n*Quota du jour atteint* : les nouveaux envois sont bloqués jusqu'à demain (minuit UTC).`
+    : `*${used}/100* emails envoyés aujourd'hui (plan gratuit).\nSeuil de *${tier}* dépassé.`;
   await sendSlack({
-    text: `⚠️ Quota Resend à ${used}/100 aujourd'hui (seuil ${tier} dépassé)`,
+    text: reached
+      ? `🚨 Quota Resend atteint : ${used}/100 aujourd'hui (envois bloqués)`
+      : `⚠️ Quota Resend à ${used}/100 aujourd'hui (seuil ${tier} dépassé)`,
     blocks: [
-      { type: "header", text: { type: "plain_text", text: "⚠️ Quota emails Resend", emoji: true } },
-      { type: "section", text: { type: "mrkdwn", text: `*${used}/100* emails envoyés aujourd'hui (plan gratuit).\nSeuil de *${tier}* dépassé.` } },
+      { type: "header", text: { type: "plain_text", text: `${icon} Quota emails Resend`, emoji: true } },
+      { type: "section", text: { type: "mrkdwn", text: headline } },
       { type: "context", elements: [{ type: "mrkdwn", text: "Au-delà de 100/jour, les envois sont bloqués jusqu'au lendemain. Pense à passer sur un plan payant." }] },
     ],
   });

--- a/src/infrastructure/services/slack/slack-notification-service.ts
+++ b/src/infrastructure/services/slack/slack-notification-service.ts
@@ -1,5 +1,6 @@
 import { URGENCY_META, USER_IMPACT_META, type AnalysisResult } from "../sentry/analysis-meta";
 import type { AuditReport, AuditVerdictLean } from "../audit/types";
+import type { QuotaTier } from "@/lib/resend-quota";
 
 const ADMIN_WEBHOOK_URL = process.env.SLACK_ADMIN_WEBHOOK_URL;
 // Canal dédié aux erreurs Sentry (#sentry). Si non configuré, les notifs Sentry
@@ -18,28 +19,38 @@ type SlackBlock =
   | { type: "context"; elements: { type: "mrkdwn"; text: string }[] }
   | { type: "actions"; elements: { type: "button"; text: { type: "plain_text"; text: string }; url: string; style?: "primary" | "danger" }[] };
 
+/**
+ * Renvoie `true` uniquement si le message a été RÉELLEMENT délivré (webhook
+ * configuré, prod, réponse 2xx). `false` couvre webhook absent, garde non-prod,
+ * timeout, et réponse non-2xx (un fetch ne throw PAS sur 4xx/5xx — d'où le
+ * `res.ok` explicite). La plupart des appelants ignorent ce retour (Slack =
+ * best-effort), mais un appelant qui persiste un état « notifié » doit pouvoir
+ * distinguer délivré d'avalé en silence (cf. dédup quota Resend).
+ */
 async function sendSlack(
   payload: { text: string; blocks?: SlackBlock[] },
   webhookUrl: string | undefined = ADMIN_WEBHOOK_URL,
-): Promise<void> {
-  if (!webhookUrl) return;
+): Promise<boolean> {
+  if (!webhookUrl) return false;
 
   // Guard symétrique avec safe-resend : seul VERCEL_ENV=production laisse
   // passer. Tout le reste (preview, staging, local, CI) bloque — fail-closed.
   if (process.env.VERCEL_ENV !== "production") {
     console.warn("[staging-guard] Blocked Slack notification:", payload.text);
-    return;
+    return false;
   }
 
   try {
-    await fetch(webhookUrl, {
+    const res = await fetch(webhookUrl, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(payload),
       signal: AbortSignal.timeout(5000),
     });
+    return res.ok;
   } catch {
-    // Silent failure — Slack is best-effort, never block the main flow
+    // Échec réseau/timeout — Slack est best-effort, on ne bloque jamais le flux.
+    return false;
   }
 }
 
@@ -234,17 +245,20 @@ export async function notifySlackCommentPending(params: {
   });
 }
 
+// Renvoie `true` si l'alerte a été délivrée à Slack — l'appelant (cron quota)
+// ne persiste l'état dédup que dans ce cas, pour ne pas figer un palier comme
+// notifié alors que le message a été avalé (timeout / non-2xx / webhook absent).
 export async function notifySlackQuotaWarning(
   used: number,
-  tier: 70 | 90 | 100,
-): Promise<void> {
+  tier: QuotaTier,
+): Promise<boolean> {
   // 100 = plafond atteint (envois bloqués), pas un simple seuil franchi.
   const reached = tier === 100;
   const icon = reached ? "🚨" : "⚠️";
   const headline = reached
     ? `*${used}/100* emails envoyés aujourd'hui (plan gratuit).\n*Quota du jour atteint* : les nouveaux envois sont bloqués jusqu'à demain (minuit UTC).`
     : `*${used}/100* emails envoyés aujourd'hui (plan gratuit).\nSeuil de *${tier}* dépassé.`;
-  await sendSlack({
+  return sendSlack({
     text: reached
       ? `🚨 Quota Resend atteint : ${used}/100 aujourd'hui (envois bloqués)`
       : `⚠️ Quota Resend à ${used}/100 aujourd'hui (seuil ${tier} dépassé)`,

--- a/src/lib/__tests__/resend-quota.test.ts
+++ b/src/lib/__tests__/resend-quota.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { countSentToday, quotaTier } from "@/lib/resend-quota";
+import {
+  countSentToday,
+  quotaTier,
+  shouldNotifyQuota,
+  type QuotaAlertState,
+  type QuotaTier,
+} from "@/lib/resend-quota";
 
 describe("countSentToday", () => {
   const today = "2026-06-03";
@@ -26,8 +32,37 @@ describe("quotaTier", () => {
     [70, 70],
     [89, 70],
     [90, 90],
-    [100, 90],
+    [99, 90],
+    [100, 100],
+    [120, 100],
   ])("used=%i → palier %s", (used, expected) => {
-    expect(quotaTier(used as number)).toBe(expected as 70 | 90 | null);
+    expect(quotaTier(used as number)).toBe(expected as QuotaTier | null);
+  });
+});
+
+describe("shouldNotifyQuota", () => {
+  const today = "2026-06-24";
+
+  it("notifie au premier franchissement du jour (aucun état)", () => {
+    expect(shouldNotifyQuota(70, today, undefined)).toBe(true);
+  });
+
+  it("ne re-notifie pas un palier déjà notifié aujourd'hui", () => {
+    const state: QuotaAlertState = { date: today, tier: 70 };
+    expect(shouldNotifyQuota(70, today, state)).toBe(false);
+  });
+
+  it("notifie la montée vers un palier supérieur (70 → 90 → 100)", () => {
+    expect(shouldNotifyQuota(90, today, { date: today, tier: 70 })).toBe(true);
+    expect(shouldNotifyQuota(100, today, { date: today, tier: 90 })).toBe(true);
+  });
+
+  it("ne notifie pas un palier inférieur déjà couvert (jamais le cas en pratique)", () => {
+    expect(shouldNotifyQuota(70, today, { date: today, tier: 90 })).toBe(false);
+  });
+
+  it("re-notifie un nouveau jour UTC, même palier (reset implicite à minuit)", () => {
+    const veille: QuotaAlertState = { date: "2026-06-23", tier: 100 };
+    expect(shouldNotifyQuota(70, today, veille)).toBe(true);
   });
 });

--- a/src/lib/resend-quota.ts
+++ b/src/lib/resend-quota.ts
@@ -15,9 +15,33 @@ export function countSentToday(
     .length;
 }
 
-/** Palier de quota dépassé (90 prioritaire sur 70), ou null sous le seuil. */
-export function quotaTier(used: number): 70 | 90 | null {
+export type QuotaTier = 70 | 90 | 100;
+
+/**
+ * Palier de quota atteint (100 prioritaire sur 90 prioritaire sur 70), ou null
+ * sous le premier seuil. 100 = plafond du plan gratuit (envois bloqués au-delà).
+ */
+export function quotaTier(used: number): QuotaTier | null {
+  if (used >= 100) return 100;
   if (used >= 90) return 90;
   if (used >= 70) return 70;
   return null;
+}
+
+/** État du dernier palier notifié, persisté par jour UTC (Edge Config). */
+export type QuotaAlertState = { date: string; tier: QuotaTier };
+
+/**
+ * Décide s'il faut notifier le palier courant. On ne notifie qu'au FRANCHISSEMENT
+ * d'un palier strictement supérieur à celui déjà notifié le même jour UTC. Un état
+ * daté d'un autre jour (ou absent) compte comme « rien notifié aujourd'hui » →
+ * reset implicite à minuit UTC, sans persistance à purger.
+ */
+export function shouldNotifyQuota(
+  tier: QuotaTier,
+  todayUtc: string,
+  state: QuotaAlertState | undefined
+): boolean {
+  const notifiedToday = state?.date === todayUtc ? state.tier : 0;
+  return tier > notifiedToday;
 }


### PR DESCRIPTION
## Contexte

Le cron horaire \`check-resend-quota\` ré-alertait sur Slack **à chaque passage** tant qu'un seuil restait dépassé (jusqu'à ~11 pings/jour pour le même incident), faute de persistance. Cette PR ajoute une dédup et un troisième palier.

## Ce que ça fait

- **Trois paliers** : 70, 90 et **100** (plafond du plan gratuit = envois bloqués), avec un wording Slack dédié pour le 100 (« quota atteint » vs « seuil dépassé »).
- **Dédup via Edge Config** : l'état du dernier palier notifié du jour (\`resendQuotaAlert\`) est persisté ; on ne re-notifie qu'au **franchissement d'un palier supérieur**. Reset implicite à minuit UTC par comparaison de date, rien à purger.
- Décision de notification isolée dans une fonction **pure et testée** (\`shouldNotifyQuota\`).

## Robustesse (suite code-review)

- \`sendSlack\` vérifie désormais \`res.ok\` et renvoie un **booléen de livraison** (un \`fetch\` ne throw pas sur 4xx/5xx).
- La route **ne persiste l'état dédup que si l'alerte a été réellement délivrée** : un hoquet Slack au franchissement du 100 ne fige plus le palier comme notifié (sinon l'alerte critique « envois bloqués » était perdue pour la journée). En cas d'échec → re-tentative au passage suivant.

## Notes

- Écriture Edge Config via l'API REST Vercel (dépend de \`VERCEL_TOKEN\`, déjà présent en prod pour la blocklist). Guard prod ; la clé se crée au premier upsert.
- Pas de changement de schema Prisma.
- Le scaffolding REST Edge Config est volontairement **dupliqué** avec \`blocklist-admin.ts\` (choix assumé pour ne pas toucher au code sécu de la blocklist dans cette PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)