### PR TITLE
docs: mise à jour pré-release 2.17.0 (README + stats)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ Le modèle communautaire de Meetup + l'expérience de Luma + 100% gratuit. Pas d
 
 **Pour l'organisateur**
 - Créer et gérer sa communauté — privée ou publique, avec invitations par lien
+- **Co-organisateurs** — déléguez la gestion sans partager les accès sensibles (Stripe, suppression)
 - Créer des événements avec une page autonome et partageable
+- **Pièces jointes** — documents et vidéos consultables directement sur la page événement
 - **Billetterie intégrée** via Stripe Connect — 0% commission plateforme
 - **Inscriptions sur validation** pour filtrer les participants si besoin
 - Gérer ses participants de façon persistante (pas événement par événement)
@@ -46,9 +48,10 @@ Le modèle communautaire de Meetup + l'expérience de Luma + 100% gratuit. Pas d
 - Inscription en quelques secondes — magic link, pas de compte requis
 - Devient automatiquement membre de la communauté
 - **Profil public** avec bio, ville, liens sociaux
+- Ajout à son calendrier en un clic (Google Calendar, Apple Calendar, .ics)
 - Notifications email (confirmation, rappel 24h avant, changements, annulations)
 - Page communauté : prochains événements, membres, historique
-- Fil de commentaires sur chaque événement
+- Fil de commentaires (avec photos) sur chaque événement
 
 **Plateforme**
 - [Explorer](https://the-playground.fr/explorer) — répertoire public de communautés avec tri, filtres et section À la une

--- a/src/app/[locale]/(routes)/(static)/about/page.tsx
+++ b/src/app/[locale]/(routes)/(static)/about/page.tsx
@@ -375,10 +375,10 @@ export default async function AboutPage() {
         </h2>
         <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
           {[
-            { value: "2 300+", label: isFr ? "commits" : "commits" },
-            { value: "500+", label: isFr ? "pull requests" : "pull requests" },
-            { value: "85", label: isFr ? "cas d'usage" : "use cases" },
-            { value: "1 480+", label: isFr ? "tests" : "tests" },
+            { value: "2 500+", label: isFr ? "commits" : "commits" },
+            { value: "520+", label: isFr ? "pull requests" : "pull requests" },
+            { value: "87", label: isFr ? "cas d'usage" : "use cases" },
+            { value: "1 560+", label: isFr ? "tests" : "tests" },
           ].map(({ value, label }) => (
             <div key={label} className="text-center">
               <p className="text-2xl font-extrabold tracking-tight bg-gradient-to-r from-pink-500 to-violet-500 bg-clip-text text-transparent">


### PR DESCRIPTION
Mise à jour des pages statiques avant la release 2.17.0.

- **README « Fonctionnalités »** : co-organisateurs, pièces jointes (documents + vidéos), calendrier participant, commentaires avec photos.
- **Page About « En chiffres »** : stats à jour (2 500+ commits, 520+ PRs, 87 usecases, 1 560+ tests).
- Page Aide + reste du README (stack, prérequis, archi, commandes, auth, liens) : audités, déjà conformes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)