### PR TITLE
copy(blog): liens vers the-playground.fr dans l'article alternatives Meetup (FR/EN)

### DIFF
--- a/src/content/blog/en/alternative-meetup-gratuite.md
+++ b/src/content/blog/en/alternative-meetup-gratuite.md
@@ -36,7 +36,7 @@ Before choosing, ask yourself the right questions:
 
 ### The Playground, community first, built in Europe
 
-The Playground takes Meetup's community model, a persistent community where members stay from one event to the next, and pairs it with a modern experience and total free pricing.
+[The Playground](https://the-playground.fr) takes Meetup's community model, a persistent community where members stay from one event to the next, and pairs it with a modern experience and total free pricing.
 
 **The principle**: when someone registers for your event, they automatically join your community. After the event, they see the next meetups, the other members, your group's identity. The connection doesn't break.
 
@@ -103,7 +103,7 @@ These platforms offer what event tools don't: **ongoing conversation** between e
 
 The choice depends on what you're building:
 
-> **You're building a lasting local community.** You want your attendees to come back from one event to the next, with no commission, and your data in Europe → **The Playground**
+> **You're building a lasting local community.** You want your attendees to come back from one event to the next, with no commission, and your data in Europe → **[The Playground](https://the-playground.fr)**
 
 > **You organise one-off premium events.** Event page quality is decisive, you need SMS/WhatsApp, community isn't your priority → **Luma**
 

--- a/src/content/blog/fr/alternative-meetup-gratuite.md
+++ b/src/content/blog/fr/alternative-meetup-gratuite.md
@@ -36,7 +36,7 @@ Avant de choisir, posez-vous les bonnes questions :
 
 ### The Playground, la communauté d'abord, conçue en France
 
-The Playground reprend le modèle communautaire de Meetup, une communauté persistante où les membres restent d'un événement à l'autre, mais avec une expérience moderne et une gratuité totale.
+[The Playground](https://the-playground.fr) reprend le modèle communautaire de Meetup, une communauté persistante où les membres restent d'un événement à l'autre, mais avec une expérience moderne et une gratuité totale.
 
 **Le principe** : quand quelqu'un s'inscrit à votre événement, il rejoint automatiquement votre communauté. Après l'événement, il voit les prochains rendez-vous, les autres membres, l'identité de votre groupe. Le lien ne se casse pas.
 
@@ -103,7 +103,7 @@ Ces plateformes offrent ce que les outils événementiels n'ont pas : la **conve
 
 Le choix dépend de ce que vous construisez :
 
-> **Vous construisez une communauté locale qui dure.** Vous voulez que vos participants reviennent d'un événement à l'autre, sans payer de commission, avec vos données en Europe → **The Playground**
+> **Vous construisez une communauté locale qui dure.** Vous voulez que vos participants reviennent d'un événement à l'autre, sans payer de commission, avec vos données en Europe → **[The Playground](https://the-playground.fr)**
 
 > **Vous organisez des événements ponctuels premium.** La qualité de la page d'inscription est déterminante, vous avez besoin de SMS/WhatsApp, la communauté n'est pas votre priorité → **Luma**
 


### PR DESCRIPTION
## Contexte

L'article `/blog/alternative-meetup-gratuite` citait The Playground sans jamais le linker, ce qui réduit les chances que le lecteur aille vers la landing (il ne sait pas toujours qu'il est déjà sur le site cité).

## Changements

Ajout de 2 liens vers `https://the-playground.fr` par langue (FR + EN), en calquant le pattern déjà en place dans `checklist-organiser-evenement.md` :
- première mention dans la section « The Playground, la communauté d'abord »
- recommandation finale dans « Comment choisir »

Ancres de marque uniquement, pas de sur-linkage (le tableau comparatif reste en texte brut, cohérent avec les autres colonnes).

## Reste à faire (hors scope, non demandé)

5 autres articles ont le même trou (dont `meetup-vs-luma-vs-the-playground` et `migrer-meetup-vers-the-playground`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7zCcxjVxhj1294uL1xEX6