### PR TITLE
fix(csp): autorise media.licdn.com dans img-src (avatars LinkedIn invisibles)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -41,7 +41,7 @@ const baseCspDirectives = [
   "script-src 'self' 'unsafe-inline' 'unsafe-eval' js.stripe.com",
   "style-src 'self' 'unsafe-inline'",
   // Images : domaine propre + blobs + avatars OAuth + Unsplash + Stripe
-  "img-src 'self' data: blob: *.unsplash.com *.public.blob.vercel-storage.com avatars.githubusercontent.com lh3.googleusercontent.com q.stripe.com",
+  "img-src 'self' data: blob: *.unsplash.com *.public.blob.vercel-storage.com avatars.githubusercontent.com lh3.googleusercontent.com media.licdn.com q.stripe.com",
   // Vidéos : pièces jointes lues directement depuis le store Vercel Blob
   // (sans media-src, la lecture retomberait sur default-src 'self' et serait bloquée)
   "media-src 'self' *.public.blob.vercel-storage.com",


### PR DESCRIPTION
## Problème

Un utilisateur qui se connecte via OAuth LinkedIn voit son avatar remplacé par le dégradé + initiales, partout dans l'app et pour tous les viewers.

La synchro d'avatar du callback `signIn` (`auth.config.ts`) écrit bien l'URL de la photo LinkedIn (`media.licdn.com/...`) en base, mais la CSP `img-src` ne listait que les hosts d'avatars Google (`lh3.googleusercontent.com`) et GitHub (`avatars.githubusercontent.com`) : le navigateur bloque le chargement de l'image et le composant `UserAvatar` retombe sur le fallback initiales.

## Fix

Ajout de `media.licdn.com` à la directive `img-src` (`next.config.ts`). La directive est partagée par la CSP standard et celle du widget embed, donc les deux surfaces sont couvertes.

Host exact plutôt que `*.licdn.com`, par cohérence avec les hosts Google/GitHub déjà listés.

## Hors scope (connu)

Les URLs de photo LinkedIn sont expirantes : même avec la CSP corrigée, un avatar LinkedIn cassera des semaines plus tard, jusqu'à la reconnexion suivante. Le fix durable (copie de la photo OAuth vers Vercel Blob à la synchro) est un chantier séparé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7zCcxjVxhj1294uL1xEX6