### PR TITLE
fix(og): aperçu social des Circles privés partagés par lien

### DIFF
--- a/src/app/[locale]/(routes)/circles/[slug]/opengraph-image.tsx
+++ b/src/app/[locale]/(routes)/circles/[slug]/opengraph-image.tsx
@@ -2,6 +2,7 @@ import { getTranslations } from "next-intl/server";
 import { prismaCircleRepository } from "@/infrastructure/repositories";
 import { getCircleBySlug } from "@/domain/usecases/get-circle";
 import { CircleNotFoundError } from "@/domain/errors";
+import { isValidSlug } from "@/lib/slug";
 import { getMomentGradient } from "@/lib/gradient";
 import { loadCoverAsOgJpeg } from "@/lib/og-image-loader";
 import { ogJpegResponse, ogFallbackResponse } from "@/lib/og/render";
@@ -22,6 +23,7 @@ export default async function OgImage({
   params: Promise<{ slug: string; locale: string }>;
 }) {
   const { slug, locale } = await params;
+  if (!isValidSlug(slug)) return new Response("Not found", { status: 404 });
 
   let circle;
   try {

--- a/src/app/[locale]/(routes)/circles/[slug]/opengraph-image.tsx
+++ b/src/app/[locale]/(routes)/circles/[slug]/opengraph-image.tsx
@@ -35,10 +35,11 @@ export default async function OgImage({
     throw error;
   }
 
-  if (circle.visibility !== "PUBLIC") {
-    return new Response("Not found", { status: 404 });
-  }
-
+  // Pas de gate sur la visibilité ici : un Circle privé reste accessible par
+  // lien direct (partage), et son aperçu social doit s'afficher comme celui d'un
+  // Circle public. La règle « privé » agit sur l'indexation crawler (robots) et
+  // l'affichage Explorer, pas sur la génération de l'image de partage. Même
+  // pattern que la route OG de /m/[slug] (aucun gate de visibilité).
   const coverJpeg = circle.coverImage
     ? await loadCoverAsOgJpeg(circle.coverImage)
     : null;

--- a/src/app/[locale]/(routes)/circles/[slug]/page.tsx
+++ b/src/app/[locale]/(routes)/circles/[slug]/page.tsx
@@ -27,7 +27,11 @@ import { getMomentGradient } from "@/lib/gradient";
 import { formatLongDate } from "@/lib/format-date";
 import { collapseWhitespace } from "@/lib/text";
 import { isUpcomingCancelled, isPastMoment, byStartsAtDesc } from "@/lib/moment-timeline";
-import { buildAlternates, isCircleIndexable } from "@/lib/seo";
+import {
+  buildAlternates,
+  buildSocialMetadata,
+  isCircleIndexable,
+} from "@/lib/seo";
 import { getAppUrl } from "@/lib/app-url";
 import { JoinCircleButton } from "@/components/circles/join-circle-button";
 import { CollapsibleDescription } from "@/components/moments/collapsible-description";
@@ -111,16 +115,7 @@ export async function generateMetadata({
       // doit afficher le même aperçu qu'un Circle public. On découple l'indexation
       // de la génération de l'image de partage (même pattern que /m/[slug]).
       ...(isPrivate && { robots: { index: false, follow: false } }),
-      openGraph: {
-        title,
-        description,
-        type: "website",
-      },
-      twitter: {
-        card: "summary_large_image",
-        title,
-        description,
-      },
+      ...buildSocialMetadata(title, description),
     };
   } catch {
     return {};

--- a/src/app/[locale]/(routes)/circles/[slug]/page.tsx
+++ b/src/app/[locale]/(routes)/circles/[slug]/page.tsx
@@ -105,19 +105,22 @@ export async function generateMetadata({
       title,
       description,
       alternates: buildAlternates(locale, `/circles/${slug}`),
+      // Visibilité PRIVÉ → non indexable par les crawlers (robots). Mais l'aperçu
+      // social (Open Graph / Twitter + og:image via la convention opengraph-image)
+      // reste émis inconditionnellement : un lien privé partagé sur les réseaux
+      // doit afficher le même aperçu qu'un Circle public. On découple l'indexation
+      // de la génération de l'image de partage (même pattern que /m/[slug]).
       ...(isPrivate && { robots: { index: false, follow: false } }),
-      ...(!isPrivate && {
-        openGraph: {
-          title,
-          description,
-          type: "website",
-        },
-        twitter: {
-          card: "summary_large_image",
-          title,
-          description,
-        },
-      }),
+      openGraph: {
+        title,
+        description,
+        type: "website",
+      },
+      twitter: {
+        card: "summary_large_image",
+        title,
+        description,
+      },
     };
   } catch {
     return {};

--- a/src/app/[locale]/(routes)/m/[slug]/page.tsx
+++ b/src/app/[locale]/(routes)/m/[slug]/page.tsx
@@ -7,7 +7,11 @@ import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 import { formatLongDate, formatLocalizedTime } from "@/lib/format-date";
 import { collapseWhitespace } from "@/lib/text";
-import { buildAlternates, isCircleIndexable } from "@/lib/seo";
+import {
+  buildAlternates,
+  buildSocialMetadata,
+  isCircleIndexable,
+} from "@/lib/seo";
 import { getAppUrl } from "@/lib/app-url";
 
 // Revalide toutes les 30 secondes — équilibre entre fraîcheur et performance.
@@ -88,16 +92,7 @@ export async function generateMetadata({
     description,
     alternates: buildAlternates(locale, `/m/${slug}`),
     ...(isInPrivateCircle && { robots: { index: false, follow: false } }),
-    openGraph: {
-      title,
-      description,
-      type: "website",
-    },
-    twitter: {
-      card: "summary_large_image",
-      title,
-      description,
-    },
+    ...buildSocialMetadata(title, description),
   };
 }
 

--- a/src/lib/__tests__/seo.test.ts
+++ b/src/lib/__tests__/seo.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { buildAlternates, isCircleIndexable } from "@/lib/seo";
+import {
+  buildAlternates,
+  buildSocialMetadata,
+  isCircleIndexable,
+} from "@/lib/seo";
 
 const APP_URL = "https://the-playground.fr";
 
@@ -75,6 +79,38 @@ describe("buildAlternates", () => {
     it("falls back to FR as the canonical (defensive default)", () => {
       const result = buildAlternates("de", "/about");
       expect(result.canonical).toBe(`${APP_URL}/about`);
+    });
+  });
+});
+
+describe("buildSocialMetadata", () => {
+  describe("given a title and a description", () => {
+    it("emits an Open Graph website block carrying both", () => {
+      const result = buildSocialMetadata("Mon titre", "Ma description");
+      expect(result.openGraph).toEqual({
+        title: "Mon titre",
+        description: "Ma description",
+        type: "website",
+      });
+    });
+
+    it("emits a summary_large_image Twitter card carrying both", () => {
+      const result = buildSocialMetadata("Mon titre", "Ma description");
+      expect(result.twitter).toEqual({
+        card: "summary_large_image",
+        title: "Mon titre",
+        description: "Ma description",
+      });
+    });
+
+    // Le découplage indexation/aperçu repose sur ce contrat : le helper produit
+    // l'aperçu social sans aucune notion de visibilité. Un Circle/Moment privé
+    // partagé par lien doit afficher le même aperçu qu'un public ; seul `robots`
+    // (côté generateMetadata) dépend de la visibilité, jamais l'Open Graph.
+    it("never gates the social preview on visibility (no robots/index keys)", () => {
+      const result = buildSocialMetadata("x", "y") as Record<string, unknown>;
+      expect(result.robots).toBeUndefined();
+      expect(Object.keys(result).sort()).toEqual(["openGraph", "twitter"]);
     });
   });
 });

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import { routing, isSupportedLocale, type Locale } from "@/i18n/routing";
 import type { CircleVisibility } from "@/domain/models/circle";
 import { getAppUrl } from "./app-url";
@@ -13,6 +14,22 @@ export function isCircleIndexable(
   circle: { visibility: CircleVisibility } | null | undefined,
 ): boolean {
   return circle?.visibility === "PUBLIC";
+}
+
+// Open Graph + Twitter Card pour l'aperçu social (unfurl Slack/WhatsApp/iMessage…).
+// Partagé par /m/[slug] et /circles/[slug] : l'aperçu est émis pour toute page
+// accessible par lien, indépendamment de l'indexation crawler (robots). On
+// découple volontairement « privé = non indexable » de « génère l'aperçu de
+// partage ». L'og:image est injectée par la convention opengraph-image.tsx de
+// chaque route.
+export function buildSocialMetadata(
+  title: string,
+  description: string,
+): Pick<Metadata, "openGraph" | "twitter"> {
+  return {
+    openGraph: { title, description, type: "website" },
+    twitter: { card: "summary_large_image", title, description },
+  };
 }
 
 // Per-locale absolute URLs for a path. `path` is the URL after the locale


### PR DESCRIPTION
## Problème

Les liens de Communautés **privées** partagés (WhatsApp, Slack, réseaux) n'affichaient **aucun aperçu** : l'`og:image` pointait vers une route qui renvoyait systématiquement **404**.

Diagnostic confirmé en prod : `le-club-de-mont-saint-leger` est une Communauté privée. La route OG faisait `404` dès que `visibility !== "PUBLIC"` (`opengraph-image.tsx:38-40`), et `generateMetadata` omettait les blocs `openGraph`/`twitter` pour les privés. Une Communauté **publique** servait bien sa cover (HTTP 200). Le gate datait du tout premier commit SEO, **pas** du chantier covers récent.

## Décision

Découpler deux préoccupations distinctes (comme le fait déjà `/m/[slug]`) :

- **Visibilité PRIVÉ** → pilote l'indexation crawler (`robots: noindex`) + l'affichage Explorer.
- **Génération de l'og:image** → pour **tous** les Circles, parce qu'un lien privé partagé doit afficher son aperçu.

Pas de fuite : l'aperçu (cover, nom, compteur de membres) n'expose que ce qui est déjà visible sur la page, accessible par lien direct sans auth.

## Changements

- `circles/[slug]/opengraph-image.tsx` : retire le gate de visibilité (404 conservé uniquement sur Circle introuvable / slug invalide).
- `circles/[slug]/page.tsx` & `m/[slug]/page.tsx` : `openGraph`/`twitter` émis inconditionnellement, seul `robots` reste gaté sur le statut privé.
- `lib/seo.ts` : extrait `buildSocialMetadata()`, partagé par les deux routes (supprime la duplication verbatim).
- `circles/[slug]/opengraph-image.tsx` : ajoute le guard `isValidSlug` manquant (alignement réel sur le pattern `/m/[slug]`).

## Tests

- 3 nouveaux tests sur `buildSocialMetadata`, dont l'invariant « l'aperçu ne dépend jamais de la visibilité ».
- `pnpm typecheck` vert, `seo.test.ts` 16/16.
- Pas de changement de schema Prisma.

## Revue

`/code-review` (high) passé : 5 findings, 2 by-design (aperçu privé = décision explicite, coût compute = tradeoff assumé), 3 corrigés (slug, DRY, tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)