### PR TITLE
CTA « S'inscrire » pour les visiteurs non connectés + mesure de l'intention d'inscription

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -629,6 +629,7 @@
       "cancelNonRefundableWarning": "This event is non-refundable. You will not be refunded.",
       "confirmCancel": "Yes, cancel",
       "spotsRemaining": "{count} spots remaining",
+      "signInToRegister": "Sign in to join",
       "registrantsCount": "{count} joined",
       "eventFull": "Full",
       "attendeesCount": "{count} member(s)",

--- a/messages/en.json
+++ b/messages/en.json
@@ -350,7 +350,6 @@
       "manageCircle": "Manage this community",
       "shareableLink": "Shareable link",
       "signInToSeeMembers": "Sign in to see the members of this community",
-      "signInToJoin": "Sign in to join",
       "autoJoinSuccess": "You've joined the community",
       "autoJoinPending": "Membership request sent"
     },
@@ -630,7 +629,6 @@
       "cancelNonRefundableWarning": "This event is non-refundable. You will not be refunded.",
       "confirmCancel": "Yes, cancel",
       "spotsRemaining": "{count} spots remaining",
-      "signInToRegister": "Sign in to join",
       "registrantsCount": "{count} joined",
       "eventFull": "Full",
       "attendeesCount": "{count} member(s)",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -629,6 +629,7 @@
       "cancelNonRefundableWarning": "Cet événement n'est pas remboursable. Vous ne serez pas remboursé.",
       "confirmCancel": "Oui, annuler",
       "spotsRemaining": "{count} places restantes",
+      "signInToRegister": "Se connecter pour s'inscrire",
       "registrantsCount": "{count} inscrits",
       "eventFull": "Complet",
       "attendeesCount": "{count} participant(s)",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -350,7 +350,6 @@
       "manageCircle": "Gérer cette communauté",
       "shareableLink": "Lien partageable",
       "signInToSeeMembers": "Connecte-toi pour voir les membres de cette communauté",
-      "signInToJoin": "Se connecter pour rejoindre",
       "autoJoinSuccess": "Vous avez rejoint la communauté",
       "autoJoinPending": "Demande d'adhésion envoyée"
     },
@@ -630,7 +629,6 @@
       "cancelNonRefundableWarning": "Cet événement n'est pas remboursable. Vous ne serez pas remboursé.",
       "confirmCancel": "Oui, annuler",
       "spotsRemaining": "{count} places restantes",
-      "signInToRegister": "Se connecter pour s'inscrire",
       "registrantsCount": "{count} inscrits",
       "eventFull": "Complet",
       "attendeesCount": "{count} participant(s)",

--- a/src/app/[locale]/(routes)/circles/[slug]/page.tsx
+++ b/src/app/[locale]/(routes)/circles/[slug]/page.tsx
@@ -404,19 +404,18 @@ export default async function PublicCirclePage({
             </div>
           )}
 
-          {/* Bouton Rejoindre — visible uniquement pour les utilisateurs connectés non-membres */}
-          {showJoinButton && (
-            <JoinCircleButton circleId={circle.id} requiresApproval={circle.requiresApproval} />
-          )}
-
-          {/* CTA Se connecter — visible pour les visiteurs non-authentifiés */}
-          {showSignInToJoin && (
-            <Button variant="default" size="sm" asChild className="w-full gap-2">
-              <a href={signInUrlWithAutoJoin(locale, `/${locale}/circles/${slug}`)}>
-                <Users className="size-4" />
-                {t("detail.signInToJoin")}
-              </a>
-            </Button>
+          {/* Bouton Rejoindre — connecté non-membre (adhésion directe) ou
+              visiteur non connecté (lien vers l'auth avec intention ?join=1) */}
+          {(showJoinButton || showSignInToJoin) && (
+            <JoinCircleButton
+              circleId={circle.id}
+              requiresApproval={circle.requiresApproval}
+              signInUrl={
+                showSignInToJoin
+                  ? signInUrlWithAutoJoin(locale, `/${locale}/circles/${slug}`)
+                  : null
+              }
+            />
           )}
           </div>
           {/* /Groupe 2 */}

--- a/src/components/circles/join-circle-button.tsx
+++ b/src/components/circles/join-circle-button.tsx
@@ -4,6 +4,7 @@ import { useState, useTransition } from "react";
 import { useRouter } from "@/i18n/navigation";
 import posthog from "posthog-js";
 import { toast } from "sonner";
+import { captureIntentEvent } from "@/lib/capture-intent";
 import { Users, Check, Clock } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { joinCircleDirectlyAction } from "@/app/actions/circle";
@@ -54,17 +55,20 @@ export function JoinCircleButton({ circleId, requiresApproval = false, signInUrl
     onTrigger: () => runJoin("auto"),
   });
 
-  // Intention d'adhésion : clic manuel sur le CTA, connecté ou non (l'auto-
-  // adhésion post-auth est exclue, l'intention a déjà été capturée avant l'auth).
-  // Permet de distinguer le désintérêt de l'abandon lié à l'authentification (#610).
+  // Intention d'adhésion : clic manuel sur le CTA (l'auto-adhésion post-auth
+  // est exclue, l'intention a déjà été capturée avant l'auth).
   function captureJoinIntent(authenticated: boolean) {
-    posthog.capture(
-      "join_circle_cta_clicked",
-      { circle_id: circleId, authenticated },
-      // sendBeacon : non connecté, l'event doit survivre à la navigation vers /auth/sign-in.
-      authenticated ? undefined : { transport: "sendBeacon" }
-    );
+    captureIntentEvent("join_circle_cta_clicked", { circle_id: circleId }, authenticated);
   }
+
+  // Contenu partagé entre les branches visiteur et connecté : le visiteur doit
+  // voir exactement le même libellé métier avant et après l'authentification.
+  const joinContent = (
+    <>
+      <Users className="size-4" />
+      {requiresApproval ? t("joinRequiresApproval") : t("join")}
+    </>
+  );
 
   // Non connecté : le CTA affiche l'action métier (« Rejoindre »), pas la
   // friction — l'auth est une étape du flux (?join=1 → auto-adhésion au retour).
@@ -72,8 +76,7 @@ export function JoinCircleButton({ circleId, requiresApproval = false, signInUrl
     return (
       <Button variant="default" size="sm" asChild className="w-full gap-2">
         <a href={signInUrl} onClick={() => captureJoinIntent(false)}>
-          <Users className="size-4" />
-          {requiresApproval ? t("joinRequiresApproval") : t("join")}
+          {joinContent}
         </a>
       </Button>
     );
@@ -108,8 +111,7 @@ export function JoinCircleButton({ circleId, requiresApproval = false, signInUrl
       disabled={isPending}
       className="w-full gap-2"
     >
-      <Users className="size-4" />
-      {requiresApproval ? t("joinRequiresApproval") : t("join")}
+      {joinContent}
     </Button>
   );
 }

--- a/src/components/circles/join-circle-button.tsx
+++ b/src/components/circles/join-circle-button.tsx
@@ -14,9 +14,11 @@ import { useTranslations } from "next-intl";
 type Props = {
   circleId: string;
   requiresApproval?: boolean;
+  /** Non connecté : le CTA devient un lien vers l'auth (avec `?join=1`). */
+  signInUrl?: string | null;
 };
 
-export function JoinCircleButton({ circleId, requiresApproval = false }: Props) {
+export function JoinCircleButton({ circleId, requiresApproval = false, signInUrl = null }: Props) {
   const t = useTranslations("Circle.detail");
   const router = useRouter();
   const [state, setState] = useState<"idle" | "joined" | "pending">("idle");
@@ -44,13 +46,38 @@ export function JoinCircleButton({ circleId, requiresApproval = false }: Props) 
     });
   }
 
-  // Auto-adhésion post-auth : ce composant n'est monté que pour un utilisateur
-  // connecté non-membre. Si l'URL porte `?join=1` (CTA « Rejoindre » avant
+  // Auto-adhésion post-auth : si l'URL porte `?join=1` (CTA « Rejoindre » avant
   // authentification), déclenche l'adhésion au retour, sans re-cliquer.
+  // Uniquement en mode connecté non-membre (signInUrl null).
   useAutoJoin({
-    enabled: state === "idle",
+    enabled: state === "idle" && !signInUrl,
     onTrigger: () => runJoin("auto"),
   });
+
+  // Intention d'adhésion : clic manuel sur le CTA, connecté ou non (l'auto-
+  // adhésion post-auth est exclue, l'intention a déjà été capturée avant l'auth).
+  // Permet de distinguer le désintérêt de l'abandon lié à l'authentification (#610).
+  function captureJoinIntent(authenticated: boolean) {
+    posthog.capture(
+      "join_circle_cta_clicked",
+      { circle_id: circleId, authenticated },
+      // sendBeacon : non connecté, l'event doit survivre à la navigation vers /auth/sign-in.
+      authenticated ? undefined : { transport: "sendBeacon" }
+    );
+  }
+
+  // Non connecté : le CTA affiche l'action métier (« Rejoindre »), pas la
+  // friction — l'auth est une étape du flux (?join=1 → auto-adhésion au retour).
+  if (signInUrl) {
+    return (
+      <Button variant="default" size="sm" asChild className="w-full gap-2">
+        <a href={signInUrl} onClick={() => captureJoinIntent(false)}>
+          <Users className="size-4" />
+          {requiresApproval ? t("joinRequiresApproval") : t("join")}
+        </a>
+      </Button>
+    );
+  }
 
   if (state === "joined") {
     return (
@@ -74,7 +101,10 @@ export function JoinCircleButton({ circleId, requiresApproval = false }: Props) 
     <Button
       variant="default"
       size="sm"
-      onClick={() => runJoin("click")}
+      onClick={() => {
+        captureJoinIntent(true);
+        runJoin("click");
+      }}
       disabled={isPending}
       className="w-full gap-2"
     >

--- a/src/components/moments/registration-button.tsx
+++ b/src/components/moments/registration-button.tsx
@@ -130,11 +130,45 @@ export function RegistrationButton({
     onTrigger: () => runJoin("auto"),
   });
 
-  // Not authenticated: link to sign-in (same for free and paid)
+  // Intention d'inscription : clic manuel sur le CTA, connecté ou non (l'auto-
+  // inscription post-auth est exclue, l'intention a déjà été capturée avant l'auth).
+  // Permet de distinguer le désintérêt de l'abandon lié à l'authentification (#610).
+  function captureRegisterIntent(authenticated: boolean) {
+    posthog.capture(
+      "register_cta_clicked",
+      { moment_id: momentId, circle_id: circleId, authenticated },
+      // sendBeacon : non connecté, l'event doit survivre à la navigation vers /auth/sign-in.
+      authenticated ? undefined : { transport: "sendBeacon" }
+    );
+  }
+
+  // Non connecté : le CTA affiche l'action métier (même libellé que connecté),
+  // pas la friction — l'auth est une étape du flux (?join=1 → auto-inscription
+  // au retour).
   if (!isAuthenticated) {
+    if (price > 0 && isFull) {
+      return (
+        <Button className="w-full" size="sm" disabled>
+          {t("public.eventFull")}
+        </Button>
+      );
+    }
+    const label =
+      price > 0
+        ? t("public.registerPaid", {
+            price: formatPrice(price, currency, locale),
+            currency,
+          })
+        : requiresApproval
+          ? t("public.requestToJoin")
+          : isFull
+            ? t("public.joinWaitlist")
+            : t("public.registerFree");
     return (
       <Button className="w-full" size="sm" asChild>
-        <a href={signInUrl}>{t("public.signInToRegister")}</a>
+        <a href={signInUrl} onClick={() => captureRegisterIntent(false)}>
+          {label}
+        </a>
       </Button>
     );
   }
@@ -156,6 +190,7 @@ export function RegistrationButton({
           size="sm"
           disabled={isPending}
           onClick={() => {
+            captureRegisterIntent(true);
             startTransition(async () => {
               setError(null);
               const baseUrl = window.location.origin;
@@ -284,7 +319,10 @@ export function RegistrationButton({
         className="w-full"
         size="sm"
         disabled={isPending}
-        onClick={() => runJoin("click")}
+        onClick={() => {
+          captureRegisterIntent(true);
+          runJoin("click");
+        }}
       >
         {isPending
           ? tCommon("loading")

--- a/src/components/moments/registration-button.tsx
+++ b/src/components/moments/registration-button.tsx
@@ -27,6 +27,7 @@ import { useAutoJoin } from "@/components/auth/use-auto-join";
 import { formatPrice } from "@/lib/format-price";
 import type { Registration, RegistrationStatus } from "@/domain/models/registration";
 import type { CalendarEventData } from "@/lib/calendar";
+import { captureIntentEvent } from "@/lib/capture-intent";
 import posthog from "posthog-js";
 import { toast } from "sonner";
 
@@ -130,44 +131,43 @@ export function RegistrationButton({
     onTrigger: () => runJoin("auto"),
   });
 
-  // Intention d'inscription : clic manuel sur le CTA, connecté ou non (l'auto-
-  // inscription post-auth est exclue, l'intention a déjà été capturée avant l'auth).
-  // Permet de distinguer le désintérêt de l'abandon lié à l'authentification (#610).
+  // Intention d'inscription : clic manuel sur le CTA (l'auto-inscription
+  // post-auth est exclue, l'intention a déjà été capturée avant l'auth).
   function captureRegisterIntent(authenticated: boolean) {
-    posthog.capture(
+    captureIntentEvent(
       "register_cta_clicked",
-      { moment_id: momentId, circle_id: circleId, authenticated },
-      // sendBeacon : non connecté, l'event doit survivre à la navigation vers /auth/sign-in.
-      authenticated ? undefined : { transport: "sendBeacon" }
+      { moment_id: momentId, circle_id: circleId },
+      authenticated
     );
   }
 
-  // Non connecté : le CTA affiche l'action métier (même libellé que connecté),
-  // pas la friction — l'auth est une étape du flux (?join=1 → auto-inscription
-  // au retour).
+  // Libellé du CTA d'inscription gratuit — calculé une fois et partagé entre
+  // les branches visiteur et connecté : le visiteur doit voir exactement le
+  // même libellé métier avant et après l'authentification.
+  const joinLabel = requiresApproval
+    ? t("public.requestToJoin")
+    : isFull
+      ? t("public.joinWaitlist")
+      : t("public.registerFree");
+
+  // Non connecté, gratuit : le CTA affiche l'action métier, pas la friction —
+  // l'auth est une étape du flux (?join=1 → auto-inscription au retour). Le
+  // clic exprime l'intention d'inscription (#610). Le payant garde « Se
+  // connecter pour s'inscrire » : l'auto-inscription y est bloquée (pas
+  // d'auto-paiement), le libellé en deux temps reste donc honnête, et
+  // l'intention n'est capturée qu'au clic post-auth (un event par parcours).
   if (!isAuthenticated) {
-    if (price > 0 && isFull) {
+    if (price > 0) {
       return (
-        <Button className="w-full" size="sm" disabled>
-          {t("public.eventFull")}
+        <Button className="w-full" size="sm" asChild>
+          <a href={signInUrl}>{t("public.signInToRegister")}</a>
         </Button>
       );
     }
-    const label =
-      price > 0
-        ? t("public.registerPaid", {
-            price: formatPrice(price, currency, locale),
-            currency,
-          })
-        : requiresApproval
-          ? t("public.requestToJoin")
-          : isFull
-            ? t("public.joinWaitlist")
-            : t("public.registerFree");
     return (
       <Button className="w-full" size="sm" asChild>
         <a href={signInUrl} onClick={() => captureRegisterIntent(false)}>
-          {label}
+          {joinLabel}
         </a>
       </Button>
     );
@@ -324,13 +324,7 @@ export function RegistrationButton({
           runJoin("click");
         }}
       >
-        {isPending
-          ? tCommon("loading")
-          : requiresApproval
-            ? t("public.requestToJoin")
-            : isFull
-              ? t("public.joinWaitlist")
-              : t("public.registerFree")}
+        {isPending ? tCommon("loading") : joinLabel}
       </Button>
       {error && (
         <div className="bg-destructive/10 text-destructive rounded-md p-3 text-sm">

--- a/src/lib/capture-intent.ts
+++ b/src/lib/capture-intent.ts
@@ -1,0 +1,21 @@
+import posthog from "posthog-js";
+
+/**
+ * Capture un event d'intention au clic d'un CTA pré-auth (« S'inscrire » sur un
+ * événement, « Rejoindre » sur une Communauté). Permet de distinguer le
+ * désintérêt (pas de clic) de l'abandon lié à l'authentification (#610).
+ *
+ * Non connecté, le clic navigue immédiatement vers /auth/sign-in : sendBeacon
+ * garantit que l'event survit à la navigation.
+ */
+export function captureIntentEvent(
+  event: string,
+  properties: Record<string, string>,
+  authenticated: boolean
+): void {
+  posthog.capture(
+    event,
+    { ...properties, authenticated },
+    authenticated ? undefined : { transport: "sendBeacon" }
+  );
+}


### PR DESCRIPTION
## Problème

Impossible de mesurer le drop du funnel d'inscription causé par l'obligation de se connecter : le CTA « Se connecter pour s'inscrire » mélange dans le même abandon les visiteurs désintéressés et ceux qui renoncent devant la connexion. Et le clic sur ce CTA n'émettait aucun event PostHog (`autocapture` et `capture_pageview` désactivés).

## Solution

**Page événement** (`registration-button.tsx`) :
- Visiteur non connecté, événement **gratuit** : le CTA affiche l'action métier avec le même libellé que le bouton connecté (« S'inscrire » / « Rejoindre la liste d'attente » / « S'inscrire (soumis à validation) »). L'auth devient une étape du flux : la mécanique existante `?join=1` → auto-inscription au retour prend le relais.
- Le **payant** garde « Se connecter pour s'inscrire » : l'auto-inscription post-auth y est bloquée (pas d'auto-paiement), le libellé en deux temps reste honnête.
- Event `register_cta_clicked` (`moment_id`, `circle_id`, `authenticated`) au clic du CTA. Côté visiteur, transport `sendBeacon` pour survivre à la navigation vers l'auth. Un seul event par parcours (l'auto-inscription post-auth ne re-capture pas).

**Page Communauté** : « Se connecter pour rejoindre » → « Rejoindre », même mécanique (`JoinCircleButton` gagne un mode visiteur via la prop `signInUrl`), event miroir `join_circle_cta_clicked`.

**Partagé** : helper `src/lib/capture-intent.ts` (capture d'intention pré-auth), libellés calculés une fois et partagés entre branches visiteur/connecté (même libellé garanti avant/après auth).

**i18n** : clé `signInToJoin` supprimée (FR + EN), `signInToRegister` conservée pour le payant.

## Funnel résultant

`moment_viewed` → `register_cta_clicked` → `sign_in_provider_clicked` → `moment_joined` (trigger `auto`). Drop avant le clic = désintérêt ; drop après = friction d'authentification.

## Tests

- `pnpm typecheck` ✅
- `pnpm test:unit` ✅ (1560 tests)
- /code-review (high) passé : les 3 findings bloquants (régressions UX payant, double event) résolus par la restriction du nouveau CTA au gratuit ; cleanups appliqués.

Closes #610

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7zCcxjVxhj1294uL1xEX6