### PR TITLE
feat(circle): événements annulés futurs dans l'agenda à venir + historique antichronologique

### DIFF
--- a/src/app/[locale]/(routes)/circles/[slug]/page.tsx
+++ b/src/app/[locale]/(routes)/circles/[slug]/page.tsx
@@ -26,6 +26,7 @@ import { Button } from "@/components/ui/button";
 import { getMomentGradient } from "@/lib/gradient";
 import { formatLongDate } from "@/lib/format-date";
 import { collapseWhitespace } from "@/lib/text";
+import { isUpcomingCancelled, isPastMoment, byStartsAtDesc } from "@/lib/moment-timeline";
 import { buildAlternates } from "@/lib/seo";
 import { getAppUrl } from "@/lib/app-url";
 import { JoinCircleButton } from "@/components/circles/join-circle-button";
@@ -192,11 +193,14 @@ export default async function PublicCirclePage({
   const showSignInToJoin = !isConnected;
   const showMemberBadge = isMember && !isOrganizer;
 
-  const upcomingMoments = allMoments.filter((m) => m.status === "PUBLISHED");
+  // Un événement annulé encore daté dans le futur reste dans « prochains »
+  // (affiché barré), les autres annulés rejoignent l'historique « passés ».
+  const now = Date.now();
+  const upcomingMoments = allMoments.filter(
+    (m) => m.status === "PUBLISHED" || isUpcomingCancelled(m, now)
+  );
   // Historique en antichronologique : le plus récent d'abord (les upcoming restent chronologiques).
-  const pastMoments = allMoments
-    .filter((m) => m.status === "PAST" || m.status === "CANCELLED")
-    .sort((a, b) => b.startsAt.getTime() - a.startsAt.getTime());
+  const pastMoments = allMoments.filter((m) => isPastMoment(m, now)).sort(byStartsAtDesc);
   // Fetch registration counts + top attendees (avatars) pour TOUS les moments (upcoming + past)
   const allMomentIds = allMoments.map((m) => m.id);
   const [countByMomentId, topAttendeesByMomentId, circleNetworks, membersFirstPage] = await Promise.all([

--- a/src/app/[locale]/(routes)/circles/[slug]/page.tsx
+++ b/src/app/[locale]/(routes)/circles/[slug]/page.tsx
@@ -193,9 +193,10 @@ export default async function PublicCirclePage({
   const showMemberBadge = isMember && !isOrganizer;
 
   const upcomingMoments = allMoments.filter((m) => m.status === "PUBLISHED");
-  const pastMoments = allMoments.filter(
-    (m) => m.status === "PAST" || m.status === "CANCELLED"
-  );
+  // Historique en antichronologique : le plus récent d'abord (les upcoming restent chronologiques).
+  const pastMoments = allMoments
+    .filter((m) => m.status === "PAST" || m.status === "CANCELLED")
+    .sort((a, b) => b.startsAt.getTime() - a.startsAt.getTime());
   // Fetch registration counts + top attendees (avatars) pour TOUS les moments (upcoming + past)
   const allMomentIds = allMoments.map((m) => m.id);
   const [countByMomentId, topAttendeesByMomentId, circleNetworks, membersFirstPage] = await Promise.all([

--- a/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/page.tsx
+++ b/src/app/[locale]/(routes)/dashboard/(app)/(main)/circles/[slug]/page.tsx
@@ -48,6 +48,7 @@ import {
   Tag,
 } from "lucide-react";
 import { resolveCategoryLabel } from "@/lib/circle-category-helpers";
+import { isUpcomingCancelled, isPastMoment, byStartsAtDesc } from "@/lib/moment-timeline";
 import { computeMembersMeta, sortCircleOrganizers } from "@/lib/circle-helpers";
 import { MemberAvatarStack } from "@/components/circles/member-avatar-stack";
 import { CircleOrganizersList } from "@/components/circles/circle-organizers-list";
@@ -133,8 +134,14 @@ export default async function CircleDetailPage({
   const anonymousFallback = tCommon("anonymousFallback");
   const { visibleAvatars: visibleMemberAvatars, metaText: membersMetaText, metaMobileText: membersMetaMobileText } =
     computeMembersMeta(hosts, players, totalMembers, t, anonymousFallback);
-  const upcomingMoments = allMoments.filter((m) => m.status === "PUBLISHED" || (m.status === "DRAFT" && isOrganizer));
-  const pastMoments = allMoments.filter((m) => m.status === "PAST" || m.status === "CANCELLED");
+  // Un événement annulé encore daté dans le futur reste dans « prochains »
+  // (affiché barré), les autres annulés rejoignent l'historique « passés »,
+  // trié en antichronologique (le plus récent d'abord).
+  const now = Date.now();
+  const upcomingMoments = allMoments.filter(
+    (m) => m.status === "PUBLISHED" || (m.status === "DRAFT" && isOrganizer) || isUpcomingCancelled(m, now)
+  );
+  const pastMoments = allMoments.filter((m) => isPastMoment(m, now)).sort(byStartsAtDesc);
 
   // Récupère compteurs + inscriptions utilisateur + top inscrits (avatars) pour TOUS les moments
   const allMomentIds = allMoments.map((m) => m.id);

--- a/src/lib/__tests__/moment-timeline.test.ts
+++ b/src/lib/__tests__/moment-timeline.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { isUpcomingCancelled, isPastMoment, byStartsAtDesc } from "@/lib/moment-timeline";
+
+const NOW = new Date("2026-06-25T12:00:00Z").getTime();
+const future = new Date("2026-07-23T20:00:00Z");
+const past = new Date("2026-05-01T20:00:00Z");
+
+describe("moment-timeline", () => {
+  describe("isUpcomingCancelled", () => {
+    it("given a CANCELLED moment dated in the future, should be treated as upcoming", () => {
+      expect(isUpcomingCancelled({ status: "CANCELLED", startsAt: future }, NOW)).toBe(true);
+    });
+
+    it("given a CANCELLED moment dated in the past, should not be upcoming", () => {
+      expect(isUpcomingCancelled({ status: "CANCELLED", startsAt: past }, NOW)).toBe(false);
+    });
+
+    it.each(["PUBLISHED", "PAST", "DRAFT"])(
+      "given a %s moment, should never be upcoming-cancelled",
+      (status) => {
+        expect(isUpcomingCancelled({ status, startsAt: future }, NOW)).toBe(false);
+      }
+    );
+  });
+
+  describe("isPastMoment", () => {
+    it("given a PAST moment, should belong to history", () => {
+      expect(isPastMoment({ status: "PAST", startsAt: past }, NOW)).toBe(true);
+    });
+
+    it("given a CANCELLED moment dated in the past, should belong to history", () => {
+      expect(isPastMoment({ status: "CANCELLED", startsAt: past }, NOW)).toBe(true);
+    });
+
+    it("given a CANCELLED moment dated in the future, should NOT belong to history", () => {
+      expect(isPastMoment({ status: "CANCELLED", startsAt: future }, NOW)).toBe(false);
+    });
+
+    it.each(["PUBLISHED", "DRAFT"])(
+      "given a %s moment, should not belong to history",
+      (status) => {
+        expect(isPastMoment({ status, startsAt: past }, NOW)).toBe(false);
+      }
+    );
+  });
+
+  describe("byStartsAtDesc", () => {
+    it("should order the most recent first", () => {
+      const a = { startsAt: new Date("2026-01-01") };
+      const b = { startsAt: new Date("2026-03-01") };
+      const c = { startsAt: new Date("2026-02-01") };
+      expect([a, b, c].sort(byStartsAtDesc)).toEqual([b, c, a]);
+    });
+  });
+});

--- a/src/lib/moment-timeline.ts
+++ b/src/lib/moment-timeline.ts
@@ -1,0 +1,31 @@
+/**
+ * Helpers de catégorisation et de tri des événements (Moments) dans les
+ * timelines des pages Circle (publique et dashboard).
+ *
+ * Règle métier : un événement annulé (CANCELLED) reste rattaché à l'agenda
+ * « à venir » tant que sa date n'est pas passée — affiché barré. Une fois sa
+ * date dépassée, il rejoint l'historique « passés ».
+ *
+ * Types structurels (pas d'import du domaine) pour rester un util pur : `lib/`
+ * ne dépend de rien.
+ */
+
+type DatedMoment = { status: string; startsAt: Date };
+
+/** Un événement annulé encore daté dans le futur : appartient à l'agenda à venir. */
+export function isUpcomingCancelled(moment: DatedMoment, now: number): boolean {
+  return moment.status === "CANCELLED" && moment.startsAt.getTime() > now;
+}
+
+/** Un événement appartenant à l'historique : passé, ou annulé dont la date est passée. */
+export function isPastMoment(moment: DatedMoment, now: number): boolean {
+  return (
+    moment.status === "PAST" ||
+    (moment.status === "CANCELLED" && moment.startsAt.getTime() <= now)
+  );
+}
+
+/** Comparateur antichronologique : le plus récent d'abord. */
+export function byStartsAtDesc(a: { startsAt: Date }, b: { startsAt: Date }): number {
+  return b.startsAt.getTime() - a.startsAt.getTime();
+}


### PR DESCRIPTION
## Contexte

Sur la page d'une Communauté, l'historique des événements passés était trié du plus **ancien** au plus **récent**, contre-intuitif pour un historique (on attend le plus récent d'abord, comme Meetup/Luma, et comme le faisait déjà le dashboard Organisateur).

En corrigeant le tri, un cas limite est apparu : un événement **annulé dont la date est encore future** (annuler un événement à venir est supporté) tombait dans la section « passés » et, avec le tri antichronologique, remontait en tête de l'historique — une entrée datée du futur en haut des « passés ».

## Changement

Un événement annulé encore daté dans le futur reste désormais dans la section **« prochains événements »**, affiché barré (le composant `MomentTimelineItem` gérait déjà l'état annulé : bandeau, titre barré, vignette grisée, compteur masqué). Une fois sa date passée, il rejoint l'historique.

Résultat :
- **prochains** = `PUBLISHED` (+ `DRAFT` côté dashboard) + annulés futurs, chronologique
- **passés** = `PAST` + annulés déjà datés du passé, antichronologique (le plus récent d'abord)

La logique de catégorisation (`isUpcomingCancelled`, `isPastMoment`) et le tri (`byStartsAtDesc`) sont extraits dans un helper pur `src/lib/moment-timeline.ts`, appliqué à la fois sur la **page Circle publique** et la **page dashboard** (qui ne triait pas son historique) pour aligner les deux vues.

## Tests

- Tests unitaires du helper (`src/lib/__tests__/moment-timeline.test.ts`), 11 cas.
- `pnpm typecheck` vert.
- Validé en staging.

## Notes

- Pas de changement de schema Prisma.
- Revue : `/code-review` (high, multi-agent) passée, findings adressés.

🤖 Generated with [Claude Code](https://claude.com/claude-code)