### PR TITLE
fix(seo): les Communautés et événements privés ne sont plus indexés par Google

### DIFF
--- a/src/app/[locale]/(routes)/circles/[slug]/page.tsx
+++ b/src/app/[locale]/(routes)/circles/[slug]/page.tsx
@@ -27,7 +27,7 @@ import { getMomentGradient } from "@/lib/gradient";
 import { formatLongDate } from "@/lib/format-date";
 import { collapseWhitespace } from "@/lib/text";
 import { isUpcomingCancelled, isPastMoment, byStartsAtDesc } from "@/lib/moment-timeline";
-import { buildAlternates } from "@/lib/seo";
+import { buildAlternates, isCircleIndexable } from "@/lib/seo";
 import { getAppUrl } from "@/lib/app-url";
 import { JoinCircleButton } from "@/components/circles/join-circle-button";
 import { CollapsibleDescription } from "@/components/moments/collapsible-description";
@@ -85,7 +85,7 @@ export async function generateMetadata({
   try {
     const circle = await getCachedCircle(slug);
     if (!circle) return {};
-    const isPrivate = circle.visibility !== "PUBLIC";
+    const isPrivate = !isCircleIndexable(circle);
 
     const [memberCount, t] = await Promise.all([
       getCachedMemberCount(circle.id),

--- a/src/app/[locale]/(routes)/m/[slug]/page.tsx
+++ b/src/app/[locale]/(routes)/m/[slug]/page.tsx
@@ -7,7 +7,7 @@ import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 import { formatLongDate, formatLocalizedTime } from "@/lib/format-date";
 import { collapseWhitespace } from "@/lib/text";
-import { buildAlternates } from "@/lib/seo";
+import { buildAlternates, isCircleIndexable } from "@/lib/seo";
 import { getAppUrl } from "@/lib/app-url";
 
 // Revalide toutes les 30 secondes — équilibre entre fraîcheur et performance.
@@ -69,8 +69,7 @@ export async function generateMetadata({
   const circle = await getCircle(moment.circleId);
   // Événement rattaché à une Communauté privée : page accessible par lien direct
   // (partage), mais jamais indexée par les crawlers (même pattern que /circles/[slug]).
-  // Fail-safe : si le Circle est introuvable, on n'indexe pas.
-  const isInPrivateCircle = circle?.visibility !== "PUBLIC";
+  const isInPrivateCircle = !isCircleIndexable(circle);
   const t = await getTranslations({ locale, namespace: "Moment" });
   const date = formatLongDate(moment.startsAt, locale);
   const time = formatLocalizedTime(moment.startsAt, locale);
@@ -238,8 +237,12 @@ export default async function PublicMomentPage({
       ? "https://schema.org/SoldOut"
       : "https://schema.org/InStock";
 
+  // Pas de données structurées schema.org pour un événement en Communauté privée :
+  // le noindex masque la page de l'index, mais le JSON-LD reste une surface
+  // exploitable par les crawlers / scrapers — on la ferme aussi (cf. generateMetadata).
   const jsonLd =
-    moment.status === "PUBLISHED" || moment.status === "PAST"
+    (moment.status === "PUBLISHED" || moment.status === "PAST") &&
+    isCircleIndexable(circle)
       ? {
           "@context": "https://schema.org",
           "@type": "Event",

--- a/src/app/[locale]/(routes)/m/[slug]/page.tsx
+++ b/src/app/[locale]/(routes)/m/[slug]/page.tsx
@@ -67,6 +67,10 @@ export async function generateMetadata({
   }
 
   const circle = await getCircle(moment.circleId);
+  // Événement rattaché à une Communauté privée : page accessible par lien direct
+  // (partage), mais jamais indexée par les crawlers (même pattern que /circles/[slug]).
+  // Fail-safe : si le Circle est introuvable, on n'indexe pas.
+  const isInPrivateCircle = circle?.visibility !== "PUBLIC";
   const t = await getTranslations({ locale, namespace: "Moment" });
   const date = formatLongDate(moment.startsAt, locale);
   const time = formatLocalizedTime(moment.startsAt, locale);
@@ -84,6 +88,7 @@ export async function generateMetadata({
     title,
     description,
     alternates: buildAlternates(locale, `/m/${slug}`),
+    ...(isInPrivateCircle && { robots: { index: false, follow: false } }),
     openGraph: {
       title,
       description,

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -63,6 +63,10 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       where: {
         status: { in: ["PUBLISHED", "PAST"] },
         circleId: { notIn: excludeCircleIds },
+        // N'expose pas les événements rattachés à une Communauté privée :
+        // accessibles par lien direct, mais hors sitemap et non indexés
+        // (cf. noindex dans /m/[slug]/page.tsx).
+        circle: { visibility: "PUBLIC" },
       },
       select: { slug: true, updatedAt: true },
     }),

--- a/src/lib/__tests__/seo.test.ts
+++ b/src/lib/__tests__/seo.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { buildAlternates } from "@/lib/seo";
+import { buildAlternates, isCircleIndexable } from "@/lib/seo";
 
 const APP_URL = "https://the-playground.fr";
 
@@ -75,6 +75,30 @@ describe("buildAlternates", () => {
     it("falls back to FR as the canonical (defensive default)", () => {
       const result = buildAlternates("de", "/about");
       expect(result.canonical).toBe(`${APP_URL}/about`);
+    });
+  });
+});
+
+describe("isCircleIndexable", () => {
+  describe("given a public Circle", () => {
+    it("is indexable (noindex off, JSON-LD + sitemap allowed)", () => {
+      expect(isCircleIndexable({ visibility: "PUBLIC" })).toBe(true);
+    });
+  });
+
+  describe("given a private Circle", () => {
+    it("is NOT indexable (page reachable by direct link, hidden from crawlers)", () => {
+      expect(isCircleIndexable({ visibility: "PRIVATE" })).toBe(false);
+    });
+  });
+
+  describe("given a missing Circle (fail-safe)", () => {
+    it("is NOT indexable when null", () => {
+      expect(isCircleIndexable(null)).toBe(false);
+    });
+
+    it("is NOT indexable when undefined", () => {
+      expect(isCircleIndexable(undefined)).toBe(false);
     });
   });
 });

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,7 +1,19 @@
 import { routing, isSupportedLocale, type Locale } from "@/i18n/routing";
+import type { CircleVisibility } from "@/domain/models/circle";
 import { getAppUrl } from "./app-url";
 
 type LocaleUrls = Record<Locale, string>;
+
+// Source unique de la règle SEO « Communauté privée = masquée des crawlers ».
+// Partagée par /m/[slug] (noindex + JSON-LD événement), /circles/[slug] (noindex)
+// : une page rattachée à une Communauté n'est indexable que si celle-ci est
+// publique. Fail-safe : un Circle absent (null/undefined) est non indexable.
+// Le sitemap applique la même règle via un filtre Prisma (circle.visibility).
+export function isCircleIndexable(
+  circle: { visibility: CircleVisibility } | null | undefined,
+): boolean {
+  return circle?.visibility === "PUBLIC";
+}
 
 // Per-locale absolute URLs for a path. `path` is the URL after the locale
 // segment, with a leading slash for sub-paths (e.g. "/m/abc"). Use "" for the


### PR DESCRIPTION
## Problème

Les Communautés et événements **privés** restaient indexables par Google, alors qu'ils ne doivent être atteignables que par **lien direct** (partage), jamais via la recherche.

État avant :
- **Circle privé** : `noindex` déjà posé + exclu du sitemap. ✅
- **Événement (Moment) en Circle privé** : aucun `noindex`, **et** présent dans le sitemap (filtre sur `status` seulement, sans regarder la visibilité du Circle parent). ❌
- **JSON-LD `schema.org/Event`** émis pour tout Moment publié, quelle que soit la visibilité → données structurées (titre, dates, prix, organisateur) exploitables par les crawlers même pour un événement privé. ❌

## Solution

`noindex` (pas de `robots.txt Disallow` : les pages doivent rester crawlables pour que Google **voie** le `noindex` et déréférence l'existant ; et l'accès par lien direct est préservé).

- **`/m/[slug]`** : `robots: { index:false, follow:false }` quand le Circle parent n'est pas `PUBLIC` (même pattern que `/circles/[slug]` et les événements annulés).
- **`sitemap.ts`** : filtre les Moments sur `circle.visibility = PUBLIC`.
- **JSON-LD** : n'est plus émis pour un événement en Communauté privée (fermeture de la surface structurée que le `noindex` ne couvrait pas).
- **`isCircleIndexable()`** dans `lib/seo` : source unique de la règle « Communauté privée = masquée des crawlers » (fail-safe : Circle absent = non indexable), partagée par `/m/[slug]` et `/circles/[slug]`.

## Décision produit

L'**aperçu social (OG/Twitter)** des événements est **volontairement conservé**, même en Communauté privée : le lien direct reste l'outil de partage souhaité, avec son aperçu. Divergence assumée avec `/circles/[slug]` (qui strippe l'OG des Circles privés). Seul Google est visé.

## Tests
- `pnpm typecheck` ✅
- Tests unitaires `isCircleIndexable` (public / privé / null / undefined) ✅
- Pas de schema Prisma touché

## Suivi opérationnel (hors PR)
Les pages privées **déjà indexées** sortiront de l'index au prochain crawl. Pour accélérer : Search Console (suppression d'URL + resoumettre le sitemap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)