### PR TITLE
copy(landing): étape 3 « Comment ça marche » à l'impératif actif

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -26,7 +26,7 @@
     "step1Description": "Your community space in 30 seconds. Public or private, you decide.",
     "step2Title": "Launch your Events",
     "step2Description": "Every Event gets a premium, shareable page. One link, and you're live.",
-    "step3Title": "Watch your community grow",
+    "step3Title": "Grow your community",
     "step3Description": "Members stay in your community and come back for the next Events.",
     "pillarsHeading": "What makes The Playground different",
     "pillar1Title": "Community-first",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -26,7 +26,7 @@
     "step1Description": "Votre espace communautaire en 30 secondes. Public ou privé, vous décidez.",
     "step2Title": "Lancez des événements",
     "step2Description": "Chaque événement a sa page premium partageable. Un lien, et c'est parti.",
-    "step3Title": "Regardez votre communauté grandir",
+    "step3Title": "Faites grandir votre communauté",
     "step3Description": "Les participants restent membres de votre communauté et reviennent pour les prochains événements.",
     "pillarsHeading": "Ce qui rend The Playground différent",
     "pillar1Title": "La communauté d'abord",


### PR DESCRIPTION
## Quoi

Reformule le titre de l'étape 3 de la section « Comment ça marche » de la landing page.

- **FR** : « Regardez votre communauté grandir » → **« Faites grandir votre communauté »**
- **EN** : « Watch your community grow » → **« Grow your community »**

## Pourquoi

« Regardez » mettait l'organisateur en position de spectateur passif et cassait le parallélisme impératif des deux premières étapes (Créez / Lancez). La nouvelle formulation garde le rythme actif sur les trois étapes. Les descriptions restent inchangées.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7zCcxjVxhj1294uL1xEX6