### PR TITLE
fix(audit): neutralise le faux signal « télémétrie client absente »

### DIFF
--- a/src/infrastructure/services/audit/build-audit-prompt.ts
+++ b/src/infrastructure/services/audit/build-audit-prompt.ts
@@ -15,6 +15,7 @@ export function buildAuditPrompt(dossier: AuditDossier): string {
 - Le slop = créer une Communauté / un événement PUBLICITAIRE pointant vers un produit/site externe. Signaux forts : website du Circle vers un site commercial / billetterie externe ; description machine-translated / SEO / recopiée à l'identique Circle↔Moment ; "événement" qui est une annonce et pas un vrai rassemblement.
 - IMPORTANT : un lien externe n'est PAS suspect en soi. Distingue "pub vers un produit commercial" (slop) de "site perso de l'organisateur" ou "page d'inscription du vrai événement hébergé" (légitime).
 - Si le compte n'a AUCUN contenu (0 Communauté / 0 événement) : c'est un compte dormant, il n'a rien fait de répréhensible. Ne conclus PAS "spam" sans preuve.
+- TÉLÉMÉTRIE CLIENT NON FIABLE : une liste de villes client vide et un \`eventCount\` faible ne sont PAS des signaux. La navigation web est très souvent invisible (adblocker / Firefox, ou session anonyme jamais reliée à la person) — beaucoup de comptes parfaitement légitimes n'ont AUCUN event client et un seul \`auth_sign_in\` serveur. Ne conclus RIEN de cette absence, ni à charge ni à décharge. L'engagement réel se lit dans \`engagement\` (memberships / registrations / comments) et dans le contenu, jamais dans le volume PostHog.
 - En cas de doute, dis-le (ambigu) plutôt que d'inventer un signal.
 
 # Dossier (DB = source de vérité ; le geoip serveur "Frankfurt" a déjà été exclu, les villes listées sont côté client)


### PR DESCRIPTION
## Contexte

Investigation de deux comptes dont PostHog ne montrait qu'une **seule ligne** (`auth_sign_in` serveur, isolé) :
- **magic link** : un scanner d'email (Defender/Mimecast/Proofpoint) prefetch le lien → event serveur, nav humaine sous un distinct_id anonyme jamais relié.
- **OAuth Google** : connexion nominale mais **zéro event client** car le navigateur (Firefox + adblocker) bloque le SDK PostHog côté client, malgré le proxy first-party `/ingest` (qui ne couvre que le blocage par domaine, pas par path).

Dans les deux cas : compte parfaitement légitime, navigation web invisible dans PostHog.

## Problème

Le prompt de `/audit-user` présentait `clientCities` et `eventCount` comme exploitables (« géoloc client », « vélocité »). Or la nav client n'est quasi jamais reliée à la person (le filtre de collecte est `distinct_id = user.id OR person.email`, qui ne capture pas les pageviews anonymes). Résultat : pour la majorité des comptes, l'audit voit `clientCities: []` et `eventCount ≈ 1` — un profil « compte vide » trompeur, qui peut biaiser le LLM.

## Changement

Une leçon ajoutée au prompt : une télémétrie client vide / un `eventCount` faible **ne sont pas des signaux**, ni à charge ni à décharge. L'engagement réel se lit en DB (`memberships` / `registrations` / `comments`), jamais dans le volume PostHog.

Patch volontairement limité au prompt. L'angle mort de **collecte** (rapatrier la nav anonyme par corrélation session/IP) n'est pas traité : fragile, et la géoloc client n'est pas un discriminant fiable de spam (cf. leçon krishna).

## Vérifs
- `pnpm typecheck` ✅
- Pas de changement de schema Prisma
- Diff = contenu de prompt uniquement (aucune logique)

🤖 Generated with [Claude Code](https://claude.com/claude-code)