### PR TITLE
fix(auth): reconnecte en transparence sur lien magic expiré si la session est active

### DIFF
--- a/src/app/[locale]/auth/error/page.tsx
+++ b/src/app/[locale]/auth/error/page.tsx
@@ -7,11 +7,10 @@ import {
 } from "@/lib/auth/error-kinds";
 import { getRequestObservability } from "@/lib/auth/request-observability";
 import { getCachedSession } from "@/lib/auth-cache";
-import { safeCallbackUrl } from "@/lib/url";
 import { AuthErrorView } from "./auth-error-view";
 
 type Props = {
-  searchParams: Promise<{ error?: string | string[]; callbackUrl?: string }>;
+  searchParams: Promise<{ error?: string | string[] }>;
 };
 
 // Capture côté serveur : les réseaux d'entreprise/administration qui bloquent
@@ -23,6 +22,10 @@ export default async function AuthErrorPage({ searchParams }: Props) {
   // Un param répété (?error=a&error=b) arrive en string[] — on ne garde que
   // la première valeur, comme le faisait useSearchParams().get().
   const error = Array.isArray(params.error) ? params.error[0] : params.error;
+  // Le code normalisé borne la cardinalité des tags/messages Sentry
+  // (?error= est contrôlable par l'utilisateur) ; la valeur brute reste
+  // disponible en extra. Sert aussi la garde de reconnexion ci-dessous.
+  const code = normalizeAuthErrorCode(error);
 
   // Magic link expiré/invalide, mais l'utilisateur a déjà une session valide
   // dans ce navigateur : il n'avait pas besoin du lien pour revenir (cas typique :
@@ -31,18 +34,23 @@ export default async function AuthErrorPage({ searchParams }: Props) {
   // rendu — au lieu de l'envoyer sur un cul-de-sac. On ne réutilise PAS le token
   // périmé : on s'appuie uniquement sur la session déjà présente (zéro élévation).
   // Placé avant la capture Sentry : un utilisateur déjà connecté n'est pas une erreur.
-  if (normalizeAuthErrorCode(error) === AUTH_ERROR_VERIFICATION) {
-    const session = await getCachedSession();
+  if (code === AUTH_ERROR_VERIFICATION) {
+    // La page d'erreur reste le filet quand l'auth déraille : si la lecture de
+    // session lève (panne/stale-connection Neon, cf. spec/infra), on retombe sur
+    // l'affichage gracieux de l'erreur plutôt qu'un 500. Le redirect() est hors
+    // du try (il lève NEXT_REDIRECT, à ne pas avaler).
+    let session = null;
+    try {
+      session = await getCachedSession();
+    } catch {
+      session = null;
+    }
     if (session) {
-      redirect(safeCallbackUrl(params.callbackUrl) ?? "/dashboard");
+      redirect("/dashboard");
     }
   }
 
   if (error) {
-    // Le code normalisé borne la cardinalité des tags/messages Sentry
-    // (?error= est contrôlable par l'utilisateur) ; la valeur brute reste
-    // disponible en extra.
-    const code = normalizeAuthErrorCode(error);
     Sentry.captureMessage(`auth-error-page: ${code}`, {
       level: "warning",
       tags: {

--- a/src/app/[locale]/auth/error/page.tsx
+++ b/src/app/[locale]/auth/error/page.tsx
@@ -1,13 +1,17 @@
 import * as Sentry from "@sentry/nextjs";
+import { redirect } from "next/navigation";
 import {
+  AUTH_ERROR_VERIFICATION,
   classifyAuthError,
   normalizeAuthErrorCode,
 } from "@/lib/auth/error-kinds";
 import { getRequestObservability } from "@/lib/auth/request-observability";
+import { getCachedSession } from "@/lib/auth-cache";
+import { safeCallbackUrl } from "@/lib/url";
 import { AuthErrorView } from "./auth-error-view";
 
 type Props = {
-  searchParams: Promise<{ error?: string | string[] }>;
+  searchParams: Promise<{ error?: string | string[]; callbackUrl?: string }>;
 };
 
 // Capture côté serveur : les réseaux d'entreprise/administration qui bloquent
@@ -19,6 +23,20 @@ export default async function AuthErrorPage({ searchParams }: Props) {
   // Un param répété (?error=a&error=b) arrive en string[] — on ne garde que
   // la première valeur, comme le faisait useSearchParams().get().
   const error = Array.isArray(params.error) ? params.error[0] : params.error;
+
+  // Magic link expiré/invalide, mais l'utilisateur a déjà une session valide
+  // dans ce navigateur : il n'avait pas besoin du lien pour revenir (cas typique :
+  // il croit devoir recliquer un lien alors que sa session est encore active). On
+  // le reconnecte en transparence — redirection serveur, aucun écran d'erreur
+  // rendu — au lieu de l'envoyer sur un cul-de-sac. On ne réutilise PAS le token
+  // périmé : on s'appuie uniquement sur la session déjà présente (zéro élévation).
+  // Placé avant la capture Sentry : un utilisateur déjà connecté n'est pas une erreur.
+  if (normalizeAuthErrorCode(error) === AUTH_ERROR_VERIFICATION) {
+    const session = await getCachedSession();
+    if (session) {
+      redirect(safeCallbackUrl(params.callbackUrl) ?? "/dashboard");
+    }
+  }
 
   if (error) {
     // Le code normalisé borne la cardinalité des tags/messages Sentry

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -133,3 +133,26 @@ test.describe("Magic link — protection contre les scanners email", () => {
     await expect(page.getByRole("link", { name: /nouveau lien/i })).toBeVisible();
   });
 });
+
+test.describe("Magic link — reconnexion transparente sur lien expiré", () => {
+  test.use({ storageState: AUTH.HOST });
+
+  test("should redirect an already-authenticated user from a Verification error to the dashboard", async ({
+    page,
+  }) => {
+    // Lien magic expiré recliqué alors que la session est encore active : on
+    // reconnecte en transparence vers le dashboard au lieu d'afficher le
+    // cul-de-sac. Aucun token n'est réutilisé, on s'appuie sur la session.
+    await page.goto("/fr/auth/error?error=Verification");
+    await expect(page).toHaveURL(/\/dashboard/, { timeout: 10_000 });
+  });
+
+  test("should still show the error page for a non-Verification error even when authenticated", async ({
+    page,
+  }) => {
+    // Garde-fou de non-régression : SEUL Verification déclenche la reconnexion.
+    // Tout autre code d'erreur reste affiché, même avec une session active.
+    await page.goto("/fr/auth/error?error=AccessDenied");
+    await expect(page).toHaveURL(/\/auth\/error/);
+  });
+});


### PR DESCRIPTION
## Contexte

Investigation d'un utilisateur (incident réel) inscrit la veille, membre d'un Circle et inscrit à un événement, qui « bute sur la connexion » le lendemain. Diagnostic PostHog + DB prod : il reclique un magic link **expiré** (`/auth/error?error=Verification`) alors qu'il a **encore une session valide** dans le même navigateur (même `device_id`, session DB expirant à J+30). Il croit devoir recliquer un lien pour revenir, et tombe sur un cul-de-sac.

## Changement

La page d'erreur (`auth/error/page.tsx`, Server Component) lit désormais la session : si une session valide est présente **sur une erreur `Verification`**, redirection serveur transparente vers `/dashboard` (aucun écran d'erreur rendu). On **ne réutilise pas** le token périmé, on s'appuie uniquement sur la session déjà présente (zéro élévation).

## Garde-fous (suite à /code-review high)

- `redirect("/dashboard")` en dur : Auth.js v5 ne forwarde pas `callbackUrl` sur `pages.error`, le plumbing `safeCallbackUrl` était du code mort et ouvrait une redirection interne dirigeable via URL forgée. Supprimé.
- `try/catch` autour de la lecture de session : la page d'erreur reste le filet sous panne/stale-connection Neon (retombe sur l'écran gracieux au lieu d'un 500).
- Garde placée avant la capture Sentry : un utilisateur déjà connecté n'est pas une erreur.
- Décision produit assumée : redirection silencieuse (pas d'interstitiel d'identité). L'edge « lien d'un autre compte » est rare et sans élévation.

## Tests

`auth.spec.ts` — `14/14` au vert localement :
- session active + `error=Verification` → redirige `/dashboard` (nouveau)
- session active + `error=AccessDenied` → reste sur l'écran d'erreur (seul `Verification` déclenche la reconnexion)
- `Verification` sans session → écran d'erreur (non-régression, test existant)
- tous les autres parcours auth intacts

## Hors scope (signalés)

- Perte de locale sur `redirect("/dashboard")` : pré-existant et **partagé avec `sign-in/page.tsx`**, à traiter ensemble séparément.
- Refonte du cadrage de la page d'erreur (titre « Erreur d'authentification » anxiogène, bouton qui renvoie au formulaire au lieu d'un renvoi en un clic) : volontairement laissée de côté.

🤖 Generated with [Claude Code](https://claude.com/claude-code)